### PR TITLE
fix(bank-sync): initialize telegram-sender in the bank-sync process

### DIFF
--- a/bank-sync.ts
+++ b/bank-sync.ts
@@ -1,13 +1,32 @@
 // Entry point for the bank-sync PM2 process.
 // Shares the SQLite database with the main bot but runs independently.
+import { Bot } from 'gramio';
+import { rateLimitOnResponseError, rateLimitPreRequest } from './src/bot/rate-limit.hook';
+import { sanitizeOutgoingMessages } from './src/bot/sanitize-outgoing.hook';
+import { registerTopicMiddleware } from './src/bot/topic-middleware';
+import { env } from './src/config/env';
 import { processMerchantRequests } from './src/services/bank/merchant-agent';
 import { installPluginConsoleFilter } from './src/services/bank/plugin-console-filter';
 import { startSyncService } from './src/services/bank/sync-service';
+import { initSender } from './src/services/bank/telegram-sender';
 import { createLogger } from './src/utils/logger.ts';
 
 // Must run before any plugin code executes. Routes console.* through pino
 // (silent at debug level in prod) and scrubs PAN/IBAN/phone/token patterns.
 installPluginConsoleFilter();
+
+// Create a Bot instance for outbound API calls (transaction cards, panel
+// updates) — this process never calls bot.start() because only the main
+// expensesyncbot process owns long-polling. Replicates the outbound-facing
+// subset of the main bot wiring so 429 backoff, HTML sanitization, topic
+// thread_id injection, and the telegram-sender helper all behave identically
+// across the two processes.
+const bot = new Bot(env.BOT_TOKEN);
+bot.preRequest(rateLimitPreRequest);
+bot.onResponseError(rateLimitOnResponseError);
+bot.preRequest(sanitizeOutgoingMessages);
+registerTopicMiddleware(bot);
+initSender(bot);
 
 const logger = createLogger('bank-sync-main');
 


### PR DESCRIPTION
## Summary

bank-sync.ts imports `sync-service`, which calls `editMessageText` from `telegram-sender` to refresh each bank panel after every sync cycle. But bank-sync.ts never created a `Bot` or called `initSender()`, so every refresh threw

```
telegram-sender: bot not initialized — call initSender() first
```

and the bank panel silently stopped updating. This has been broken for a long time — it was drowned in ZenPlugin debug chatter until the console filter from PR #68 landed and the errors finally rose to the top of `bank-sync-out.log`.

## Fix

Create a `Bot` instance in bank-sync.ts **without** calling `bot.start()` (only the main expensesyncbot process owns long-polling for the bot token) and replicate the outbound-facing subset of the main bot wiring so behavior is identical across the two processes:

- `rateLimitPreRequest` / `rateLimitOnResponseError` — 429 backoff
- `sanitizeOutgoingMessages` — HTML sanitization
- `registerTopicMiddleware` — `message_thread_id` injection via preRequest hook
- `initSender(bot)` — stores the bot instance for the telegram-sender helpers

## Why this is separate

Runtime fix confined to a single file. Unrelated to the stage-bot workflow fix, the URL parsing fix, and the fullSyncAfterReconnect wiring — each of those is in its own PR.

## Test plan
- [x] `bun run test` — 1976 passing
- [x] `bun run type-check` clean
- [x] `bun run lint` clean
- [ ] After merge, verify bank-sync warn log no longer shows `telegram-sender: bot not initialized`
- [ ] After merge, trigger a bank sync cycle and confirm the bank panel in the target group actually refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)