### PR TITLE
ci: stage bot recreates from main on PR close + fix slashed-branch env copy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,12 +47,18 @@ jobs:
             git pull origin main
             git submodule update --init
 
-            echo "📋 Copying .env.stage to worktrees..."
+            echo "📋 Copying .env.stage into every git worktree..."
             if [ -f .env.stage ]; then
-              for wt in .claude/worktrees/*/; do
-                if [ -d "$wt" ] && [ ! -f "${wt}.env" ]; then
-                  cp .env.stage "${wt}.env"
-                  echo "  → ${wt}.env"
+              # Use `git worktree list` instead of a shell glob so branches
+              # with slashes (`fix/X`, `feat/X`) — which create nested
+              # directories — are iterated correctly. Skip the primary
+              # checkout so we don't clobber its .env.
+              MAIN_WT="$(pwd)"
+              git worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r wt; do
+                if [ "$wt" = "$MAIN_WT" ]; then continue; fi
+                if [ -d "$wt" ] && [ ! -f "$wt/.env" ]; then
+                  cp .env.stage "$wt/.env"
+                  echo "  → $wt/.env"
                 fi
               done
             fi

--- a/.github/workflows/stage-bot.yml
+++ b/.github/workflows/stage-bot.yml
@@ -58,27 +58,62 @@ jobs:
             export PATH="/var/www/.nvm/versions/node/v22.17.0/bin:/var/www/.bun/bin:$PATH"
 
             BRANCH="${{ github.head_ref }}"
-            WORKTREE="/var/www/ExpenseSyncBot/.claude/worktrees/$BRANCH"
-            ENV_FILE="/var/www/ExpenseSyncBot/.env.stage"
+            MAIN_DIR="/var/www/ExpenseSyncBot"
+            WORKTREE="$MAIN_DIR/.claude/worktrees/$BRANCH"
+            ENV_FILE="$MAIN_DIR/.env.stage"
             PM2="/var/www/.bun/bin/pm2"
             BUN="/var/www/.bun/bin/bun"
 
-            if [ "${{ github.event.action }}" = "closed" ]; then
-              echo "🛑 Stopping stage bot..."
+            # Start stage bot. Uses `bun --env-file` with an absolute path so
+            # the process doesn't depend on a `.env` file being present in
+            # the cwd — works identically for worktree and main checkouts.
+            start_stage_bot() {
+              local cwd="$1"
               $PM2 delete expensesyncbot-stage 2>/dev/null || true
+              $PM2 start "$BUN --env-file=$ENV_FILE index.ts" \
+                   --name expensesyncbot-stage \
+                   --cwd "$cwd"
+
+              sleep 3
+              STATUS=$($PM2 jlist | $BUN -e "
+                const procs = JSON.parse(await Bun.stdin.text());
+                const p = procs.find(p => p.name === 'expensesyncbot-stage');
+                console.log(p?.pm2_env?.status ?? 'not_found');
+              ")
+
+              if [ "$STATUS" != "online" ]; then
+                echo "❌ Stage bot failed to start (status: $STATUS)"
+                echo ""
+                echo "=== Last 80 lines of logs ==="
+                $PM2 logs expensesyncbot-stage --lines 80 --nostream 2>&1 || true
+                return 1
+              fi
+
+              echo "✅ Stage bot online (cwd: $cwd)"
+            }
+
+            if [ "${{ github.event.action }}" = "closed" ]; then
+              echo "🛑 PR closed — tearing down worktree and restarting stage bot from main..."
 
               if [ -d "$WORKTREE" ]; then
-                cd /var/www/ExpenseSyncBot
+                cd "$MAIN_DIR"
                 git worktree remove "$WORKTREE" --force 2>/dev/null || true
               fi
 
-              echo "✅ Stage bot stopped"
+              # Ensure main is up to date before we switch the stage bot to it.
+              cd "$MAIN_DIR"
+              git fetch origin main
+              git pull origin main || true
+              $BUN install
+
+              start_stage_bot "$MAIN_DIR"
+              $PM2 list
               exit 0
             fi
 
             echo "🚀 Deploying stage bot from branch: $BRANCH"
 
-            cd /var/www/ExpenseSyncBot
+            cd "$MAIN_DIR"
             git fetch origin
 
             if [ ! -d "$WORKTREE" ]; then
@@ -94,30 +129,7 @@ jobs:
             cd "$WORKTREE"
             $BUN install
 
-            $PM2 delete expensesyncbot-stage 2>/dev/null || true
-            $PM2 start index.ts \
-                 --name expensesyncbot-stage \
-                 --interpreter $BUN \
-                 --cwd "$WORKTREE" \
-                 -- --env-file $ENV_FILE
-
-            # Wait for bot to start and verify it's alive
-            sleep 3
-            STATUS=$($PM2 jlist | $BUN -e "
-              const procs = JSON.parse(await Bun.stdin.text());
-              const p = procs.find(p => p.name === 'expensesyncbot-stage');
-              console.log(p?.pm2_env?.status ?? 'not_found');
-            ")
-
-            if [ "$STATUS" != "online" ]; then
-              echo "❌ Stage bot failed to start (status: $STATUS)"
-              echo ""
-              echo "=== Last 80 lines of logs ==="
-              $PM2 logs expensesyncbot-stage --lines 80 --nostream 2>&1 || true
-              exit 1
-            fi
-
-            echo "✅ Stage bot deployed and running"
+            start_stage_bot "$WORKTREE"
             $PM2 list
 
       - name: Comment on PR with stage bot link
@@ -169,6 +181,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body: `${marker}\n🛑 Stage bot stopped. PR closed.`,
+                body: `${marker}\n🔁 PR closed. Stage bot switched back to \`main\`.`,
               });
             }


### PR DESCRIPTION
## Summary

Two CI/workflow fixes that surfaced when the stage bot quietly died after PR #67 and #68 merged.

### 1. stage-bot.yml no longer kills the stage bot on PR close
Old flow: when a PR closed, `pm2 delete expensesyncbot-stage` ran and that was it — no stage bot until somebody opened a new PR. Now the close branch tears down the PR worktree, pulls main, reinstalls deps, and restarts the stage bot from the main checkout. Stage bot always reflects either an active PR or main.

Also the bot start command now uses `bun --env-file=$ENV_FILE index.ts` with an absolute path, so the process doesn't depend on a `.env` file being present in the cwd. That makes the worktree → main switch reliable regardless of which directory the stage bot is currently running from.

### 2. deploy.yml .env copy now handles slashed branch worktrees
Old flow used a shell glob `.claude/worktrees/*/` that only matched one directory level. Branches with slashes (`fix/X`, `feat/X`) create nested worktrees at `.claude/worktrees/fix/X/`, which the glob silently skipped. Any process that ran against those worktrees crash-looped on `Missing required environment variable: BOT_TOKEN` — which is exactly what happened to the stage bot for PR #67 (`fix/reconnect-command`) and PR #68 (`fix/bank-sync-log-redaction`), producing 87 MB of error logs that nobody saw.

Now uses `git worktree list --porcelain` which returns absolute paths regardless of nesting.

## Why this is separate

Pure infra/workflow fix. No runtime code changed. Independent of the three bank/web follow-ups split from the same parent PR.

## Test plan
- [x] typecheck clean
- [ ] After merge, open a throwaway PR and verify stage bot deploys from the PR branch
- [ ] After closing that PR, verify stage bot stays online, switched back to main (not deleted)
- [ ] Branch with a slash (`fix/foo`) triggers `.env.stage` copy into the nested worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)