### PR TITLE
fix: bank-sync initSender, URL parsing, reconnect full sync, stage bot resilience

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,12 +47,18 @@ jobs:
             git pull origin main
             git submodule update --init
 
-            echo "📋 Copying .env.stage to worktrees..."
+            echo "📋 Copying .env.stage into every git worktree..."
             if [ -f .env.stage ]; then
-              for wt in .claude/worktrees/*/; do
-                if [ -d "$wt" ] && [ ! -f "${wt}.env" ]; then
-                  cp .env.stage "${wt}.env"
-                  echo "  → ${wt}.env"
+              # Use `git worktree list` instead of a shell glob so branches
+              # with slashes (`fix/X`, `feat/X`) — which create nested
+              # directories — are iterated correctly. Skip the primary
+              # checkout so we don't clobber its .env.
+              MAIN_WT="$(pwd)"
+              git worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r wt; do
+                if [ "$wt" = "$MAIN_WT" ]; then continue; fi
+                if [ -d "$wt" ] && [ ! -f "$wt/.env" ]; then
+                  cp .env.stage "$wt/.env"
+                  echo "  → $wt/.env"
                 fi
               done
             fi

--- a/.github/workflows/stage-bot.yml
+++ b/.github/workflows/stage-bot.yml
@@ -58,27 +58,62 @@ jobs:
             export PATH="/var/www/.nvm/versions/node/v22.17.0/bin:/var/www/.bun/bin:$PATH"
 
             BRANCH="${{ github.head_ref }}"
-            WORKTREE="/var/www/ExpenseSyncBot/.claude/worktrees/$BRANCH"
-            ENV_FILE="/var/www/ExpenseSyncBot/.env.stage"
+            MAIN_DIR="/var/www/ExpenseSyncBot"
+            WORKTREE="$MAIN_DIR/.claude/worktrees/$BRANCH"
+            ENV_FILE="$MAIN_DIR/.env.stage"
             PM2="/var/www/.bun/bin/pm2"
             BUN="/var/www/.bun/bin/bun"
 
-            if [ "${{ github.event.action }}" = "closed" ]; then
-              echo "🛑 Stopping stage bot..."
+            # Start stage bot. Uses `bun --env-file` with an absolute path so
+            # the process doesn't depend on a `.env` file being present in
+            # the cwd — works identically for worktree and main checkouts.
+            start_stage_bot() {
+              local cwd="$1"
               $PM2 delete expensesyncbot-stage 2>/dev/null || true
+              $PM2 start "$BUN --env-file=$ENV_FILE index.ts" \
+                   --name expensesyncbot-stage \
+                   --cwd "$cwd"
+
+              sleep 3
+              STATUS=$($PM2 jlist | $BUN -e "
+                const procs = JSON.parse(await Bun.stdin.text());
+                const p = procs.find(p => p.name === 'expensesyncbot-stage');
+                console.log(p?.pm2_env?.status ?? 'not_found');
+              ")
+
+              if [ "$STATUS" != "online" ]; then
+                echo "❌ Stage bot failed to start (status: $STATUS)"
+                echo ""
+                echo "=== Last 80 lines of logs ==="
+                $PM2 logs expensesyncbot-stage --lines 80 --nostream 2>&1 || true
+                return 1
+              fi
+
+              echo "✅ Stage bot online (cwd: $cwd)"
+            }
+
+            if [ "${{ github.event.action }}" = "closed" ]; then
+              echo "🛑 PR closed — tearing down worktree and restarting stage bot from main..."
 
               if [ -d "$WORKTREE" ]; then
-                cd /var/www/ExpenseSyncBot
+                cd "$MAIN_DIR"
                 git worktree remove "$WORKTREE" --force 2>/dev/null || true
               fi
 
-              echo "✅ Stage bot stopped"
+              # Ensure main is up to date before we switch the stage bot to it.
+              cd "$MAIN_DIR"
+              git fetch origin main
+              git pull origin main || true
+              $BUN install
+
+              start_stage_bot "$MAIN_DIR"
+              $PM2 list
               exit 0
             fi
 
             echo "🚀 Deploying stage bot from branch: $BRANCH"
 
-            cd /var/www/ExpenseSyncBot
+            cd "$MAIN_DIR"
             git fetch origin
 
             if [ ! -d "$WORKTREE" ]; then
@@ -94,30 +129,7 @@ jobs:
             cd "$WORKTREE"
             $BUN install
 
-            $PM2 delete expensesyncbot-stage 2>/dev/null || true
-            $PM2 start index.ts \
-                 --name expensesyncbot-stage \
-                 --interpreter $BUN \
-                 --cwd "$WORKTREE" \
-                 -- --env-file $ENV_FILE
-
-            # Wait for bot to start and verify it's alive
-            sleep 3
-            STATUS=$($PM2 jlist | $BUN -e "
-              const procs = JSON.parse(await Bun.stdin.text());
-              const p = procs.find(p => p.name === 'expensesyncbot-stage');
-              console.log(p?.pm2_env?.status ?? 'not_found');
-            ")
-
-            if [ "$STATUS" != "online" ]; then
-              echo "❌ Stage bot failed to start (status: $STATUS)"
-              echo ""
-              echo "=== Last 80 lines of logs ==="
-              $PM2 logs expensesyncbot-stage --lines 80 --nostream 2>&1 || true
-              exit 1
-            fi
-
-            echo "✅ Stage bot deployed and running"
+            start_stage_bot "$WORKTREE"
             $PM2 list
 
       - name: Comment on PR with stage bot link
@@ -169,6 +181,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body: `${marker}\n🛑 Stage bot stopped. PR closed.`,
+                body: `${marker}\n🔁 PR closed. Stage bot switched back to \`main\`.`,
               });
             }

--- a/bank-sync.ts
+++ b/bank-sync.ts
@@ -1,13 +1,32 @@
 // Entry point for the bank-sync PM2 process.
 // Shares the SQLite database with the main bot but runs independently.
+import { Bot } from 'gramio';
+import { rateLimitOnResponseError, rateLimitPreRequest } from './src/bot/rate-limit.hook';
+import { sanitizeOutgoingMessages } from './src/bot/sanitize-outgoing.hook';
+import { registerTopicMiddleware } from './src/bot/topic-middleware';
+import { env } from './src/config/env';
 import { processMerchantRequests } from './src/services/bank/merchant-agent';
 import { installPluginConsoleFilter } from './src/services/bank/plugin-console-filter';
 import { startSyncService } from './src/services/bank/sync-service';
+import { initSender } from './src/services/bank/telegram-sender';
 import { createLogger } from './src/utils/logger.ts';
 
 // Must run before any plugin code executes. Routes console.* through pino
 // (silent at debug level in prod) and scrubs PAN/IBAN/phone/token patterns.
 installPluginConsoleFilter();
+
+// Create a Bot instance for outbound API calls (transaction cards, panel
+// updates) — this process never calls bot.start() because only the main
+// expensesyncbot process owns long-polling. Replicates the outbound-facing
+// subset of the main bot wiring so 429 backoff, HTML sanitization, topic
+// thread_id injection, and the telegram-sender helper all behave identically
+// across the two processes.
+const bot = new Bot(env.BOT_TOKEN);
+bot.preRequest(rateLimitPreRequest);
+bot.onResponseError(rateLimitOnResponseError);
+bot.preRequest(sanitizeOutgoingMessages);
+registerTopicMiddleware(bot);
+initSender(bot);
 
 const logger = createLogger('bank-sync-main');
 

--- a/src/bot/commands/reconnect.ts
+++ b/src/bot/commands/reconnect.ts
@@ -96,15 +96,18 @@ interface FullSyncReport {
 }
 
 /**
- * Full bidirectional sync after reconnect:
+ * Full bidirectional sync after reconnect. Runs from the OAuth callback
+ * once the new refresh token has been persisted. Reads chatId/threadId
+ * from the surrounding chatStorage context (caller must wrap in
+ * withChatContext).
+ *
  * 1. Ensure current-year spreadsheet exists
  * 2. Sheet → DB expenses (import only, never deletes)
  * 3. DB → Sheet expenses (push missing)
  * 4. Sheet → DB budgets (import from all month tabs)
  * 5. DB → Sheet budgets (ensure tabs + write rows)
  */
