### PR TITLE
fix(web): defensive URL parsing in HTTP fetch handlers

### DIFF
--- a/src/web/miniapp-api.test.ts
+++ b/src/web/miniapp-api.test.ts
@@ -244,6 +244,21 @@ describe('handleMiniAppRequest — non-API paths', () => {
     const result = await handleMiniAppRequest(makeRequest('/health'), CORS_ORIGIN);
     expect(result).toBeNull();
   });
+
+  test('does not throw on relative/malformed URL (port-scanner regression)', async () => {
+    // Bun hands us a relative URL for some HTTP/0.9 or malformed probes.
+    // new URL(req.url) without a base would throw TypeError and crash the
+    // process. The defensive parser wraps it with a base fallback.
+    const fake = { url: '/', method: 'GET', headers: new Headers() } as unknown as Request;
+    const result = await handleMiniAppRequest(fake, CORS_ORIGIN);
+    expect(result).toBeNull();
+  });
+
+  test('returns null for unparseable URL input', async () => {
+    const fake = { url: '', method: 'GET', headers: new Headers() } as unknown as Request;
+    const result = await handleMiniAppRequest(fake, CORS_ORIGIN);
+    expect(result).toBeNull();
+  });
 });
 
 describe('handleMiniAppRequest — OPTIONS preflight', () => {

--- a/src/web/miniapp-api.ts
+++ b/src/web/miniapp-api.ts
@@ -210,7 +210,16 @@ export async function handleMiniAppRequest(
   req: Request,
   corsOrigin: string,
 ): Promise<Response | null> {
-  const url = new URL(req.url);
+  // Defensive URL parsing: port scanners send malformed HTTP that makes Bun
+  // hand us a relative URL, which would otherwise throw TypeError on every
+  // probe and crash the process. The base is only used when req.url is
+  // already relative.
+  let url: URL;
+  try {
+    url = new URL(req.url, 'http://localhost');
+  } catch {
+    return null;
+  }
 
   if (!url.pathname.startsWith('/api/')) return null;
 

--- a/src/web/oauth-callback.ts
+++ b/src/web/oauth-callback.ts
@@ -24,7 +24,15 @@ export function startOAuthServer(): void {
       const miniAppResponse = await handleMiniAppRequest(req, corsOrigin);
       if (miniAppResponse !== null) return miniAppResponse;
 
-      const url = new URL(req.url);
+      // Defensive: Bun hands us a relative URL for some malformed requests
+      // (port scanners, HTTP/0.9). Parse with a base fallback instead of
+      // letting TypeError escape the fetch handler.
+      let url: URL;
+      try {
+        url = new URL(req.url, 'http://localhost');
+      } catch {
+        return new Response('Bad Request', { status: 400 });
+      }
 
       if (url.pathname === '/callback') {
         return handleOAuthCallback(url);


### PR DESCRIPTION
## Summary

Port scanners send malformed HTTP where Bun hands the fetch callback a relative URL (`/`, `/nice%20ports%2C/Tri%6Eity.txt%2ebak`, etc.). The existing `new URL(req.url)` at the top of both `miniapp-api.ts` and `oauth-callback.ts` threw `TypeError` which escaped the fetch handler and killed the process.

The historical error log showed this pattern thousands of times per day, and is responsible for the full **76 255 restart counter** on the `expensesyncbot` PM2 process.

```
TypeError: "/nice%20ports%2C/Tri%6Eity.txt%2ebak" cannot be parsed as a URL.
 code: "ERR_INVALID_URL"

      at handleMiniAppRequest (src/web/miniapp-api.ts:213:15)
      at fetch (src/web/oauth-callback.ts:24:37)
```

## Fix

Parse with an `http://localhost` base fallback so a relative URL becomes a valid absolute one, and return `400`/`null` on truly unparseable input instead of throwing.

```ts
let url: URL;
try {
  url = new URL(req.url, 'http://localhost');
} catch {
  return new Response('Bad Request', { status: 400 });
}
```

## Regression test

`miniapp-api.test.ts` gets two new cases that pass a fake `Request` object with `url: '/'` and `url: ''` directly — `new Request()` rejects relative URLs at construction, so the only way to reproduce the Bun quirk in a unit test is to bypass the constructor.

## Why this is separate

Pure defensive HTTP-handler hardening. Independent of the stage-bot workflow fix, the bank-sync initSender fix, and the fullSyncAfterReconnect wiring — each of those is in its own PR.

## Test plan
- [x] `bun run test` — 1978 passing (2 new regression tests)
- [x] `bun run type-check` clean
- [x] `bun run lint` clean
- [ ] After merge, verify the `expensesyncbot` restart counter stops growing
- [ ] Sanity-check: `/health` endpoint still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)