### PR TITLE
fix(advice): abort hung streams + suppress false early-month alerts

### DIFF
--- a/src/bot/commands/ask.test.ts
+++ b/src/bot/commands/ask.test.ts
@@ -124,6 +124,7 @@ mock.module('../../services/ai/streaming', () => ({
 const writerCalls = {
   appended: [] as string[],
   finalized: [] as string[],
+  finalizedErrors: [] as string[],
   closed: 0,
 };
 
@@ -136,6 +137,9 @@ class StubStatusWriter {
   }
   async finalize(finalText: string): Promise<void> {
     writerCalls.finalized.push(finalText);
+  }
+  async finalizeError(errorSuffix: string): Promise<void> {
+    writerCalls.finalizedErrors.push(errorSuffix);
   }
   async close(): Promise<void> {
     writerCalls.closed += 1;
@@ -199,6 +203,7 @@ describe('handleAdviceCommand — stream abort safety', () => {
     mockAdviceLogs.create.mockClear();
     writerCalls.appended.length = 0;
     writerCalls.finalized.length = 0;
+    writerCalls.finalizedErrors.length = 0;
     writerCalls.closed = 0;
   });
 
@@ -216,7 +221,7 @@ describe('handleAdviceCommand — stream abort safety', () => {
     expect(opts.signal?.aborted).toBe(false);
   });
 
-  test('uses the smart chain for deep-tier analysis', async () => {
+  test('uses the smart chain and deep-tier budget + temperature from TIER_CONFIGS', async () => {
     successfulStream(['ok']);
 
     await handleAdviceCommand(fakeCtx(), fakeGroup());
@@ -224,6 +229,9 @@ describe('handleAdviceCommand — stream abort safety', () => {
     const [opts] = mockAiStreamRound.mock.calls[0] as unknown as [StreamRoundOptions];
     expect(opts.chain).toBe('smart');
     expect(opts.maxTokens).toBe(3000); // deep tier budget
+    // Deep tier uses a higher temperature (0.6) for more exploratory analysis —
+    // previously this was silently dropped and defaulted to 0.3 in streaming.ts.
+    expect(opts.temperature).toBe(0.6);
   });
 
   test('propagates text deltas to the status writer and finalizes the cleaned advice', async () => {
@@ -237,7 +245,7 @@ describe('handleAdviceCommand — stream abort safety', () => {
     expect(writerCalls.finalized[0]).toContain('Ситуация нормальная');
   });
 
-  test('closes the status writer when aiStreamRound rejects (aborted / errored stream)', async () => {
+  test('preserves partial content via finalizeError when aiStreamRound rejects mid-stream', async () => {
     mockAiStreamRound.mockImplementationOnce(async (_opts, callbacks) => {
       // Emit a partial delta, then fail — simulates a stream that starts writing
       // and then dies mid-way (abort, network drop, provider hang timing out).
@@ -248,10 +256,12 @@ describe('handleAdviceCommand — stream abort safety', () => {
     await handleAdviceCommand(fakeCtx(), fakeGroup());
 
     expect(writerCalls.appended).toEqual(['Critical situati']);
-    // The inner catch must tear down the writer instead of leaving the orphan
-    // message visible to the user.
-    expect(writerCalls.closed).toBeGreaterThanOrEqual(1);
+    // Do NOT delete the partial message — pin an error indicator on it instead,
+    // so the user sees what was generated so far plus a clear failure marker.
+    expect(writerCalls.closed).toBe(0);
     expect(writerCalls.finalized).toHaveLength(0);
+    expect(writerCalls.finalizedErrors).toHaveLength(1);
+    expect(writerCalls.finalizedErrors[0]).toContain('Генерация прервана');
     // Outer catch in sendSmartAdvice logs the failure but does not throw.
     expect(logMock.error).toHaveBeenCalled();
   });

--- a/src/bot/commands/ask.test.ts
+++ b/src/bot/commands/ask.test.ts
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { StreamRoundOptions, StreamRoundResult } from '../../services/ai/streaming';
-import type { FinancialSnapshot } from '../../services/analytics/types';
+import { buildNeutralSnapshot } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 import { createMockLogger } from '../../test-utils/mocks/logger';
 
@@ -48,45 +48,6 @@ mock.module('../../database', () => ({
   _budgetWriter: () => mockDb['budgets'],
 }));
 
-// ── Analytics snapshot (fed to sendSmartAdvice via spendingAnalytics mock) ──
-function buildNeutralSnapshot(): FinancialSnapshot {
-  return {
-    burnRates: [],
-    weekTrend: {
-      period: 'week',
-      current_total: 0,
-      previous_total: 0,
-      change_percent: 0,
-      direction: 'stable',
-      category_changes: [],
-    },
-    monthTrend: {
-      period: 'month',
-      current_total: 0,
-      previous_total: 0,
-      change_percent: 0,
-      direction: 'stable',
-      category_changes: [],
-    },
-    anomalies: [],
-    dayOfWeekPatterns: [],
-    velocity: {
-      period_1_daily_avg: 0,
-      period_2_daily_avg: 0,
-      acceleration: 0,
-      trend: 'stable',
-    },
-    budgetUtilization: null,
-    streak: {
-      current_streak_days: 0,
-      streak_type: 'no_spending',
-      avg_daily_during_streak: 0,
-      overall_daily_average: 0,
-    },
-    projection: null,
-  };
-}
-
 mock.module('../../services/analytics/spending-analytics', () => ({
   spendingAnalytics: {
     getFinancialSnapshot: mock(() => buildNeutralSnapshot()),
@@ -129,9 +90,6 @@ const writerCalls = {
 };
 
 class StubStatusWriter {
-  constructor(_: { header: string; mode?: 'code' | 'plain' }) {
-    void _;
-  }
   append(delta: string): void {
     writerCalls.appended.push(delta);
   }

--- a/src/bot/commands/ask.test.ts
+++ b/src/bot/commands/ask.test.ts
@@ -1,0 +1,258 @@
+// Tests for /advice smart streaming — regression coverage for the mid-stream hang bug
+// where aiStreamRound was called without an AbortSignal, leaving the user staring at a
+// half-written status message indefinitely when a provider stream stalled.
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { StreamRoundOptions, StreamRoundResult } from '../../services/ai/streaming';
+import type { FinancialSnapshot } from '../../services/analytics/types';
+import { mockDatabase } from '../../test-utils/mocks/database';
+import { createMockLogger } from '../../test-utils/mocks/logger';
+
+// ── Logger ──────────────────────────────────────────────────────────────
+const logMock = createMockLogger();
+mock.module('../../utils/logger.ts', () => ({
+  createLogger: () => logMock,
+  logger: logMock,
+}));
+
+// ── Database ────────────────────────────────────────────────────────────
+const mockGroups = {
+  findById: mock(() => ({
+    id: 1,
+    telegram_group_id: -1000,
+    default_currency: 'EUR',
+    custom_prompt: null,
+    active_topic_id: null,
+  })),
+};
+
+const mockAdviceLogs = {
+  getRecentTopics: mock(() => [] as string[]),
+  create: mock(() => undefined),
+};
+
+// formatSnapshotForPrompt (real) touches several repos — return empty
+// collections so it can build a prompt string without crashing.
+const mockBankAccounts = { findByGroupId: mock(() => []) };
+const mockRecurringPatterns = { getActiveByGroupId: mock(() => []) };
+
+const mockDb = mockDatabase({
+  groups: mockGroups,
+  adviceLogs: mockAdviceLogs,
+  bankAccounts: mockBankAccounts,
+  recurringPatterns: mockRecurringPatterns,
+});
+
+mock.module('../../database', () => ({
+  database: mockDb,
+  _budgetWriter: () => mockDb['budgets'],
+}));
+
+// ── Analytics snapshot (fed to sendSmartAdvice via spendingAnalytics mock) ──
+function buildNeutralSnapshot(): FinancialSnapshot {
+  return {
+    burnRates: [],
+    weekTrend: {
+      period: 'week',
+      current_total: 0,
+      previous_total: 0,
+      change_percent: 0,
+      direction: 'stable',
+      category_changes: [],
+    },
+    monthTrend: {
+      period: 'month',
+      current_total: 0,
+      previous_total: 0,
+      change_percent: 0,
+      direction: 'stable',
+      category_changes: [],
+    },
+    anomalies: [],
+    dayOfWeekPatterns: [],
+    velocity: {
+      period_1_daily_avg: 0,
+      period_2_daily_avg: 0,
+      acceleration: 0,
+      trend: 'stable',
+    },
+    budgetUtilization: null,
+    streak: {
+      current_streak_days: 0,
+      streak_type: 'no_spending',
+      avg_daily_during_streak: 0,
+      overall_daily_average: 0,
+    },
+    projection: null,
+  };
+}
+
+mock.module('../../services/analytics/spending-analytics', () => ({
+  spendingAnalytics: {
+    getFinancialSnapshot: mock(() => buildNeutralSnapshot()),
+  },
+}));
+
+// formatSnapshotForPrompt / computeOverallSeverity touch repos transitively —
+// stub the whole formatters module so the test only exercises the advice flow.
+mock.module('../../services/analytics/formatters', () => ({
+  formatSnapshotForPrompt: mock(() => '## Snapshot\nneutral'),
+  computeOverallSeverity: mock(() => 'good'),
+}));
+
+// ── aiStreamRound ───────────────────────────────────────────────────────
+const mockAiStreamRound =
+  mock<
+    (
+      opts: StreamRoundOptions,
+      callbacks?: import('../../services/ai/streaming').StreamCallbacks,
+    ) => Promise<StreamRoundResult>
+  >();
+
+mock.module('../../services/ai/streaming', () => ({
+  aiStreamRound: mockAiStreamRound,
+  stripThinkingTags: (text: string) => text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim(),
+  isRetryableError: mock(() => false),
+  getBackoffDelay: mock(() => 0),
+  formatApiError: mock(() => 'mock-error'),
+}));
+
+// ── StatusWriter ────────────────────────────────────────────────────────
+// Replace StatusWriter with a stub that captures the streamed text and final output.
+// The real class is an integration with telegram-sender; here we only care about
+// verifying the advice flow wires up the writer and ultimately calls finalize().
+const writerCalls = {
+  appended: [] as string[],
+  finalized: [] as string[],
+  closed: 0,
+};
+
+class StubStatusWriter {
+  constructor(_: { header: string; mode?: 'code' | 'plain' }) {
+    void _;
+  }
+  append(delta: string): void {
+    writerCalls.appended.push(delta);
+  }
+  async finalize(finalText: string): Promise<void> {
+    writerCalls.finalized.push(finalText);
+  }
+  async close(): Promise<void> {
+    writerCalls.closed += 1;
+  }
+}
+
+mock.module('../../services/receipt/status-writer', () => ({
+  StatusWriter: StubStatusWriter,
+}));
+
+// ── telegram-sender (used on finalize-error fallback) ───────────────────
+const mockSendMessage = mock(async () => null);
+mock.module('../../services/bank/telegram-sender', () => ({
+  sendMessage: mockSendMessage,
+  editMessageText: mock(async () => undefined),
+  deleteMessage: mock(async () => undefined),
+  withChatContext: async (_chatId: number, _threadId: number | null, fn: () => Promise<unknown>) =>
+    fn(),
+}));
+
+// Import AFTER all mocks are registered
+const { handleAdviceCommand } = await import('./ask');
+
+// ── Test helpers ────────────────────────────────────────────────────────
+function successfulStream(chunks: string[] = ['hello advice']): void {
+  mockAiStreamRound.mockImplementationOnce(async (_opts, callbacks) => {
+    for (const chunk of chunks) {
+      callbacks?.onTextDelta?.(chunk);
+    }
+    const text = chunks.join('');
+    return {
+      text,
+      toolCalls: [],
+      finishReason: 'stop',
+      assistantMessage: { role: 'assistant', content: text },
+      providerUsed: 'mock-smart',
+    };
+  });
+}
+
+function fakeGroup() {
+  return {
+    id: 1,
+    telegram_group_id: -1000,
+    default_currency: 'EUR',
+    custom_prompt: null,
+    active_topic_id: null,
+  } as unknown as import('../../database/types').Group;
+}
+
+function fakeCtx() {
+  // handleAdviceCommand voids ctx — a minimal stub is enough.
+  return {} as unknown as import('../types').Ctx['Command'];
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+describe('handleAdviceCommand — stream abort safety', () => {
+  beforeEach(() => {
+    mockAiStreamRound.mockClear();
+    mockSendMessage.mockClear();
+    mockAdviceLogs.create.mockClear();
+    writerCalls.appended.length = 0;
+    writerCalls.finalized.length = 0;
+    writerCalls.closed = 0;
+  });
+
+  test('passes an AbortSignal to aiStreamRound so hung provider streams cannot run forever', async () => {
+    successfulStream(['Финансовый обзор', ' за месяц']);
+
+    await handleAdviceCommand(fakeCtx(), fakeGroup());
+
+    expect(logMock.error).not.toHaveBeenCalled();
+    expect(mockAiStreamRound).toHaveBeenCalledTimes(1);
+    const [opts] = mockAiStreamRound.mock.calls[0] as unknown as [StreamRoundOptions];
+    expect(opts.signal).toBeDefined();
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+    // AbortSignal.timeout() returns a signal that has not yet fired
+    expect(opts.signal?.aborted).toBe(false);
+  });
+
+  test('uses the smart chain for deep-tier analysis', async () => {
+    successfulStream(['ok']);
+
+    await handleAdviceCommand(fakeCtx(), fakeGroup());
+
+    const [opts] = mockAiStreamRound.mock.calls[0] as unknown as [StreamRoundOptions];
+    expect(opts.chain).toBe('smart');
+    expect(opts.maxTokens).toBe(3000); // deep tier budget
+  });
+
+  test('propagates text deltas to the status writer and finalizes the cleaned advice', async () => {
+    successfulStream(['Ситуация', ' нормальная']);
+
+    await handleAdviceCommand(fakeCtx(), fakeGroup());
+
+    expect(writerCalls.appended).toEqual(['Ситуация', ' нормальная']);
+    expect(writerCalls.finalized).toHaveLength(1);
+    expect(writerCalls.finalized[0]).toContain('Финансовый обзор');
+    expect(writerCalls.finalized[0]).toContain('Ситуация нормальная');
+  });
+
+  test('closes the status writer when aiStreamRound rejects (aborted / errored stream)', async () => {
+    mockAiStreamRound.mockImplementationOnce(async (_opts, callbacks) => {
+      // Emit a partial delta, then fail — simulates a stream that starts writing
+      // and then dies mid-way (abort, network drop, provider hang timing out).
+      callbacks?.onTextDelta?.('Critical situati');
+      throw new Error('stream aborted mid-flight');
+    });
+
+    await handleAdviceCommand(fakeCtx(), fakeGroup());
+
+    expect(writerCalls.appended).toEqual(['Critical situati']);
+    // The inner catch must tear down the writer instead of leaving the orphan
+    // message visible to the user.
+    expect(writerCalls.closed).toBeGreaterThanOrEqual(1);
+    expect(writerCalls.finalized).toHaveLength(0);
+    // Outer catch in sendSmartAdvice logs the failure but does not throw.
+    expect(logMock.error).toHaveBeenCalled();
+  });
+});

--- a/src/bot/commands/ask.ts
+++ b/src/bot/commands/ask.ts
@@ -27,6 +27,15 @@ import type { Ctx } from '../types';
 const logger = createLogger('ask');
 
 /**
+ * Hard cap on how long the advice stream may run before we abort it.
+ * Without this, a provider stream that stalls mid-flight leaves the user
+ * staring at a half-written status message forever (no client-side timeout
+ * otherwise fires — the OpenAI SDK `timeout` only covers request setup).
+ * 60s comfortably covers the deep tier's 3k token budget.
+ */
+const ADVICE_TIMEOUT_MS = 60_000;
+
+/**
  * Handle questions to the bot via @botname question
  */
 export async function handleAskQuestion(
@@ -279,6 +288,7 @@ async function sendSmartAdvice(
           messages: [{ role: 'user', content: fullPrompt }],
           maxTokens: tierConfig.max_tokens,
           chain: 'smart',
+          signal: AbortSignal.timeout(ADVICE_TIMEOUT_MS),
         },
         { onTextDelta: (delta) => writer.append(delta) },
       );

--- a/src/bot/commands/ask.ts
+++ b/src/bot/commands/ask.ts
@@ -287,6 +287,7 @@ async function sendSmartAdvice(
         {
           messages: [{ role: 'user', content: fullPrompt }],
           maxTokens: tierConfig.max_tokens,
+          temperature: tierConfig.temperature,
           chain: 'smart',
           signal: AbortSignal.timeout(ADVICE_TIMEOUT_MS),
         },
@@ -294,7 +295,10 @@ async function sendSmartAdvice(
       );
       rawAdvice = result.text;
     } catch (err) {
-      await writer.close();
+      // Preserve whatever was already streamed and pin an error indicator on
+      // the end, so the user doesn't see the message silently vanish after the
+      // stream aborts (timeout, provider error, mid-stream hang).
+      await writer.finalizeError('<i>❌ Генерация прервана, попробуй ещё раз</i>');
       throw err;
     }
 

--- a/src/services/analytics/advice-triggers.test.ts
+++ b/src/services/analytics/advice-triggers.test.ts
@@ -93,7 +93,18 @@ function buildNeutralSnapshot(overrides: Partial<FinancialSnapshot> = {}): Finan
       avg_daily_during_streak: 0,
       overall_daily_average: 50,
     },
-    projection: null,
+    // Default to a non-low-confidence projection so warning/critical burn-rate
+    // tests (which exist independent of the confidence gate) are not suppressed
+    // by it. Tests that specifically exercise the gate override this explicitly.
+    projection: {
+      days_elapsed: 15,
+      days_in_month: 30,
+      current_total: 500,
+      projected_total: 1000,
+      projected_vs_last_month: 100,
+      confidence: 'medium',
+      category_projections: [],
+    },
     ...overrides,
   };
 }
@@ -238,6 +249,166 @@ describe('checkSmartTriggers', () => {
     expect(result).not.toBeNull();
     expect(result?.type).toBe('budget_threshold');
     expect(result?.tier).toBe('alert');
+    expect(result?.topic).toContain('Rent');
+    expect(result?.topic).toContain('100');
+  });
+
+  // ── Projection confidence gate ──────────────────────────────────────
+  // Reproduces the false-alert bug: a lumpy one-off expense early in the
+  // month (e.g. a car repair on day 2) produces a huge linear projection
+  // and used to fire a `critical` budget-threshold alert. The spec says
+  // projection-based triggers must be suppressed at low confidence.
+
+  test('low-confidence projection suppresses critical burn-rate alert (lumpy car expense, day 2)', () => {
+    const snapshot = buildNeutralSnapshot({
+      // One car expense of 300 on day 2 of a 30-day month → linear extrapolation
+      // projects 4500 for the month on a 500 budget. `computeBurnRates` marks
+      // this `critical`, but projection.confidence is `low` (days_elapsed < 7)
+      // so the alert must NOT fire.
+      burnRates: [
+        buildBurnRate({
+          status: 'critical',
+          category: 'Автомобиль',
+          spent: 300,
+          projected_total: 4500,
+          budget_limit: 500,
+          currency: 'EUR',
+          days_elapsed: 2,
+          days_remaining: 28,
+        }),
+      ],
+      projection: {
+        days_elapsed: 2,
+        days_in_month: 30,
+        current_total: 300,
+        projected_total: 4500,
+        projected_vs_last_month: 900,
+        confidence: 'low',
+        category_projections: [],
+      },
+    });
+
+    const result = checkSmartTriggers(8001, snapshot);
+    // Either null, or any trigger that is NOT a projection-based budget_threshold.
+    // (weekly_check on Monday is fine; exceeded facts are fine.)
+    if (result && result.type === 'budget_threshold') {
+      expect(result.topic).toContain('exceeded');
+    }
+  });
+
+  test('low-confidence projection suppresses warning burn-rate alert', () => {
+    const snapshot = buildNeutralSnapshot({
+      burnRates: [
+        buildBurnRate({
+          status: 'warning',
+          category: 'Продукты',
+          projected_total: 450,
+          budget_limit: 500,
+          currency: 'EUR',
+          days_elapsed: 3,
+        }),
+      ],
+      projection: {
+        days_elapsed: 3,
+        days_in_month: 30,
+        current_total: 150,
+        projected_total: 1500,
+        projected_vs_last_month: 300,
+        confidence: 'low',
+        category_projections: [],
+      },
+    });
+
+    const result = checkSmartTriggers(8002, snapshot);
+    if (result && result.type === 'budget_threshold') {
+      expect(result.topic).toContain('exceeded');
+    }
+  });
+
+  test('low-confidence projection still fires EXCEEDED alert (fact, not projection)', () => {
+    // `exceeded` means spent >= limit — that is a hard fact, no extrapolation
+    // involved. It must still fire even when the month is young, because the
+    // user has already blown past the budget regardless of projection math.
+    const snapshot = buildNeutralSnapshot({
+      burnRates: [
+        buildBurnRate({
+          status: 'exceeded',
+          category: 'Developer',
+          spent: 600,
+          budget_limit: 500,
+          currency: 'EUR',
+          days_elapsed: 2,
+        }),
+      ],
+      projection: {
+        days_elapsed: 2,
+        days_in_month: 30,
+        current_total: 600,
+        projected_total: 9000,
+        projected_vs_last_month: 1500,
+        confidence: 'low',
+        category_projections: [],
+      },
+    });
+
+    const result = checkSmartTriggers(8003, snapshot);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('budget_threshold');
+    expect(result?.topic).toContain('exceeded');
+    expect(result?.data['spent']).toBe(600);
+  });
+
+  test('null projection (too early in month) suppresses warning/critical alerts', () => {
+    // When projection is null (day 1, no data yet) the code should fall back
+    // to "not confident" and skip projection-based alerts.
+    const snapshot = buildNeutralSnapshot({
+      burnRates: [
+        buildBurnRate({
+          status: 'critical',
+          category: 'Транспорт',
+          projected_total: 3000,
+          budget_limit: 500,
+          currency: 'EUR',
+          days_elapsed: 1,
+        }),
+      ],
+      projection: null,
+    });
+
+    const result = checkSmartTriggers(8004, snapshot);
+    if (result && result.type === 'budget_threshold') {
+      expect(result.topic).toContain('exceeded');
+    }
+  });
+
+  test('medium-confidence projection allows critical alert to fire', () => {
+    // Past the first week: projection confidence is medium/high, the linear
+    // extrapolation is trustworthy, and the alert should fire normally.
+    const snapshot = buildNeutralSnapshot({
+      burnRates: [
+        buildBurnRate({
+          status: 'critical',
+          category: 'Rent',
+          projected_total: 1200,
+          budget_limit: 1000,
+          currency: 'USD',
+          days_elapsed: 15,
+        }),
+      ],
+      projection: {
+        days_elapsed: 15,
+        days_in_month: 30,
+        current_total: 600,
+        projected_total: 1200,
+        projected_vs_last_month: 120,
+        confidence: 'medium',
+        category_projections: [],
+      },
+    });
+
+    const result = checkSmartTriggers(8005, snapshot);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('budget_threshold');
     expect(result?.topic).toContain('Rent');
     expect(result?.topic).toContain('100');
   });

--- a/src/services/analytics/advice-triggers.test.ts
+++ b/src/services/analytics/advice-triggers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from 'bun:test';
 import type { BankConnection, BankTransaction } from '../../database/types';
+import { buildNeutralSnapshot } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 import type { AdviceLog, BudgetBurnRate, CategoryAnomaly, FinancialSnapshot } from './types';
 
@@ -50,7 +51,7 @@ const { SpendingAnalytics } = await import('./spending-analytics');
 mock.module('./spending-analytics', () => ({
   SpendingAnalytics,
   spendingAnalytics: {
-    getFinancialSnapshot: mock(() => buildNeutralSnapshot()),
+    getFinancialSnapshot: mock(() => buildTriggerSnapshot()),
   },
 }));
 
@@ -59,54 +60,21 @@ const { checkSmartTriggers, recordAdviceSent } = await import('./advice-triggers
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-function buildNeutralSnapshot(overrides: Partial<FinancialSnapshot> = {}): FinancialSnapshot {
-  return {
-    burnRates: [],
-    weekTrend: {
-      period: 'week',
-      current_total: 100,
-      previous_total: 100,
-      change_percent: 0,
-      direction: 'stable',
-      category_changes: [],
-    },
-    monthTrend: {
-      period: 'month',
-      current_total: 500,
-      previous_total: 500,
-      change_percent: 0,
-      direction: 'stable',
-      category_changes: [],
-    },
-    anomalies: [],
-    dayOfWeekPatterns: [],
-    velocity: {
-      period_1_daily_avg: 50,
-      period_2_daily_avg: 50,
-      acceleration: 0,
-      trend: 'stable',
-    },
-    budgetUtilization: null,
-    streak: {
-      current_streak_days: 0,
-      streak_type: 'no_spending',
-      avg_daily_during_streak: 0,
-      overall_daily_average: 50,
-    },
-    // Default to a non-low-confidence projection so warning/critical burn-rate
-    // tests (which exist independent of the confidence gate) are not suppressed
-    // by it. Tests that specifically exercise the gate override this explicitly.
-    projection: {
-      days_elapsed: 15,
-      days_in_month: 30,
-      current_total: 500,
-      projected_total: 1000,
-      projected_vs_last_month: 100,
-      confidence: 'medium',
-      category_projections: [],
-    },
-    ...overrides,
-  };
+// Default to a non-low-confidence projection so warning/critical burn-rate
+// tests (which exist independent of the confidence gate) are not suppressed
+// by it. Tests that specifically exercise the gate override this explicitly.
+const DEFAULT_PROJECTION: FinancialSnapshot['projection'] = {
+  days_elapsed: 15,
+  days_in_month: 30,
+  current_total: 500,
+  projected_total: 1000,
+  projected_vs_last_month: 100,
+  confidence: 'medium',
+  category_projections: [],
+};
+
+function buildTriggerSnapshot(overrides: Partial<FinancialSnapshot> = {}): FinancialSnapshot {
+  return buildNeutralSnapshot({ projection: DEFAULT_PROJECTION, ...overrides });
 }
 
 function buildBurnRate(overrides: Partial<BudgetBurnRate> = {}): BudgetBurnRate {
@@ -168,7 +136,7 @@ afterEach(() => {
 describe('checkSmartTriggers', () => {
   test('neutral snapshot with no anomalies or budget issues returns weekly_check on Monday', () => {
     // System time is set to Monday 2026-03-23 in beforeEach
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(9999, snapshot);
     // On a Monday with neutral snapshot, weekly_check fires
     expect(result).not.toBeNull();
@@ -179,7 +147,7 @@ describe('checkSmartTriggers', () => {
   test('returns null when daily advice limit is reached', () => {
     mockAdviceLogs.countToday.mockImplementation(() => 3);
 
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'exceeded', spent: 600 })],
     });
 
@@ -188,7 +156,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('budget exceeded triggers alert', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'exceeded',
@@ -212,7 +180,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('budget warning triggers alert with projected data', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'warning',
@@ -233,7 +201,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('budget critical triggers alert', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'critical',
@@ -260,7 +228,10 @@ describe('checkSmartTriggers', () => {
   // projection-based triggers must be suppressed at low confidence.
 
   test('low-confidence projection suppresses critical burn-rate alert (lumpy car expense, day 2)', () => {
-    const snapshot = buildNeutralSnapshot({
+    // Tuesday — no weekly_check noise, so null means "all triggers suppressed"
+    setSystemTime(new Date('2026-03-24T10:00:00Z'));
+
+    const snapshot = buildTriggerSnapshot({
       // One car expense of 300 on day 2 of a 30-day month → linear extrapolation
       // projects 4500 for the month on a 500 budget. `computeBurnRates` marks
       // this `critical`, but projection.confidence is `low` (days_elapsed < 7)
@@ -289,15 +260,13 @@ describe('checkSmartTriggers', () => {
     });
 
     const result = checkSmartTriggers(8001, snapshot);
-    // Either null, or any trigger that is NOT a projection-based budget_threshold.
-    // (weekly_check on Monday is fine; exceeded facts are fine.)
-    if (result && result.type === 'budget_threshold') {
-      expect(result.topic).toContain('exceeded');
-    }
+    expect(result).toBeNull();
   });
 
   test('low-confidence projection suppresses warning burn-rate alert', () => {
-    const snapshot = buildNeutralSnapshot({
+    setSystemTime(new Date('2026-03-24T10:00:00Z'));
+
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'warning',
@@ -320,16 +289,14 @@ describe('checkSmartTriggers', () => {
     });
 
     const result = checkSmartTriggers(8002, snapshot);
-    if (result && result.type === 'budget_threshold') {
-      expect(result.topic).toContain('exceeded');
-    }
+    expect(result).toBeNull();
   });
 
   test('low-confidence projection still fires EXCEEDED alert (fact, not projection)', () => {
     // `exceeded` means spent >= limit — that is a hard fact, no extrapolation
     // involved. It must still fire even when the month is young, because the
     // user has already blown past the budget regardless of projection math.
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'exceeded',
@@ -359,9 +326,9 @@ describe('checkSmartTriggers', () => {
   });
 
   test('null projection (too early in month) suppresses warning/critical alerts', () => {
-    // When projection is null (day 1, no data yet) the code should fall back
-    // to "not confident" and skip projection-based alerts.
-    const snapshot = buildNeutralSnapshot({
+    setSystemTime(new Date('2026-03-24T10:00:00Z'));
+
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'critical',
@@ -376,15 +343,13 @@ describe('checkSmartTriggers', () => {
     });
 
     const result = checkSmartTriggers(8004, snapshot);
-    if (result && result.type === 'budget_threshold') {
-      expect(result.topic).toContain('exceeded');
-    }
+    expect(result).toBeNull();
   });
 
   test('medium-confidence projection allows critical alert to fire', () => {
     // Past the first week: projection confidence is medium/high, the linear
     // extrapolation is trustworthy, and the alert should fire normally.
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'critical',
@@ -414,7 +379,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('significant category anomaly triggers alert', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       anomalies: [
         buildAnomaly({
           category: 'Entertainment',
@@ -438,7 +403,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('extreme anomaly triggers alert', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       anomalies: [buildAnomaly({ severity: 'extreme', deviation_ratio: 5.0 })],
     });
 
@@ -449,7 +414,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('mild anomaly does NOT trigger', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       anomalies: [buildAnomaly({ severity: 'mild', deviation_ratio: 1.2 })],
     });
 
@@ -462,7 +427,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('velocity spike (accelerating > 50%) triggers quick advice', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 30,
         period_2_daily_avg: 60,
@@ -479,7 +444,7 @@ describe('checkSmartTriggers', () => {
   });
 
   test('budget exceeded takes priority over anomaly (priority order)', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'exceeded', category: 'Food', spent: 600 })],
       anomalies: [buildAnomaly({ severity: 'extreme' })],
     });
@@ -493,7 +458,7 @@ describe('checkSmartTriggers', () => {
   test('already-sent topic this month is skipped', () => {
     mockAdviceLogs.hasTopicThisMonth.mockImplementation(() => true);
 
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'exceeded', category: 'Food', spent: 600 })],
       anomalies: [buildAnomaly({ severity: 'extreme' })],
       velocity: {
@@ -528,7 +493,7 @@ describe('recordAdviceSent + cooldown', () => {
     const groupId = 7001;
 
     // First call: budget exceeded should fire
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'exceeded', category: 'A', spent: 600 })],
     });
 
@@ -541,7 +506,7 @@ describe('recordAdviceSent + cooldown', () => {
     recordAdviceSent(groupId, 'quick');
 
     // Second call with a different exceeded budget — should be blocked by cooldown
-    const snapshot2 = buildNeutralSnapshot({
+    const snapshot2 = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'exceeded', category: 'B', spent: 700 })],
     });
 
@@ -553,7 +518,7 @@ describe('recordAdviceSent + cooldown', () => {
   test('quick cooldown (4h): blocks velocity spike after recording', () => {
     const groupId = 7002;
 
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 30,
         period_2_daily_avg: 60,
@@ -582,7 +547,7 @@ describe('recordAdviceSent + cooldown', () => {
     recordAdviceSent(groupId, 'alert');
 
     // Velocity spike is 'quick' tier — should still fire
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 30,
         period_2_daily_avg: 60,
@@ -604,7 +569,7 @@ describe('recordAdviceSent + cooldown', () => {
 describe('edge cases', () => {
   test('weekly_check returns correct topic format with week number', () => {
     // Monday 2026-03-23 set in beforeEach
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8001, snapshot);
     expect(result).not.toBeNull();
     expect(result?.type).toBe('weekly_check');
@@ -615,7 +580,7 @@ describe('edge cases', () => {
   test('weekly_check does NOT fire on a non-Monday (Tuesday)', () => {
     // Override to Tuesday
     setSystemTime(new Date('2026-03-24T10:00:00Z')); // Tuesday
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8002, snapshot);
     // No budget/anomaly/velocity — should return null on non-Monday
     expect(result).toBeNull();
@@ -623,13 +588,13 @@ describe('edge cases', () => {
 
   test('weekly_check does NOT fire on Sunday', () => {
     setSystemTime(new Date('2026-03-22T10:00:00Z')); // Sunday
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8003, snapshot);
     expect(result).toBeNull();
   });
 
   test('multiple budgets: only the first exceeded one fires', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({ status: 'on_track', category: 'Food', spent: 100 }),
         buildBurnRate({ status: 'exceeded', category: 'Transport', spent: 600 }),
@@ -644,7 +609,7 @@ describe('edge cases', () => {
   });
 
   test('budget warning topic includes "80" threshold', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'warning', category: 'Gym' })],
     });
     const result = checkSmartTriggers(8005, snapshot);
@@ -653,7 +618,7 @@ describe('edge cases', () => {
   });
 
   test('budget critical topic includes "100" threshold', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'critical', category: 'Rent' })],
     });
     const result = checkSmartTriggers(8006, snapshot);
@@ -662,7 +627,7 @@ describe('edge cases', () => {
   });
 
   test('velocity spike at exactly 50% acceleration does NOT trigger (boundary: > 50 required)', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 50,
         period_2_daily_avg: 75,
@@ -677,7 +642,7 @@ describe('edge cases', () => {
   });
 
   test('velocity spike at 51% acceleration DOES trigger', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 50,
         period_2_daily_avg: 75.5,
@@ -692,7 +657,7 @@ describe('edge cases', () => {
   });
 
   test('velocity trend stable does NOT trigger velocity_spike even with high acceleration number', () => {
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 50,
         period_2_daily_avg: 100,
@@ -710,7 +675,7 @@ describe('edge cases', () => {
     // Use March 1 (day 1 of month, also not Monday to isolate)
     setSystemTime(new Date('2026-03-01T10:00:00Z')); // Sunday
     mockExpenses.getCountForRange.mockImplementation(() => 1);
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8010, snapshot);
     expect(result).not.toBeNull();
     expect(result?.type).toBe('first_expense_of_month');
@@ -721,7 +686,7 @@ describe('edge cases', () => {
   test('first_expense_of_month does NOT fire when count > 1', () => {
     setSystemTime(new Date('2026-03-01T10:00:00Z'));
     mockExpenses.getCountForRange.mockImplementation(() => 5);
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8011, snapshot);
     expect(result).toBeNull();
   });
@@ -729,7 +694,7 @@ describe('edge cases', () => {
   test('first_expense_of_month does NOT fire after day 3', () => {
     setSystemTime(new Date('2026-03-05T10:00:00Z')); // day 5
     mockExpenses.getCountForRange.mockImplementation(() => 1);
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8012, snapshot);
     expect(result).toBeNull();
   });
@@ -746,7 +711,7 @@ describe('edge cases', () => {
 
     // Use Tuesday to avoid weekly_check interference
     setSystemTime(new Date('2026-03-24T10:00:00Z'));
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 30,
         period_2_daily_avg: 80,
@@ -769,7 +734,7 @@ describe('edge cases', () => {
       } as AdviceLog,
     ]);
 
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 30,
         period_2_daily_avg: 80,
@@ -785,7 +750,7 @@ describe('edge cases', () => {
 
   test('budget_limit=0 with status exceeded does NOT trigger (disabled category)', () => {
     setSystemTime(new Date('2026-03-24T10:00:00Z')); // Tuesday — no weekly_check
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({ status: 'exceeded', category: 'Путешествия', budget_limit: 0, spent: 0 }),
       ],
@@ -796,7 +761,7 @@ describe('edge cases', () => {
 
   test('budget_limit=0 with status warning does NOT trigger (disabled category)', () => {
     setSystemTime(new Date('2026-03-24T10:00:00Z'));
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'warning',
@@ -812,7 +777,7 @@ describe('edge cases', () => {
 
   test('budget_limit=0 with status critical does NOT trigger (disabled category)', () => {
     setSystemTime(new Date('2026-03-24T10:00:00Z'));
-    const snapshot = buildNeutralSnapshot({
+    const snapshot = buildTriggerSnapshot({
       burnRates: [
         buildBurnRate({
           status: 'critical',
@@ -828,7 +793,7 @@ describe('edge cases', () => {
 
   test('all trigger types return correct tier', () => {
     // alert tier
-    const alertSnap = buildNeutralSnapshot({
+    const alertSnap = buildTriggerSnapshot({
       burnRates: [buildBurnRate({ status: 'exceeded' })],
     });
     const alertResult = checkSmartTriggers(8015, alertSnap);
@@ -836,7 +801,7 @@ describe('edge cases', () => {
 
     // quick tier — velocity (use unique groupId, Tuesday to avoid weekly check overlap)
     setSystemTime(new Date('2026-03-24T10:00:00Z'));
-    const quickSnap = buildNeutralSnapshot({
+    const quickSnap = buildTriggerSnapshot({
       velocity: {
         period_1_daily_avg: 30,
         period_2_daily_avg: 80,
@@ -860,7 +825,7 @@ describe('edge cases', () => {
       () => [{ id: 1 }, { id: 2 }, { id: 3 }] as BankTransaction[],
     );
 
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8017, snapshot);
 
     expect(result).not.toBeNull();
@@ -875,7 +840,7 @@ describe('edge cases', () => {
     setSystemTime(new Date('2026-03-24T10:00:00Z'));
 
     // mockBankConnections returns [] by default (reset in beforeEach)
-    const snapshot = buildNeutralSnapshot();
+    const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8018, snapshot);
 
     expect(result).toBeNull();

--- a/src/services/analytics/advice-triggers.ts
+++ b/src/services/analytics/advice-triggers.ts
@@ -41,6 +41,16 @@ export function checkSmartTriggers(
   const snap = snapshot || spendingAnalytics.getFinancialSnapshot(groupId);
   const monthStart = `${format(startOfMonth(now), 'yyyy-MM-dd')}T00:00:00`;
 
+  // Projection-based triggers (warning/critical burn rate) rely on linear
+  // extrapolation — one lumpy expense early in the month (e.g. car repair on
+  // day 2) explodes the projection and produces a false "critical" alert.
+  // The spec (docs/specs/2026-03-09-smart-advice.md, review note #10) gates
+  // these triggers on the projection's confidence level: when
+  // `days_elapsed < 7` the projection is marked `'low'` and must NOT fire
+  // automatic alerts. `exceeded` is a fact (spent >= limit), not a projection,
+  // so it stays unconditional.
+  const projectionConfident = snap.projection != null && snap.projection.confidence !== 'low';
+
   // Priority order: budget_threshold > anomaly > velocity_spike > weekly_check > first_expense_of_month
 
   // === Trigger 1: Budget threshold crossing (>80%, >100%) ===
@@ -62,7 +72,11 @@ export function checkSmartTriggers(
           };
         }
       }
-    } else if ((br.status === 'critical' || br.status === 'warning') && br.budget_limit > 0) {
+    } else if (
+      (br.status === 'critical' || br.status === 'warning') &&
+      br.budget_limit > 0 &&
+      projectionConfident
+    ) {
       const threshold = br.status === 'critical' ? '100' : '80';
       const topic = `budget_threshold:${br.category}:${threshold}`;
       if (!database.adviceLogs.hasTopicThisMonth(groupId, topic, monthStart)) {

--- a/src/services/receipt/status-writer.ts
+++ b/src/services/receipt/status-writer.ts
@@ -110,6 +110,27 @@ export class StatusWriter {
     await editMessageText(messageId, finalText, { throwOnError: true });
   }
 
+  /**
+   * Preserve whatever was already streamed and append an error suffix in place.
+   * Unlike `close()` (which deletes the message), this keeps the partial output
+   * visible so the user can see how far the generator got before it failed —
+   * much friendlier UX for "stream aborted mid-flight" cases than watching the
+   * message silently disappear. Edit failures are log-only (best-effort).
+   */
+  async finalizeError(errorSuffix: string): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    const messageId = await this.messageIdPromise;
+    if (messageId === null) return;
+    const body = this.formatDisplay(this.buffer);
+    const finalText = `${body}\n\n${errorSuffix}`;
+    try {
+      await editMessageText(messageId, finalText);
+    } catch (err) {
+      logger.warn({ err }, '[STATUS_WRITER] finalizeError edit failed');
+    }
+  }
+
   private async flush(force: boolean): Promise<void> {
     const now = Date.now();
     if (now - this.lastErrorTime < ERROR_COOLDOWN_MS) return;

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -69,3 +69,45 @@ export function makeExpense(
     ...overrides,
   };
 }
+
+/** Minimal valid FinancialSnapshot with neutral values. Override individual fields as needed. */
+export function buildNeutralSnapshot(
+  overrides: Partial<import('../services/analytics/types').FinancialSnapshot> = {},
+): import('../services/analytics/types').FinancialSnapshot {
+  return {
+    burnRates: [],
+    weekTrend: {
+      period: 'week',
+      current_total: 0,
+      previous_total: 0,
+      change_percent: 0,
+      direction: 'stable',
+      category_changes: [],
+    },
+    monthTrend: {
+      period: 'month',
+      current_total: 0,
+      previous_total: 0,
+      change_percent: 0,
+      direction: 'stable',
+      category_changes: [],
+    },
+    anomalies: [],
+    dayOfWeekPatterns: [],
+    velocity: {
+      period_1_daily_avg: 0,
+      period_2_daily_avg: 0,
+      acceleration: 0,
+      trend: 'stable',
+    },
+    budgetUtilization: null,
+    streak: {
+      current_streak_days: 0,
+      streak_type: 'no_spending',
+      avg_daily_during_streak: 0,
+      overall_daily_average: 0,
+    },
+    projection: null,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes the "⚠️ Финансовый алерт" that hung mid-stream and was a false positive from linear extrapolation of a lumpy car expense on day 2.

### Stream hang fix
- `aiStreamRound` in `sendSmartAdvice` was the only caller without an `AbortSignal` — provider streams could stall indefinitely. Added `AbortSignal.timeout(60s)`.
- New `StatusWriter.finalizeError()` preserves partial streamed content with an error marker instead of silently deleting it via `close()`.
- `temperature` from `TIER_CONFIGS` (0.5/0.5/0.6) was silently dropped, defaulting to 0.3. Now passed through.

### False alert fix
- The smart-advice spec (Review Note #10) required gating projection-based alerts on `projection.confidence`, but `checkSmartTriggers` never checked it. One car expense on day 2 → linear extrapolation projects 4500 on a 500 budget → false `critical` alert.
- Added `projectionConfident` gate: `warning`/`critical` burn-rate alerts suppressed when `projection.confidence === 'low'` (days_elapsed < 7) or projection is null. `exceeded` (spent ≥ limit) still fires unconditionally — it's a fact, not a projection.

### Test cleanup (review fixes)
- Extracted `buildNeutralSnapshot` to shared `src/test-utils/fixtures.ts` (was duplicated across two test files).
- Strengthened low-confidence gate tests: set time to Tuesday (no weekly_check noise), assert `result === null` unconditionally instead of vacuous conditional assertions.

## Test plan
- [x] 4 ask.test.ts cases: signal presence, chain+tokens+temperature, delta→finalize flow, mid-stream error→finalizeError
- [x] 5 advice-triggers.test.ts cases: low-conf critical suppressed, low-conf warning suppressed, low-conf exceeded fires, null projection suppressed, medium-conf critical fires
- [x] All regression tests verified by reverting fix and confirming failure
- [x] Full suite: 2085 passing, typecheck + biome clean