-export async function fullSyncAfterReconnect(ctx: Ctx['Command'], groupId: number): Promise<void> {
-  void ctx;
+export async function fullSyncAfterReconnect(groupId: number): Promise<void> {
   const report: FullSyncReport = {
     snapshotId: null,
     snapshotExpenses: 0,

--- a/src/web/miniapp-api.test.ts
+++ b/src/web/miniapp-api.test.ts
@@ -244,6 +244,21 @@ describe('handleMiniAppRequest — non-API paths', () => {
     const result = await handleMiniAppRequest(makeRequest('/health'), CORS_ORIGIN);
     expect(result).toBeNull();
   });
+
+  test('does not throw on relative/malformed URL (port-scanner regression)', async () => {
+    // Bun hands us a relative URL for some HTTP/0.9 or malformed probes.
+    // new URL(req.url) without a base would throw TypeError and crash the
+    // process. The defensive parser wraps it with a base fallback.
+    const fake = { url: '/', method: 'GET', headers: new Headers() } as unknown as Request;
+    const result = await handleMiniAppRequest(fake, CORS_ORIGIN);
+    expect(result).toBeNull();
+  });
+
+  test('returns null for unparseable URL input', async () => {
+    const fake = { url: '', method: 'GET', headers: new Headers() } as unknown as Request;
+    const result = await handleMiniAppRequest(fake, CORS_ORIGIN);
+    expect(result).toBeNull();
+  });
 });
 
 describe('handleMiniAppRequest — OPTIONS preflight', () => {

--- a/src/web/miniapp-api.ts
+++ b/src/web/miniapp-api.ts
@@ -210,7 +210,16 @@ export async function handleMiniAppRequest(
   req: Request,
   corsOrigin: string,
 ): Promise<Response | null> {
-  const url = new URL(req.url);
+  // Defensive URL parsing: port scanners send malformed HTTP that makes Bun
+  // hand us a relative URL, which would otherwise throw TypeError on every
+  // probe and crash the process. The base is only used when req.url is
+  // already relative.
+  let url: URL;
+  try {
+    url = new URL(req.url, 'http://localhost');
+  } catch {
+    return null;
+  }
 
   if (!url.pathname.startsWith('/api/')) return null;
 

--- a/src/web/oauth-callback.ts
+++ b/src/web/oauth-callback.ts
@@ -1,4 +1,5 @@
 // OAuth callback HTTP server — handles Google OAuth redirects and token exchange.
+import { fullSyncAfterReconnect } from '../bot/commands/reconnect';
 import { createCurrencyKeyboard } from '../bot/keyboards';
 import { MESSAGES } from '../config/constants';
 import { env } from '../config/env';
@@ -196,10 +197,21 @@ async function handleOAuthCallback(url: URL): Promise<Response> {
 
     logger.info(`✓ OAuth successful for group ${groupId}`);
 
-    // Send success message + currency keyboard to Telegram (background, non-blocking for HTTP response)
-    notifyTelegramSuccess(group.telegram_group_id, group.active_topic_id).catch((notifyErr) => {
-      logger.error({ err: notifyErr }, '[OAuth] Failed to send success message to Telegram');
-    });
+    // Branch on whether a spreadsheet already exists:
+    //   - no spreadsheet → /connect flow (new group), send currency picker
+    //   - has spreadsheet → /reconnect flow, run full bidirectional sync
+    // Both run as background operations so the HTTP response is not blocked.
+    if (group.spreadsheet_id) {
+      withChatContext(group.telegram_group_id, group.active_topic_id, () =>
+        fullSyncAfterReconnect(group.id),
+      ).catch((syncErr) => {
+        logger.error({ err: syncErr, groupId: group.id }, '[OAuth] fullSyncAfterReconnect failed');
+      });
+    } else {
+      notifyTelegramSuccess(group.telegram_group_id, group.active_topic_id).catch((notifyErr) => {
+        logger.error({ err: notifyErr }, '[OAuth] Failed to send success message to Telegram');
+      });
+    }
 
     return new Response(
       `

--- a/src/web/oauth-callback.ts
+++ b/src/web/oauth-callback.ts
@@ -24,7 +24,15 @@ export function startOAuthServer(): void {
       const miniAppResponse = await handleMiniAppRequest(req, corsOrigin);
       if (miniAppResponse !== null) return miniAppResponse;
 
-      const url = new URL(req.url);
+      // Defensive: Bun hands us a relative URL for some malformed requests
+      // (port scanners, HTTP/0.9). Parse with a base fallback instead of
+      // letting TypeError escape the fetch handler.
+      let url: URL;
+      try {
+        url = new URL(req.url, 'http://localhost');
+      } catch {
+        return new Response('Bad Request', { status: 400 });
+      }
 
       if (url.pathname === '/callback') {
         return handleOAuthCallback(url);


### PR DESCRIPTION
Cleanup sweep surfaced by the previous two PRs, plus a real stage bot outage discovered along the way.

## What's broken, what's fixed

### 1. Stage bot was crash-looping and nobody noticed
`stage-bot.yml` deletes `expensesyncbot-stage` on PR close instead of rolling it back to main, so every time the last open PR merged the stage bot just... stopped. Worse, `deploy.yml`'s `.env.stage` copy used a shell glob `.claude/worktrees/*/` that only matches one level deep, so every worktree on a slashed branch (`fix/X`, `feat/X`) was missing `.env` and crash-looped on `Missing required environment variable: BOT_TOKEN`. The 87 MB stage-bot-error.log on the server is all of that.

Fix:
- stage-bot.yml: on PR close, tear down the PR worktree and restart the stage bot from the main checkout against `.env.stage` via `bun --env-file=<abs-path>`. Stage bot now always reflects either the active PR or `main`.
- deploy.yml: iterate worktrees via `git worktree list --porcelain` instead of a glob, so nested paths are handled correctly.

### 2. bank-sync never initialized telegram-sender
Every sync cycle called `editMessageText` to refresh bank panels, hit `telegram-sender: bot not initialized — call initSender() first`, and silently failed. Was drowned in ZenPlugin chatter before — became visible after the redaction filter landed. bank-sync.ts now creates a Bot (without `bot.start()` — only the main process owns long-polling) and wires the outbound-facing hooks (rate limit, HTML sanitize, topic middleware) + `initSender`.

### 3. 76 255 restart counter on expensesyncbot — fetch handler crashed on port scanners
`miniapp-api.ts` and `oauth-callback.ts` both did `const url = new URL(req.url)` at the top of their Bun.serve fetch handler. Port scanners send malformed HTTP where Bun hands us a relative URL (`/`, `/nice%20ports%2C/...`), the constructor throws, and the TypeError escapes the fetch handler → process exit → PM2 restart. Defensive parse with an `http://localhost` base fallback; return 400 / null on unparseable input. Regression test in `miniapp-api.test.ts` passes a fake Request with a relative `url`.

### 4. `fullSyncAfterReconnect` was dead exported code
The function has been knip-flagged since the /reconnect PR: exported, documented as "called from the callback handler", but never actually wired up. OAuth callback now branches on `group.spreadsheet_id`:
- `null` → /connect flow, currency picker (unchanged)
- set → /reconnect flow, run `fullSyncAfterReconnect` in the group's chat context

Also drop the unused `ctx: Ctx['Command']` parameter — it was `void ctx;`-discarded and the function reads chat context from `chatStorage` via the telegram-sender helpers.

## Commits
1. `ci: stage bot recreates from main on PR close + fix slashed-branch env copy`
2. `fix(bank-sync): initialize telegram-sender and harden URL parsing`
3. `fix(oauth): wire fullSyncAfterReconnect from OAuth callback`

## Test plan
- [x] `bun run test` — 1978 passing (added 2 URL regression tests, updated reconnect test for new signature)
- [x] `bun run type-check` clean
- [x] `bun run lint` clean
- [x] Stage bot manually restarted against main from `.env.stage` and verified `Bank sync cron scheduled`, `ExpenseSyncBot is running` — no crash loop
- [ ] After merge: verify stage bot survives the PR-close transition (should land on main cwd automatically)
- [ ] After merge: confirm `expensesyncbot` restart counter stops climbing
- [ ] After merge: trigger /reconnect in a configured group and watch for "🔄 Полная синхронизация..." + "✅ Синхронизация завершена"
- [ ] After merge: bank-sync warn log should no longer show `telegram-sender: bot not initialized`

🤖 Generated with [Claude Code](https://claude.com/claude-code)