### PR TITLE
feat: stricter [SKIP] prompt + forgiving skip-signal parsing

### DIFF
--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -519,7 +519,8 @@ When a user asks "что ты умеешь?", "what can you do?", or similar —
 ${formatCommandsForPrompt()}
 
 ## WHEN TO STAY SILENT
-Respond with exactly [SKIP] and nothing else unless the message contains a direct question or command for you.
+CRITICAL: The skip marker is EXACTLY the 6-character string [SKIP]. Not [ПРОПУСК], not [skip], not (skip), not any variation. ALWAYS output [SKIP] in English, in square brackets, uppercase. This is a machine-parsed token — do not translate it.
+When you decide to stay silent, output [SKIP] and NOTHING ELSE — no reasoning, no emoji, no "Готово", no commentary before or after.
 Stay silent ([SKIP]) when:
 - Someone makes a statement, shares a thought, or talks about plans ("надо будет обсудить", "хочу разобраться", "интересно было бы", "мог бы", "было бы хорошо")
 - Casual acknowledgements: "ok", "thanks", "понял", "окей", "хорошо", "+1", "ок"

--- a/src/services/ai/telegram-stream.test.ts
+++ b/src/services/ai/telegram-stream.test.ts
@@ -8,7 +8,7 @@ mock.module('../../utils/logger.ts', () => ({
 }));
 
 import { TelegramError } from 'gramio';
-import { TelegramStreamWriter } from './telegram-stream';
+import { TelegramStreamWriter, isSkipSignal } from './telegram-stream';
 
 /**
  * Helper to construct TelegramError instances for tests.
@@ -984,4 +984,31 @@ describe('placeholder reuse prevents double-message race', () => {
     // biome-ignore lint/suspicious/noExplicitAny: access private method
     (writer as any).stopTyping();
   });
+});
+
+describe('isSkipSignal', () => {
+  // --- Should match ---
+  test('exact [SKIP]', () => expect(isSkipSignal('[SKIP]')).toBe(true));
+  test('[SKIP] with whitespace', () => expect(isSkipSignal('  [SKIP]  ')).toBe(true));
+  test('[ПРОПУСК] Russian variant', () => expect(isSkipSignal('[ПРОПУСК]')).toBe(true));
+  test('lowercase [skip]', () => expect(isSkipSignal('[skip]')).toBe(true));
+  test('mixed case [Skip]', () => expect(isSkipSignal('[Skip]')).toBe(true));
+  test('broken bracket [SKIP', () => expect(isSkipSignal('[SKIP')).toBe(true));
+  test('broken bracket ПРОПУСК]', () => expect(isSkipSignal('ПРОПУСК]')).toBe(true));
+  test('[SKIP] embedded in text', () => expect(isSkipSignal('ok [SKIP] done')).toBe(true));
+  test('empty string', () => expect(isSkipSignal('')).toBe(true));
+  test('triple dot', () => expect(isSkipSignal('...')).toBe(true));
+  test('ellipsis character', () => expect(isSkipSignal('…')).toBe(true));
+  test('whitespace only', () => expect(isSkipSignal('   ')).toBe(true));
+
+  // --- Should NOT match ---
+  test('normal text', () => expect(isSkipSignal('Привет, как дела?')).toBe(false));
+  test('word skip without brackets', () => expect(isSkipSignal('skip')).toBe(false));
+  test('parentheses (SKIP)', () => expect(isSkipSignal('(SKIP)')).toBe(false));
+  test('random dots', () => expect(isSkipSignal('..')).toBe(false));
+  test('actual response', () => expect(isSkipSignal('Итого за месяц: 500€')).toBe(false));
+  test('long reply quoting [SKIP] marker', () =>
+    expect(isSkipSignal('Маркер [SKIP] используется когда бот решает промолчать. Это машинный токен.')).toBe(false));
+  test('long reply quoting [ПРОПУСК]', () =>
+    expect(isSkipSignal('Токен [ПРОПУСК] — это устаревший русский вариант маркера молчания.')).toBe(false));
 });

--- a/src/services/ai/telegram-stream.ts
+++ b/src/services/ai/telegram-stream.ts
@@ -84,11 +84,23 @@ function formatToolInput(name: string, input?: Record<string, unknown>): string 
 
 /**
  * Returns true if the AI response is a skip signal — bot chose to stay silent.
- * Recognized signals: [SKIP], ..., or empty string.
+ * Strict in the prompt (require [SKIP]), forgiving in parsing (accept variations).
+ * Short responses (≤50 chars) use substring match; longer ones require exact match
+ * to avoid swallowing real replies that quote the marker.
  */
 export function isSkipSignal(text: string): boolean {
-  const t = text.trim();
-  return t === '[SKIP]' || t === '...' || t === '';
+  const trimmed = text.trim();
+  if (trimmed === '' || trimmed === '...' || trimmed === '…') return true;
+  const upper = trimmed.toUpperCase();
+  const hasMarker =
+    upper.includes('[SKIP]') ||
+    upper.includes('[ПРОПУСК]') ||
+    upper.includes('[SKIP') ||
+    upper.includes('ПРОПУСК]');
+  if (!hasMarker) return false;
+  // Short text — definitely a skip signal (possibly with stray whitespace/punctuation)
+  // Long text — the marker is likely quoted inside a real answer
+  return trimmed.length <= 50;
 }
 
 const UPDATE_INTERVAL_MS = 1000; // ~Telegram's safe edit rate per chat


### PR DESCRIPTION
## Summary
- Port skip-marker pattern from hypercalendarbot: strict prompt ("CRITICAL: exactly [SKIP]"), forgiving parser (accepts [ПРОПУСК], broken brackets, case variations)
- Length guard (≤50 chars) prevents false positives when the marker is quoted in a real reply
- 19 new test cases for `isSkipSignal`

## Test plan
- [x] `bun test src/services/ai/telegram-stream.test.ts` — 72 pass, 0 fail
- [x] `tsc --noEmit` — clean
- [x] Codex review — P2 finding addressed (length guard)
- [ ] Manual: send messages in group chat, verify bot stays silent on casual messages
- [ ] Manual: ask bot "что такое [SKIP]?" — verify it answers instead of going silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)