### PR TITLE
fix(oauth): wire fullSyncAfterReconnect from OAuth callback

### DIFF
--- a/src/bot/commands/reconnect.ts
+++ b/src/bot/commands/reconnect.ts
@@ -96,15 +96,18 @@ interface FullSyncReport {
 }
 
 /**
- * Full bidirectional sync after reconnect:
+ * Full bidirectional sync after reconnect. Runs from the OAuth callback
+ * once the new refresh token has been persisted. Reads chatId/threadId
+ * from the surrounding chatStorage context (caller must wrap in
+ * withChatContext).
+ *
  * 1. Ensure current-year spreadsheet exists
  * 2. Sheet → DB expenses (import only, never deletes)
  * 3. DB → Sheet expenses (push missing)
  * 4. Sheet → DB budgets (import from all month tabs)
  * 5. DB → Sheet budgets (ensure tabs + write rows)
  */
-export async function fullSyncAfterReconnect(ctx: Ctx['Command'], groupId: number): Promise<void> {
-  void ctx;
+export async function fullSyncAfterReconnect(groupId: number): Promise<void> {
   const report: FullSyncReport = {
     snapshotId: null,
     snapshotExpenses: 0,

--- a/src/web/oauth-callback.ts
+++ b/src/web/oauth-callback.ts
@@ -1,4 +1,5 @@
 // OAuth callback HTTP server — handles Google OAuth redirects and token exchange.
+import { fullSyncAfterReconnect } from '../bot/commands/reconnect';
 import { createCurrencyKeyboard } from '../bot/keyboards';
 import { MESSAGES } from '../config/constants';
 import { env } from '../config/env';
@@ -188,10 +189,21 @@ async function handleOAuthCallback(url: URL): Promise<Response> {
 
     logger.info(`✓ OAuth successful for group ${groupId}`);
 
-    // Send success message + currency keyboard to Telegram (background, non-blocking for HTTP response)
-    notifyTelegramSuccess(group.telegram_group_id, group.active_topic_id).catch((notifyErr) => {
-      logger.error({ err: notifyErr }, '[OAuth] Failed to send success message to Telegram');
-    });
+    // Branch on whether a spreadsheet already exists:
+    //   - no spreadsheet → /connect flow (new group), send currency picker
+    //   - has spreadsheet → /reconnect flow, run full bidirectional sync
+    // Both run as background operations so the HTTP response is not blocked.
+    if (group.spreadsheet_id) {
+      withChatContext(group.telegram_group_id, group.active_topic_id, () =>
+        fullSyncAfterReconnect(group.id),
+      ).catch((syncErr) => {
+        logger.error({ err: syncErr, groupId: group.id }, '[OAuth] fullSyncAfterReconnect failed');
+      });
+    } else {
+      notifyTelegramSuccess(group.telegram_group_id, group.active_topic_id).catch((notifyErr) => {
+        logger.error({ err: notifyErr }, '[OAuth] Failed to send success message to Telegram');
+      });
+    }
 
     return new Response(
       `


### PR DESCRIPTION
## Summary

`fullSyncAfterReconnect` has been an exported dead function since the /reconnect command was added — `knip` flagged it, the comment in `reconnect.ts` referenced "the callback handler" but nothing was ever actually wired up. Successful /reconnect refreshed the Google token and then **silently skipped** the documented bidirectional spreadsheet sync (the reason /reconnect exists in the first place).

## Fix

The OAuth callback now branches on the group's existing `spreadsheet_id`:

| `spreadsheet_id` | Flow | Action |
|---|---|---|
| `null` | `/connect` (new group setup) | Currency picker (unchanged) |
| set | `/reconnect` (existing group) | `fullSyncAfterReconnect(group.id)` wrapped in `withChatContext` |

Both paths run as background operations so the HTTP response is not blocked.

Also drops the unused `ctx: Ctx['Command']` parameter from `fullSyncAfterReconnect` since it was never used (`void ctx;`) — the function reads chat context from `chatStorage` via the telegram-sender helpers instead.

## Why this is separate

Pure wiring fix for the reconnect flow. Independent of the stage-bot workflow fix, the bank-sync initSender fix, and the URL parsing hardening — each of those is in its own PR.

## Test plan
- [x] `bun run test` — 1978 passing
- [x] `bun run type-check` clean
- [x] `bun run lint` clean
- [ ] After merge, trigger `/reconnect` in a configured group and verify:
  - "🔄 Полная синхронизация..." progress message appears
  - Final report shows "✅ Синхронизация завершена!" with DB↔Sheet counts
  - `logs/out.log` module=`reconnect` shows `[RECONNECT] Sheet backup created`, `Imported N budgets`, etc.
- [ ] After merge, trigger `/connect` in a fresh group and verify the currency picker still appears (path not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)