### PR TITLE
ci(stage): announce PR / commit in Telegram on stage bot deploy

### DIFF
--- a/.github/workflows/stage-bot.yml
+++ b/.github/workflows/stage-bot.yml
@@ -49,10 +49,17 @@ jobs:
       - name: Deploy or stop stage bot
         id: deploy
         uses: appleboy/ssh-action@v1
+        env:
+          ADMIN_CHAT_ID: ${{ secrets.BOT_ADMIN_CHAT_ID }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_EVENT_ACTION: ${{ github.event.action }}
         with:
           host: 104.248.84.190
           username: www-data
           key: ${{ secrets.DIGITAL_OCEAN_SSH_KEY }}
+          envs: ADMIN_CHAT_ID,REPO,PR_NUMBER,PR_TITLE,GH_EVENT_ACTION
           script: |
             set -e
             export PATH="/var/www/.nvm/versions/node/v22.17.0/bin:/var/www/.bun/bin:$PATH"
@@ -92,7 +99,56 @@ jobs:
               echo "✅ Stage bot online (cwd: $cwd)"
             }
 
-            if [ "${{ github.event.action }}" = "closed" ]; then
+            # HTML-escape the three characters Telegram's HTML parse mode
+            # rejects inside free text.
+            escape_html() {
+              printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+            }
+
+            # Announce "stage bot now runs PR #N" or "stage bot now runs
+            # main commit abc1234" via curl to the Telegram Bot API, using
+            # the stage bot's own token (read from .env.stage). Mirrors the
+            # "Notify deploy success" step in deploy.yml.
+            send_startup_notification() {
+              local cwd="$1"
+              local mode="$2"  # "pr" or "main"
+
+              local commit_sha
+              commit_sha=$(cd "$cwd" && git rev-parse HEAD)
+              local commit_msg
+              commit_msg=$(cd "$cwd" && git log -1 --format='%s')
+              local short_sha="${commit_sha:0:7}"
+
+              local stage_bot_token
+              stage_bot_token=$(grep "^BOT_TOKEN=" "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'")
+              if [ -z "$stage_bot_token" ]; then
+                echo "⚠️  BOT_TOKEN not found in $ENV_FILE — skipping announcement"
+                return 0
+              fi
+              if [ -z "${ADMIN_CHAT_ID:-}" ]; then
+                echo "⚠️  ADMIN_CHAT_ID not set — skipping announcement"
+                return 0
+              fi
+
+              local text
+              if [ "$mode" = "pr" ]; then
+                local title_escaped
+                title_escaped=$(escape_html "${PR_TITLE:-}")
+                text="🚀 Stage bot running <a href=\"https://github.com/${REPO}/pull/${PR_NUMBER}\">PR #${PR_NUMBER}</a>: ${title_escaped}"
+              else
+                local msg_escaped
+                msg_escaped=$(escape_html "$commit_msg")
+                text="🚀 Stage bot running <code>main</code> <a href=\"https://github.com/${REPO}/commit/${commit_sha}\">${short_sha}</a>: ${msg_escaped}"
+              fi
+
+              curl -sS -X POST "https://api.telegram.org/bot${stage_bot_token}/sendMessage" \
+                -H "Content-Type: application/json" \
+                -d "$(jq -n --arg chat_id "$ADMIN_CHAT_ID" --arg text "$text" \
+                  '{chat_id: $chat_id, text: $text, parse_mode: "HTML", disable_web_page_preview: true}')" \
+                > /dev/null || echo "⚠️  Telegram notification failed (non-fatal)"
+            }
+
+            if [ "$GH_EVENT_ACTION" = "closed" ]; then
               echo "🛑 PR closed — tearing down worktree and restarting stage bot from main..."
 
               if [ -d "$WORKTREE" ]; then
@@ -107,6 +163,7 @@ jobs:
               $BUN install
 
               start_stage_bot "$MAIN_DIR"
+              send_startup_notification "$MAIN_DIR" "main"
               $PM2 list
               exit 0
             fi
@@ -130,6 +187,7 @@ jobs:
             $BUN install
 
             start_stage_bot "$WORKTREE"
+            send_startup_notification "$WORKTREE" "pr"
             $PM2 list
 
       - name: Comment on PR with stage bot link


### PR DESCRIPTION
## Summary

When the stage bot boots — either on PR open/sync (running from the PR branch) or on PR close (switching back to `main` as introduced in #70) — send a Telegram message to the admin chat announcing what version is currently loaded:

**PR mode:**
> 🚀 Stage bot running [PR #72](https://github.com/.../pull/72): fix(web): defensive URL parsing in HTTP fetch handlers

**main mode:**
> 🚀 Stage bot running `main` [abc1234](https://github.com/.../commit/abc1234): ci(stage): announce PR / commit in Telegram on stage bot deploy

## How it works

Mirrors the existing "Notify deploy success" step in `deploy.yml`:

- Uses `curl` against the Telegram Bot API
- Reads `BOT_TOKEN` from `.env.stage` on the server (so the message is sent **from the stage bot**, not prod bot — clearer origin for testers)
- `ADMIN_CHAT_ID` forwarded from the existing `secrets.BOT_ADMIN_CHAT_ID` GitHub secret
- PR title and commit subject are HTML-escaped before interpolation into the message body
- The `curl` call is non-fatal — if Telegram is unreachable or the token is missing, the deploy still succeeds (only a warning is logged to the workflow output)

## Why

After #70 landed, the stage bot gracefully switches between PR branches and main. But there was no visible indication of which version is currently loaded — testers had to check PM2 logs or GitHub to figure out what they were hitting. This adds a one-message deploy announcement to the admin chat so it's obvious at a glance.

## Test plan
- [ ] Open a throwaway PR → verify Telegram message from stage bot: "🚀 Stage bot running PR #NNN: ..." with clickable PR link
- [ ] Close that PR → verify Telegram message: "🚀 Stage bot running main abc1234: ..." with clickable commit link
- [ ] Confirm PR titles with special characters (`<`, `>`, `&`) are properly escaped
- [ ] Verify the workflow still succeeds if `.env.stage` does not contain BOT_TOKEN (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)