### PR TITLE
perf(db): eliminate redundant queries in getFinancialSnapshot (#8)

### DIFF
--- a/src/bot/commands/budget.ts
+++ b/src/bot/commands/budget.ts
@@ -9,6 +9,7 @@ import {
   getCurrencySymbol,
 } from '../../config/constants';
 import { database } from '../../database';
+import { computeBudgetProgress } from '../../database/repositories/budget.repository';
 import { spendingAnalytics } from '../../services/analytics/spending-analytics';
 import { sendMessage } from '../../services/bank/telegram-sender';
 import { getBudgetManager } from '../../services/budget-manager';
@@ -226,15 +227,8 @@ export function formatBudgetProgressText(groupId: number): { text: string; hasBu
   const budgetProgress = budgets.map((budget) => {
     const spentEur = categorySpending[budget.category] || 0;
     const spent = convertCurrency(spentEur, BASE_CURRENCY, budget.currency);
-    const percentage =
-      budget.limit_amount > 0 ? Math.round((spent / budget.limit_amount) * 100) : 0;
-    return {
-      budget,
-      spent,
-      percentage,
-      is_exceeded: spent > budget.limit_amount,
-      is_warning: percentage >= 90,
-    };
+    const progress = computeBudgetProgress(budget, spent);
+    return { budget, spent, ...progress };
   });
 
   budgetProgress.sort((a, b) => b.percentage - a.percentage);

--- a/src/bot/commands/sum.ts
+++ b/src/bot/commands/sum.ts
@@ -4,6 +4,7 @@ import { InlineKeyboard } from 'gramio';
 import { getCategoryEmoji } from '../../config/category-emojis';
 import { BASE_CURRENCY, type CurrencyCode } from '../../config/constants';
 import { database } from '../../database';
+import { computeBudgetProgress } from '../../database/repositories/budget.repository';
 import type { Group } from '../../database/types';
 import { spendingAnalytics } from '../../services/analytics/spending-analytics';
 import { sendMessage } from '../../services/bank/telegram-sender';
@@ -343,16 +344,15 @@ export function buildBudgetProgressEntry(
 } {
   const currency = budget.currency as CurrencyCode;
   const spentInCurrency = convertCurrency(spentEur, BASE_CURRENCY, currency);
-  const percentage =
-    budget.limit_amount > 0 ? Math.round((spentInCurrency / budget.limit_amount) * 100) : 0;
+  const progress = computeBudgetProgress(budget, spentInCurrency);
   return {
     category: budget.category,
     spentInCurrency,
     limit: budget.limit_amount,
     currency,
-    percentage,
-    is_exceeded: spentInCurrency > budget.limit_amount,
-    is_warning: percentage >= 90 && spentInCurrency <= budget.limit_amount,
+    percentage: progress.percentage,
+    is_exceeded: progress.is_exceeded,
+    is_warning: progress.is_warning,
   };
 }
 

--- a/src/bot/handlers/message.handler.test.ts
+++ b/src/bot/handlers/message.handler.test.ts
@@ -8,7 +8,11 @@ describe('buildBudgetAlertStatus — budget currency conversion', () => {
   // 100 EUR ≈ 11 600 RSD; budget limit = 15 000 RSD → ~77%
 
   it('converts EUR spending to budget currency before computing percentage', () => {
-    const result = buildBudgetAlertStatus(100, { limit_amount: 15_000, currency: 'RSD' });
+    const result = buildBudgetAlertStatus(100, {
+      category: 'Food',
+      limit_amount: 15_000,
+      currency: 'RSD',
+    });
     // 100 EUR ≈ 11 600 RSD, so percentage should be around 77%, not 0.67%
     expect(result.percentage).toBeGreaterThan(50);
     expect(result.percentage).toBeLessThan(100);
@@ -16,31 +20,51 @@ describe('buildBudgetAlertStatus — budget currency conversion', () => {
 
   it('isExceeded is false when EUR spending converts below limit', () => {
     // 100 EUR ≈ 11 600 RSD < 15 000 RSD limit
-    const result = buildBudgetAlertStatus(100, { limit_amount: 15_000, currency: 'RSD' });
+    const result = buildBudgetAlertStatus(100, {
+      category: 'Food',
+      limit_amount: 15_000,
+      currency: 'RSD',
+    });
     expect(result.isExceeded).toBe(false);
   });
 
   it('isExceeded is true when EUR spending converts above limit', () => {
     // 200 EUR ≈ 23 200 RSD > 15 000 RSD limit
-    const result = buildBudgetAlertStatus(200, { limit_amount: 15_000, currency: 'RSD' });
+    const result = buildBudgetAlertStatus(200, {
+      category: 'Food',
+      limit_amount: 15_000,
+      currency: 'RSD',
+    });
     expect(result.isExceeded).toBe(true);
   });
 
   it('isWarning triggers when spending is 90–99% of limit in budget currency', () => {
     // 125 EUR ≈ 14 500 RSD, limit 15 000 RSD → ~97% → warning
-    const result = buildBudgetAlertStatus(125, { limit_amount: 15_000, currency: 'RSD' });
+    const result = buildBudgetAlertStatus(125, {
+      category: 'Food',
+      limit_amount: 15_000,
+      currency: 'RSD',
+    });
     expect(result.isWarning).toBe(true);
     expect(result.isExceeded).toBe(false);
   });
 
   it('EUR budget: 1:1, no conversion needed', () => {
-    const result = buildBudgetAlertStatus(150, { limit_amount: 200, currency: 'EUR' });
+    const result = buildBudgetAlertStatus(150, {
+      category: 'Rent',
+      limit_amount: 200,
+      currency: 'EUR',
+    });
     expect(result.percentage).toBe(75);
     expect(result.isExceeded).toBe(false);
   });
 
   it('spentInCurrency is in budget currency, not EUR', () => {
-    const result = buildBudgetAlertStatus(100, { limit_amount: 15_000, currency: 'RSD' });
+    const result = buildBudgetAlertStatus(100, {
+      category: 'Food',
+      limit_amount: 15_000,
+      currency: 'RSD',
+    });
     // spentInCurrency should be ~11 600 RSD, not 100
     expect(result.spentInCurrency).toBeGreaterThan(1_000);
   });

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -743,17 +743,10 @@ async function handleBulkCorrectionInput(
  */
 export function buildBudgetAlertStatus(
   spentEur: number,
-  budget: { limit_amount: number; currency: string; category?: string },
+  budget: { category: string; limit_amount: number; currency: string },
 ): { spentInCurrency: number; percentage: number; isExceeded: boolean; isWarning: boolean } {
   const spentInCurrency = convertCurrency(spentEur, BASE_CURRENCY, budget.currency as CurrencyCode);
-  const progress = computeBudgetProgress(
-    {
-      category: budget.category ?? '',
-      limit_amount: budget.limit_amount,
-      currency: budget.currency,
-    },
-    spentInCurrency,
-  );
+  const progress = computeBudgetProgress(budget, spentInCurrency);
   return {
     spentInCurrency,
     percentage: progress.percentage,

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -2,6 +2,7 @@
 import { BASE_CURRENCY, type CurrencyCode, MESSAGES } from '../../config/constants';
 import { env } from '../../config/env';
 import { database } from '../../database';
+import { computeBudgetProgress } from '../../database/repositories/budget.repository';
 import type { Group, PhotoQueueItem, ReceiptItem } from '../../database/types';
 import { createInviteLink, sendMessage } from '../../services/bank/telegram-sender';
 import { convertCurrency, formatAmount } from '../../services/currency/converter';
@@ -742,12 +743,21 @@ async function handleBulkCorrectionInput(
  */
 export function buildBudgetAlertStatus(
   spentEur: number,
-  budget: { limit_amount: number; currency: string },
+  budget: { limit_amount: number; currency: string; category?: string },
 ): { spentInCurrency: number; percentage: number; isExceeded: boolean; isWarning: boolean } {
   const spentInCurrency = convertCurrency(spentEur, BASE_CURRENCY, budget.currency as CurrencyCode);
-  const percentage =
-    budget.limit_amount > 0 ? Math.round((spentInCurrency / budget.limit_amount) * 100) : 0;
-  const isExceeded = spentInCurrency > budget.limit_amount;
-  const isWarning = percentage >= 90 && !isExceeded;
-  return { spentInCurrency, percentage, isExceeded, isWarning };
+  const progress = computeBudgetProgress(
+    {
+      category: budget.category ?? '',
+      limit_amount: budget.limit_amount,
+      currency: budget.currency,
+    },
+    spentInCurrency,
+  );
+  return {
+    spentInCurrency,
+    percentage: progress.percentage,
+    isExceeded: progress.is_exceeded,
+    isWarning: progress.is_warning,
+  };
 }

--- a/src/bot/services/expense-saver.ts
+++ b/src/bot/services/expense-saver.ts
@@ -4,6 +4,7 @@ import { InlineKeyboard } from 'gramio';
 import { getCategoryEmoji } from '../../config/category-emojis';
 import type { CurrencyCode } from '../../config/constants';
 import { database } from '../../database';
+import { computeBudgetProgress } from '../../database/repositories/budget.repository';
 import type { Group, PendingExpense } from '../../database/types';
 import { sendMessage } from '../../services/bank/telegram-sender';
 import {
@@ -184,28 +185,24 @@ async function checkBudgetLimit(
   const budgetCurrency = budget.currency as CurrencyCode;
   const spentInCurrency = convertCurrency(spentEur, 'EUR', budgetCurrency);
 
-  const percentage =
-    budget.limit_amount > 0 ? Math.round((spentInCurrency / budget.limit_amount) * 100) : 0;
+  const progress = computeBudgetProgress(budget, spentInCurrency);
 
-  const isExceeded = spentInCurrency > budget.limit_amount;
-  const isWarning = percentage >= 90 && !isExceeded;
-
-  if (isExceeded || isWarning) {
+  if (progress.is_exceeded || progress.is_warning) {
     const emoji = getCategoryEmoji(category);
-    const progress = `${formatAmount(spentInCurrency, budgetCurrency)} / ${formatAmount(budget.limit_amount, budgetCurrency)} (${percentage}%)`;
+    const progressText = `${formatAmount(spentInCurrency, budgetCurrency)} / ${formatAmount(budget.limit_amount, budgetCurrency)} (${progress.percentage}%)`;
     let message = '';
 
-    if (isExceeded) {
+    if (progress.is_exceeded) {
       message = `🔴 ПРЕВЫШЕН БЮДЖЕТ!\n`;
-      message += `${emoji} ${category}: ${progress}`;
-    } else if (isWarning) {
+      message += `${emoji} ${category}: ${progressText}`;
+    } else if (progress.is_warning) {
       message = `⚠️ Внимание! Приближение к лимиту бюджета:\n`;
-      message += `${emoji} ${category}: ${progress}`;
+      message += `${emoji} ${category}: ${progressText}`;
     }
 
     try {
       await sendMessage(message);
-      logger.info(`[BUDGET] Sent warning for category "${category}": ${percentage}%`);
+      logger.info(`[BUDGET] Sent warning for category "${category}": ${progress.percentage}%`);
     } catch (error) {
       logger.error({ err: error }, '[BUDGET] Failed to send warning');
     }

--- a/src/database/repositories/budget.repository.test.ts
+++ b/src/database/repositories/budget.repository.test.ts
@@ -3,7 +3,7 @@
 import type { Database } from 'bun:sqlite';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { clearTestDb, createTestDb } from '../../test-utils/db';
-import { BudgetRepository } from './budget.repository';
+import { BudgetRepository, computeBudgetProgress } from './budget.repository';
 import { GroupRepository } from './group.repository';
 
 let db: Database;
@@ -407,6 +407,18 @@ describe('BudgetRepository', () => {
       expect(progress?.is_warning).toBe(false);
     });
 
+    test('is_warning false when exceeded (not both)', () => {
+      budgetRepo.setBudget({
+        group_id: groupId,
+        category: 'Food',
+        month: '2024-01',
+        limit_amount: 100,
+      });
+      const progress = budgetRepo.getBudgetProgress(groupId, 'Food', '2024-01', 110);
+      expect(progress?.is_exceeded).toBe(true);
+      expect(progress?.is_warning).toBe(false);
+    });
+
     test('returns null when no budget exists', () => {
       expect(budgetRepo.getBudgetProgress(groupId, 'NoCategory', '2024-01', 50)).toBeNull();
     });
@@ -495,5 +507,83 @@ describe('BudgetRepository', () => {
       groupRepo.delete(tgId);
       expect(budgetRepo.findById(budget.id)).toBeNull();
     });
+  });
+});
+
+describe('computeBudgetProgress (pure function)', () => {
+  const budget = { category: 'Food', limit_amount: 500, currency: 'EUR' };
+
+  test('computes correct percentage', () => {
+    const progress = computeBudgetProgress(budget, 250);
+    expect(progress.percentage).toBe(50);
+    expect(progress.is_exceeded).toBe(false);
+    expect(progress.is_warning).toBe(false);
+  });
+
+  test('returns 0% when limit_amount is 0', () => {
+    const zeroBudget = { category: 'Zero', limit_amount: 0, currency: 'EUR' };
+    const progress = computeBudgetProgress(zeroBudget, 100);
+    expect(progress.percentage).toBe(0);
+    expect(progress.is_exceeded).toBe(true);
+  });
+
+  test('returns 0% when spentAmount is 0', () => {
+    const progress = computeBudgetProgress(budget, 0);
+    expect(progress.percentage).toBe(0);
+    expect(progress.is_exceeded).toBe(false);
+    expect(progress.is_warning).toBe(false);
+  });
+
+  test('is_warning at exactly 90%', () => {
+    const progress = computeBudgetProgress(budget, 450);
+    expect(progress.percentage).toBe(90);
+    expect(progress.is_warning).toBe(true);
+    expect(progress.is_exceeded).toBe(false);
+  });
+
+  test('is_warning at exactly 100% (not exceeded — equal)', () => {
+    const progress = computeBudgetProgress(budget, 500);
+    expect(progress.percentage).toBe(100);
+    expect(progress.is_warning).toBe(true);
+    expect(progress.is_exceeded).toBe(false);
+  });
+
+  test('is_exceeded when spending exceeds limit', () => {
+    const progress = computeBudgetProgress(budget, 501);
+    expect(progress.percentage).toBe(100);
+    expect(progress.is_exceeded).toBe(true);
+    expect(progress.is_warning).toBe(false);
+  });
+
+  test('is_warning and is_exceeded are mutually exclusive', () => {
+    // At 95%: warning, not exceeded
+    const w = computeBudgetProgress(budget, 475);
+    expect(w.is_warning).toBe(true);
+    expect(w.is_exceeded).toBe(false);
+
+    // At 120%: exceeded, not warning
+    const e = computeBudgetProgress(budget, 600);
+    expect(e.is_exceeded).toBe(true);
+    expect(e.is_warning).toBe(false);
+  });
+
+  test('returns correct spent_amount and limit_amount passthrough', () => {
+    const progress = computeBudgetProgress(budget, 123.45);
+    expect(progress.spent_amount).toBe(123.45);
+    expect(progress.limit_amount).toBe(500);
+    expect(progress.category).toBe('Food');
+    expect(progress.currency).toBe('EUR');
+  });
+
+  test('handles negative spentAmount gracefully', () => {
+    const progress = computeBudgetProgress(budget, -50);
+    expect(progress.percentage).toBe(-10);
+    expect(progress.is_exceeded).toBe(false);
+    expect(progress.is_warning).toBe(false);
+  });
+
+  test('rounds percentage to nearest integer', () => {
+    const progress = computeBudgetProgress({ ...budget, limit_amount: 300 }, 100);
+    expect(progress.percentage).toBe(33);
   });
 });

--- a/src/database/repositories/budget.repository.ts
+++ b/src/database/repositories/budget.repository.ts
@@ -1,7 +1,29 @@
 /** Budget repository — CRUD and progress tracking for per-category spending budgets */
 import type { Database } from 'bun:sqlite';
+import type { CurrencyCode } from '../../config/constants';
 import { findBestCategoryMatch } from '../../utils/fuzzy-search';
 import type { Budget, BudgetProgress, CreateBudgetData } from '../types';
+
+/**
+ * Pure computation of budget progress from a budget object and spent amount.
+ * No DB queries — safe to call in loops.
+ */
+export function computeBudgetProgress(
+  budget: { category: string; limit_amount: number; currency: string },
+  spentAmount: number,
+): BudgetProgress {
+  const percentage =
+    budget.limit_amount > 0 ? Math.round((spentAmount / budget.limit_amount) * 100) : 0;
+  return {
+    category: budget.category,
+    limit_amount: budget.limit_amount,
+    spent_amount: spentAmount,
+    currency: budget.currency as CurrencyCode,
+    percentage,
+    is_exceeded: spentAmount > budget.limit_amount,
+    is_warning: percentage >= 90 && spentAmount <= budget.limit_amount,
+  };
+}
 
 /**
  * Read-only budget operations.
@@ -148,18 +170,7 @@ export class BudgetRepository implements BudgetReadRepository {
     const budget = this.findByGroupCategoryMonth(groupId, category, month);
     if (!budget) return null;
 
-    const percentage =
-      budget.limit_amount > 0 ? Math.round((spentAmount / budget.limit_amount) * 100) : 0;
-
-    return {
-      category,
-      limit_amount: budget.limit_amount,
-      spent_amount: spentAmount,
-      currency: budget.currency,
-      percentage,
-      is_exceeded: spentAmount > budget.limit_amount,
-      is_warning: percentage >= 90,
-    };
+    return computeBudgetProgress(budget, spentAmount);
   }
 
   /** Check if category exists in any budget for group (fuzzy match) */

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -215,9 +215,9 @@ mock.module('../../bot/services/budget-sync', () => ({
   silentSyncBudgets: mock(() => Promise.resolve(0)),
 }));
 
-// Mock spending analytics — used by get_technical_analysis tool
+// Mock spending analytics — used by get_technical_analysis and get_budgets tools
 // biome-ignore lint/suspicious/noExplicitAny: test mock returns partial FinancialSnapshot
-const mockGetFinancialSnapshot = mock((): any => ({ technicalAnalysis: null }));
+const mockGetFinancialSnapshot = mock((): any => ({ technicalAnalysis: null, burnRates: [] }));
 mock.module('../analytics/spending-analytics', () => ({
   spendingAnalytics: {
     getFinancialSnapshot: mockGetFinancialSnapshot,
@@ -762,6 +762,149 @@ describe('get_budgets batch', () => {
       ctx,
     );
     expect(result.success).toBe(true);
+  });
+});
+
+describe('get_budgets enriched output', () => {
+  beforeEach(resetAllMocks);
+
+  test('current month shows EMA-based burn rate and projected total from spendingAnalytics', async () => {
+    const now = new Date();
+    const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+    mockBudgets.getAllBudgetsForMonth.mockReturnValue([
+      {
+        id: 1,
+        group_id: 1,
+        category: 'Food',
+        month: currentMonth,
+        limit_amount: 500,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+    ]);
+    mockExpenses.findByDateRange.mockReturnValue([
+      {
+        id: 1,
+        group_id: 1,
+        user_id: 123,
+        date: `${currentMonth}-05`,
+        category: 'Food',
+        comment: '',
+        amount: 200,
+        currency: 'EUR',
+        eur_amount: 200,
+        receipt_id: null,
+        receipt_file_id: null,
+        created_at: '',
+      },
+    ]);
+    // EMA-based burn rate from spendingAnalytics
+    mockGetFinancialSnapshot.mockReturnValue({
+      technicalAnalysis: null,
+      burnRates: [
+        {
+          category: 'Food',
+          budget_limit: 500,
+          spent: 200,
+          currency: 'EUR',
+          days_elapsed: now.getDate(),
+          days_remaining: 30 - now.getDate(),
+          daily_burn_rate: 15.5,
+          projected_total: 465,
+          projected_overshoot: -35,
+          runway_days: 19.4,
+          status: 'warning',
+        },
+      ],
+    });
+
+    const result = await executeTool('get_budgets', { month: currentMonth }, ctx);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('burn:');
+    expect(result.output).toContain('15.50');
+    expect(result.output).toContain('projected:');
+    expect(result.output).toContain('465.00');
+    expect(result.output).toContain('runway:');
+    expect(result.output).toContain('19d');
+    expect(result.output).toContain('Grand Total:');
+  });
+
+  test('past month does not show burn rate details', async () => {
+    mockBudgets.getAllBudgetsForMonth.mockReturnValue([
+      {
+        id: 1,
+        group_id: 1,
+        category: 'Food',
+        month: '2025-01',
+        limit_amount: 500,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+    ]);
+    mockExpenses.findByDateRange.mockReturnValue([]);
+
+    const result = await executeTool('get_budgets', { month: '2025-01' }, ctx);
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain('burn:');
+    expect(result.output).not.toContain('projected:');
+    expect(result.output).not.toContain('runway:');
+  });
+
+  test('grand total shows inline percentage without synthetic budget object', async () => {
+    const now = new Date();
+    const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+    mockBudgets.getAllBudgetsForMonth.mockReturnValue([
+      {
+        id: 1,
+        group_id: 1,
+        category: 'Food',
+        month: currentMonth,
+        limit_amount: 300,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+      {
+        id: 2,
+        group_id: 1,
+        category: 'Transport',
+        month: currentMonth,
+        limit_amount: 200,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+    ]);
+    mockExpenses.findByDateRange.mockReturnValue([
+      {
+        id: 1,
+        group_id: 1,
+        user_id: 123,
+        date: `${currentMonth}-05`,
+        category: 'Food',
+        comment: '',
+        amount: 150,
+        currency: 'EUR',
+        eur_amount: 150,
+        receipt_id: null,
+        receipt_file_id: null,
+        created_at: '',
+      },
+    ]);
+    mockGetFinancialSnapshot.mockReturnValue({
+      technicalAnalysis: null,
+      burnRates: [],
+    });
+
+    const result = await executeTool('get_budgets', { month: currentMonth }, ctx);
+    expect(result.success).toBe(true);
+    // Grand Total: 150 / 500 = 30%
+    expect(result.output).toContain('Grand Total:');
+    expect(result.output).toContain('30%');
   });
 });
 

--- a/src/services/ai/tool-executor.ts
+++ b/src/services/ai/tool-executor.ts
@@ -322,7 +322,8 @@ async function executeGetBudgets(
   input: Record<string, unknown>,
   ctx: AgentContext,
 ): Promise<ToolResult> {
-  const months = normalizeArrayParam(input['month'], format(new Date(), 'yyyy-MM'));
+  const now = new Date();
+  const months = normalizeArrayParam(input['month'], format(now, 'yyyy-MM'));
   const categories = normalizeArrayParam(input['category']);
   const isBatch = months.length > 1;
 
@@ -332,7 +333,23 @@ async function executeGetBudgets(
   const allLines: string[] = [];
   let grandTotalEur = 0;
 
-  const nowMonth = format(new Date(), 'yyyy-MM');
+  const nowMonth = format(now, 'yyyy-MM');
+
+  // Pre-compute EMA-based burn rates for current month (avoids naive linear projection)
+  const burnRateMap = new Map<
+    string,
+    { projected_total: number; daily_burn_rate: number; runway_days: number }
+  >();
+  if (months.includes(nowMonth)) {
+    const snapshot = spendingAnalytics.getFinancialSnapshot(ctx.groupId);
+    for (const br of snapshot.burnRates) {
+      burnRateMap.set(br.category, {
+        projected_total: br.projected_total,
+        daily_burn_rate: br.daily_burn_rate,
+        runway_days: br.runway_days,
+      });
+    }
+  }
 
   for (const month of months) {
     let budgets = database.budgets.getAllBudgetsForMonth(ctx.groupId, month);
@@ -359,16 +376,16 @@ async function executeGetBudgets(
       grandTotalEur += e.eur_amount;
     }
 
-    // Days elapsed for burn rate and projections
+    // Days elapsed for header and grand total
     const isCurrentMonth = nowMonth === month;
-    const daysInMonth = new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0).getDate();
-    const daysElapsed = isCurrentMonth ? new Date().getDate() : daysInMonth;
+    const daysInMonth = getDaysInMonth(monthDate);
+    const daysElapsed = isCurrentMonth ? now.getDate() : daysInMonth;
     const daysRemaining = isCurrentMonth ? daysInMonth - daysElapsed : 0;
 
     if (isBatch) allLines.push(`=== ${month} ===`);
     else allLines.push(`Budgets for ${month} (day ${daysElapsed}/${daysInMonth}):`, '');
 
-    // Per-month totals in EUR (for optional single-month grand total)
+    // Per-month totals in EUR (for single-month grand total)
     let monthBudgetSpentEur = 0;
     let monthBudgetLimitEur = 0;
 
@@ -376,16 +393,25 @@ async function executeGetBudgets(
       const spentEur = spendingByCategory[budget.category] || 0;
       const spentInCurrency = convertCurrency(spentEur, BASE_CURRENCY, budget.currency);
       const progress = computeBudgetProgress(budget, spentInCurrency);
-      const remaining = budget.limit_amount - spentInCurrency;
       const status = progress.is_exceeded ? 'EXCEEDED' : progress.is_warning ? 'WARNING' : 'OK';
 
-      // Daily burn rate and projections for current month
+      // Use EMA-based projections for current month (from spending-analytics)
       let details = '';
       if (isCurrentMonth && daysElapsed > 0) {
-        const dailyBurn = spentInCurrency / daysElapsed;
-        const projectedTotal = dailyBurn * daysInMonth;
-        const runwayDays = dailyBurn > 0 ? Math.max(0, remaining / dailyBurn) : 999;
-        details = ` | burn: ${formatAmount(dailyBurn, budget.currency, true)}/day, projected: ${formatAmount(projectedTotal, budget.currency, true)}, runway: ${runwayDays >= 999 ? '∞' : `${Math.round(runwayDays)}d`}`;
+        const br = burnRateMap.get(budget.category);
+        if (br) {
+          // EMA-based projection (budget currency, already computed by spending-analytics)
+          const projectedDisplay = formatAmount(br.projected_total, budget.currency, true);
+          const burnDisplay = formatAmount(br.daily_burn_rate, budget.currency, true);
+          const runwayStr = br.runway_days >= 999 ? '∞' : `${Math.round(br.runway_days)}d`;
+          details = ` | burn: ${burnDisplay}/day, projected: ${projectedDisplay}, runway: ${runwayStr}`;
+        } else {
+          // Fallback for categories without burn rate data (e.g. no spending yet)
+          const dailyBurn = spentInCurrency / daysElapsed;
+          const remaining = budget.limit_amount - spentInCurrency;
+          const runwayDays = dailyBurn > 0 ? Math.max(0, remaining / dailyBurn) : 999;
+          details = ` | burn: ${formatAmount(dailyBurn, budget.currency, true)}/day, projected: ${formatAmount(dailyBurn * daysInMonth, budget.currency, true)}, runway: ${runwayDays >= 999 ? '∞' : `${Math.round(runwayDays)}d`}`;
+        }
       }
 
       allLines.push(
@@ -408,12 +434,10 @@ async function executeGetBudgets(
         BASE_CURRENCY,
         displayCurrency,
       );
-      const monthProgress = computeBudgetProgress(
-        { category: 'total', limit_amount: monthLimitDisplay, currency: displayCurrency },
-        monthSpentDisplay,
-      );
+      const grandPercentage =
+        monthLimitDisplay > 0 ? Math.round((monthSpentDisplay / monthLimitDisplay) * 100) : 0;
       allLines.push('');
-      let grandLine = `Grand Total: ${formatAmount(monthSpentDisplay, displayCurrency, true)}/${formatAmount(monthLimitDisplay, displayCurrency, true)} (${monthProgress.percentage}%)`;
+      let grandLine = `Grand Total: ${formatAmount(monthSpentDisplay, displayCurrency, true)}/${formatAmount(monthLimitDisplay, displayCurrency, true)} (${grandPercentage}%)`;
       if (isCurrentMonth && daysElapsed > 0) {
         const grandDailyBurn = monthSpentDisplay / daysElapsed;
         const grandProjected = grandDailyBurn * daysInMonth;

--- a/src/services/ai/tool-executor.ts
+++ b/src/services/ai/tool-executor.ts
@@ -7,6 +7,7 @@ import { endOfMonth, format, getDaysInMonth } from 'date-fns';
 import { marked } from 'marked';
 import { BASE_CURRENCY, type CurrencyCode, SUPPORTED_CURRENCIES } from '../../config/constants';
 import { database } from '../../database';
+import { computeBudgetProgress } from '../../database/repositories/budget.repository';
 import type { BankTransaction, BankTransactionFilters, Expense } from '../../database/types';
 import { getErrorMessage } from '../../utils/error';
 import { createLogger } from '../../utils/logger.ts';
@@ -331,6 +332,8 @@ async function executeGetBudgets(
   const allLines: string[] = [];
   let grandTotalEur = 0;
 
+  const nowMonth = format(new Date(), 'yyyy-MM');
+
   for (const month of months) {
     let budgets = database.budgets.getAllBudgetsForMonth(ctx.groupId, month);
 
@@ -346,7 +349,8 @@ async function executeGetBudgets(
     }
 
     const monthStart = `${month}-01`;
-    const monthEnd = format(endOfMonth(new Date(`${month}-01`)), 'yyyy-MM-dd');
+    const monthDate = new Date(`${month}-01`);
+    const monthEnd = format(endOfMonth(monthDate), 'yyyy-MM-dd');
     const expenses = database.expenses.findByDateRange(ctx.groupId, monthStart, monthEnd);
 
     const spendingByCategory: Record<string, number> = {};
@@ -355,25 +359,72 @@ async function executeGetBudgets(
       grandTotalEur += e.eur_amount;
     }
 
+    // Days elapsed for burn rate and projections
+    const isCurrentMonth = nowMonth === month;
+    const daysInMonth = new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0).getDate();
+    const daysElapsed = isCurrentMonth ? new Date().getDate() : daysInMonth;
+    const daysRemaining = isCurrentMonth ? daysInMonth - daysElapsed : 0;
+
     if (isBatch) allLines.push(`=== ${month} ===`);
-    else allLines.push(`Budgets for ${month}:`, '');
+    else allLines.push(`Budgets for ${month} (day ${daysElapsed}/${daysInMonth}):`, '');
+
+    // Per-month totals in EUR (for optional single-month grand total)
+    let monthBudgetSpentEur = 0;
+    let monthBudgetLimitEur = 0;
 
     for (const budget of budgets) {
       const spentEur = spendingByCategory[budget.category] || 0;
       const spentInCurrency = convertCurrency(spentEur, BASE_CURRENCY, budget.currency);
+      const progress = computeBudgetProgress(budget, spentInCurrency);
       const remaining = budget.limit_amount - spentInCurrency;
-      const percent =
-        budget.limit_amount > 0 ? Math.round((spentInCurrency / budget.limit_amount) * 100) : 0;
-      const status = remaining < 0 ? 'EXCEEDED' : percent >= 90 ? 'WARNING' : 'OK';
+      const status = progress.is_exceeded ? 'EXCEEDED' : progress.is_warning ? 'WARNING' : 'OK';
+
+      // Daily burn rate and projections for current month
+      let details = '';
+      if (isCurrentMonth && daysElapsed > 0) {
+        const dailyBurn = spentInCurrency / daysElapsed;
+        const projectedTotal = dailyBurn * daysInMonth;
+        const runwayDays = dailyBurn > 0 ? Math.max(0, remaining / dailyBurn) : 999;
+        details = ` | burn: ${formatAmount(dailyBurn, budget.currency, true)}/day, projected: ${formatAmount(projectedTotal, budget.currency, true)}, runway: ${runwayDays >= 999 ? '∞' : `${Math.round(runwayDays)}d`}`;
+      }
 
       allLines.push(
-        `${budget.category}: ${formatAmount(spentInCurrency, budget.currency, true)}/${formatAmount(budget.limit_amount, budget.currency, true)} (${percent}%) [${status}]`,
+        `${budget.category}: ${formatAmount(spentInCurrency, budget.currency, true)}/${formatAmount(budget.limit_amount, budget.currency, true)} (${progress.percentage}%) [${status}]${details}`,
       );
+
+      monthBudgetSpentEur += spentEur;
+      monthBudgetLimitEur += convertCurrency(budget.limit_amount, budget.currency, BASE_CURRENCY);
+    }
+
+    // Per-month grand total with burn/projection (single-month view only)
+    if (!isBatch) {
+      const monthSpentDisplay = convertCurrency(
+        monthBudgetSpentEur,
+        BASE_CURRENCY,
+        displayCurrency,
+      );
+      const monthLimitDisplay = convertCurrency(
+        monthBudgetLimitEur,
+        BASE_CURRENCY,
+        displayCurrency,
+      );
+      const monthProgress = computeBudgetProgress(
+        { category: 'total', limit_amount: monthLimitDisplay, currency: displayCurrency },
+        monthSpentDisplay,
+      );
+      allLines.push('');
+      let grandLine = `Grand Total: ${formatAmount(monthSpentDisplay, displayCurrency, true)}/${formatAmount(monthLimitDisplay, displayCurrency, true)} (${monthProgress.percentage}%)`;
+      if (isCurrentMonth && daysElapsed > 0) {
+        const grandDailyBurn = monthSpentDisplay / daysElapsed;
+        const grandProjected = grandDailyBurn * daysInMonth;
+        grandLine += ` | burn: ${formatAmount(grandDailyBurn, displayCurrency, true)}/day, projected: ${formatAmount(grandProjected, displayCurrency, true)}, ${daysRemaining}d left`;
+      }
+      allLines.push(grandLine);
     }
     allLines.push('');
   }
 
-  // Grand total across all months for batch (uses accumulated EUR total)
+  // Grand total across all months for batch (uses accumulated EUR total from all expenses)
   if (isBatch && grandTotalEur > 0) {
     const totalDisplay = convertCurrency(grandTotalEur, BASE_CURRENCY, displayCurrency);
     allLines.push(`=== Grand Total (${months.length} months) ===`);

--- a/src/services/analytics/formatters.test.ts
+++ b/src/services/analytics/formatters.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, mock, test } from 'bun:test';
+import type { BankAccount, BankTransaction } from '../../database/types';
 import { mockDatabase } from '../../test-utils/mocks/database';
-import { computeOverallSeverity, formatSnapshotForPrompt } from './formatters';
+
+const bankAccountsFindByGroupId = mock(() => [] as BankAccount[]);
+const bankTransactionsFindByGroupId = mock(() => [] as BankTransaction[]);
 
 mock.module('../../database', () => ({
   database: mockDatabase({
-    bankAccounts: { findByGroupId: mock(() => []) },
-    bankTransactions: { findByGroupId: mock(() => []) },
+    bankAccounts: { findByGroupId: bankAccountsFindByGroupId },
+    bankTransactions: { findByGroupId: bankTransactionsFindByGroupId },
   }),
 }));
+
+import { computeOverallSeverity, formatSnapshotForPrompt } from './formatters';
 
 import type {
   BudgetBurnRate,
@@ -90,6 +95,51 @@ function makeProjection(overrides: Partial<MonthlyProjection> = {}): MonthlyProj
     projected_vs_last_month: 10,
     confidence: 'medium',
     category_projections: [],
+    ...overrides,
+  };
+}
+
+function makeBankAccount(overrides: Partial<BankAccount> = {}): BankAccount {
+  return {
+    id: 1,
+    connection_id: 1,
+    account_id: 'acc1',
+    title: 'Main Card',
+    balance: 1000,
+    currency: 'EUR',
+    type: 'card',
+    is_excluded: 0,
+    updated_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeBankTransaction(overrides: Partial<BankTransaction> = {}): BankTransaction {
+  return {
+    id: 1,
+    connection_id: 1,
+    external_id: 'tx1',
+    account_id: 'acc1',
+    date: '2026-04-10',
+    time: '12:00',
+    amount: -50,
+    sign_type: 'debit',
+    currency: 'EUR',
+    merchant: 'Grocery Store',
+    merchant_normalized: null,
+    mcc: 5411,
+    raw_data: '{}',
+    invoice_amount: null,
+    invoice_currency: null,
+    matched_expense_id: null,
+    matched_receipt_id: null,
+    telegram_message_id: null,
+    edit_in_progress: 0,
+    awaiting_comment: 0,
+    prefill_category: null,
+    prefill_comment: null,
+    status: 'confirmed',
+    created_at: '2026-04-10T12:00:00Z',
     ...overrides,
   };
 }
@@ -301,5 +351,93 @@ describe('formatSnapshotForPrompt — full snapshot', () => {
     expect(output).toContain('ПРОГНОЗ');
     expect(output).toContain('СКОРОСТЬ ТРАТ');
     expect(output).toContain('СЕРИЯ ТРАТ');
+  });
+});
+
+describe('formatSnapshotForPrompt — bank sections', () => {
+  test('includes bank balances when accounts exist', () => {
+    bankAccountsFindByGroupId.mockReturnValueOnce([
+      makeBankAccount({ title: 'Mastercard', balance: 1234.56, currency: 'EUR' }),
+      makeBankAccount({ id: 2, title: 'Visa RSD', balance: 55000, currency: 'RSD' }),
+    ]);
+
+    const snapshot = makeSnapshot();
+    const output = formatSnapshotForPrompt(snapshot, 1);
+
+    expect(output).toContain('## Банковские балансы');
+    expect(output).toContain('Mastercard: 1234.56 EUR');
+    expect(output).toContain('Visa RSD: 55000.00 RSD');
+  });
+
+  test('includes confirmed bank transactions with merchant info', () => {
+    bankTransactionsFindByGroupId.mockReturnValueOnce([
+      makeBankTransaction({
+        date: '2026-04-10',
+        amount: -42.5,
+        currency: 'EUR',
+        merchant: 'LIDL STORE 123',
+        merchant_normalized: 'Lidl',
+      }),
+      makeBankTransaction({
+        id: 2,
+        date: '2026-04-09',
+        amount: -15,
+        currency: 'EUR',
+        merchant: 'Unknown Merchant',
+        merchant_normalized: null,
+      }),
+      makeBankTransaction({
+        id: 3,
+        date: '2026-04-08',
+        amount: -100,
+        currency: 'RSD',
+        merchant: null,
+        merchant_normalized: null,
+      }),
+    ]);
+
+    const snapshot = makeSnapshot();
+    const output = formatSnapshotForPrompt(snapshot, 1);
+
+    expect(output).toContain('## Подтверждённые банковские транзакции');
+    // merchant_normalized takes precedence over merchant
+    expect(output).toContain('2026-04-10 -42.5 EUR — Lidl');
+    // falls back to merchant when merchant_normalized is null
+    expect(output).toContain('2026-04-09 -15 EUR — Unknown Merchant');
+    // falls back to dash when both are null
+    expect(output).toContain('2026-04-08 -100 RSD — —');
+  });
+
+  test('only first 20 transactions are included (slice cap)', () => {
+    const transactions = Array.from({ length: 25 }, (_, i) =>
+      makeBankTransaction({
+        id: i + 1,
+        external_id: `tx${i + 1}`,
+        date: '2026-04-10',
+        amount: -(i + 1),
+        currency: 'EUR',
+        merchant: `Store ${i + 1}`,
+      }),
+    );
+    bankTransactionsFindByGroupId.mockReturnValueOnce(transactions);
+
+    const snapshot = makeSnapshot();
+    const output = formatSnapshotForPrompt(snapshot, 1);
+
+    expect(output).toContain('## Подтверждённые банковские транзакции');
+    // First 20 should be present
+    expect(output).toContain('Store 20');
+    // Items 21-25 should be absent
+    expect(output).not.toContain('Store 21');
+    expect(output).not.toContain('Store 25');
+  });
+
+  test('bank sections omitted when no data exists', () => {
+    // Default mocks return empty arrays
+    const snapshot = makeSnapshot();
+    const output = formatSnapshotForPrompt(snapshot, 1);
+
+    expect(output).not.toContain('Банковские балансы');
+    expect(output).not.toContain('Подтверждённые банковские транзакции');
   });
 });

--- a/src/services/analytics/spending-analytics.test.ts
+++ b/src/services/analytics/spending-analytics.test.ts
@@ -1064,24 +1064,24 @@ describe('projectCategory', () => {
 
 describe('burn rate: single large expense early in month', () => {
   test('single large expense does not produce critical status (with or without history)', () => {
-    // Group 10: budget 500 EUR for "Car", single expense of 200 EUR
+    // Group 40: budget 500 EUR for "Car", single expense of 200 EUR
     db.run(
       `INSERT INTO groups (id, telegram_group_id, default_currency, enabled_currencies) VALUES (?, ?, ?, ?)`,
-      [10, 101010, 'EUR', '["EUR"]'],
+      [40, 404040, 'EUR', '["EUR"]'],
     );
     db.run(
       `INSERT INTO budgets (group_id, category, month, limit_amount, currency) VALUES (?, ?, ?, ?, ?)`,
-      [10, 'Car', currentMonth, 500, 'EUR'],
+      [40, 'Car', currentMonth, 500, 'EUR'],
     );
     // Single expense: 200 EUR → naive projection on day 4 = 200/4*30 = 1500 → critical
     db.run(
       `INSERT INTO expenses (group_id, user_id, date, category, comment, amount, currency, eur_amount)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [10, USER_ID, today, 'Car', 'repair', 200, 'EUR', 200],
+      [40, USER_ID, today, 'Car', 'repair', 200, 'EUR', 200],
     );
 
     const monthStart = format(startOfMonth(now), 'yyyy-MM-dd');
-    const burnRates = analytics.testComputeBurnRates(10, now, currentMonth, monthStart, today);
+    const burnRates = analytics.testComputeBurnRates(40, now, currentMonth, monthStart, today);
 
     expect(burnRates.length).toBe(1);
     const carBurn = burnRates[0];
@@ -1094,14 +1094,14 @@ describe('burn rate: single large expense early in month', () => {
   });
 
   test('category with historical pattern uses EMA for projection', () => {
-    // Group 11: has 3 months of Car history averaging ~100 EUR/month
+    // Group 41: has 3 months of Car history averaging ~100 EUR/month
     db.run(
       `INSERT INTO groups (id, telegram_group_id, default_currency, enabled_currencies) VALUES (?, ?, ?, ?)`,
-      [11, 111111, 'EUR', '["EUR"]'],
+      [41, 414141, 'EUR', '["EUR"]'],
     );
     db.run(
       `INSERT INTO budgets (group_id, category, month, limit_amount, currency) VALUES (?, ?, ?, ?, ?)`,
-      [11, 'Car', currentMonth, 500, 'EUR'],
+      [41, 'Car', currentMonth, 500, 'EUR'],
     );
 
     // Historical data: 3 months of ~100 EUR
@@ -1121,7 +1121,7 @@ describe('burn rate: single large expense early in month', () => {
       db.run(
         `INSERT INTO expenses (group_id, user_id, date, category, comment, amount, currency, eur_amount)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [11, USER_ID, d, 'Car', 'fuel', 100, 'EUR', 100],
+        [41, USER_ID, d, 'Car', 'fuel', 100, 'EUR', 100],
       );
     }
 
@@ -1129,11 +1129,11 @@ describe('burn rate: single large expense early in month', () => {
     db.run(
       `INSERT INTO expenses (group_id, user_id, date, category, comment, amount, currency, eur_amount)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [11, USER_ID, today, 'Car', 'fuel', 80, 'EUR', 80],
+      [41, USER_ID, today, 'Car', 'fuel', 80, 'EUR', 80],
     );
 
     const monthStart = format(startOfMonth(now), 'yyyy-MM-dd');
-    const burnRates = analytics.testComputeBurnRates(11, now, currentMonth, monthStart, today);
+    const burnRates = analytics.testComputeBurnRates(41, now, currentMonth, monthStart, today);
 
     expect(burnRates.length).toBe(1);
     const carBurn = burnRates[0];

--- a/src/services/analytics/spending-analytics.test.ts
+++ b/src/services/analytics/spending-analytics.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from 'bun:test';
 import { format, getDaysInMonth, startOfMonth, subDays, subMonths } from 'date-fns';
 import { createTestDb } from '../../test-utils/db';
 import { seedGroupAndUser } from '../../test-utils/fixtures';
@@ -871,6 +871,46 @@ describe('getFinancialSnapshot', () => {
   test('monthTrend period is month', () => {
     const snapshot = analytics.getFinancialSnapshot(GROUP_ID);
     expect(snapshot.monthTrend.period).toBe('month');
+  });
+
+  test('getAllBudgetsForMonth is called only once per snapshot', () => {
+    const spy = spyOn(budgetRepo, 'getAllBudgetsForMonth');
+    analytics.getFinancialSnapshot(GROUP_ID);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  test('getCategoryTotals is called only once per snapshot', () => {
+    const spy = spyOn(expenseRepo, 'getCategoryTotals');
+    analytics.getFinancialSnapshot(GROUP_ID);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});
+
+describe('getAllBudgetsForMonth with multiple categories', () => {
+  test('returns all 5 categories in a single call', () => {
+    const multiGroupId = 10;
+    db.run(
+      `INSERT INTO groups (id, telegram_group_id, default_currency, enabled_currencies) VALUES (?, ?, ?, ?)`,
+      [multiGroupId, 101010, 'EUR', '["EUR"]'],
+    );
+
+    const categories = ['Entertainment', 'Food', 'Health', 'Shopping', 'Transport'];
+    for (const cat of categories) {
+      db.run(
+        `INSERT INTO budgets (group_id, category, month, limit_amount, currency) VALUES (?, ?, ?, ?, ?)`,
+        [multiGroupId, cat, currentMonth, 200, 'EUR'],
+      );
+    }
+
+    const spy = spyOn(budgetRepo, 'getAllBudgetsForMonth');
+    const budgets = budgetRepo.getAllBudgetsForMonth(multiGroupId, currentMonth);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(budgets).toHaveLength(5);
+    expect(budgets.map((b: { category: string }) => b.category)).toEqual(categories);
+    spy.mockRestore();
   });
 });
 

--- a/src/services/analytics/spending-analytics.ts
+++ b/src/services/analytics/spending-analytics.ts
@@ -101,7 +101,13 @@ export class SpendingAnalytics {
         budgets,
         categoryTotals,
       ),
-      technicalAnalysis: this.computeTechnicalAnalysis(groupId, now, currentMonthStart, today),
+      technicalAnalysis: this.computeTechnicalAnalysis(
+        groupId,
+        now,
+        currentMonthStart,
+        today,
+        categoryTotals,
+      ),
     };
   }
 
@@ -826,6 +832,7 @@ export class SpendingAnalytics {
     now: Date,
     currentMonthStart: string,
     today: string,
+    prefetchedCategoryTotals?: CategoryTotal[],
   ): TechnicalAnalysis | null {
     // Use 12 months of history for TA (more than the 6 used for profiles)
     const historyStart = format(subMonths(startOfMonth(now), 12), 'yyyy-MM-dd');
@@ -849,7 +856,9 @@ export class SpendingAnalytics {
     }
 
     // Get current month spending per category for anomaly detection
-    const currentTotals = database.expenses.getCategoryTotals(groupId, currentMonthStart, today);
+    const currentTotals =
+      prefetchedCategoryTotals ??
+      database.expenses.getCategoryTotals(groupId, currentMonthStart, today);
     const currentByCategory = new Map<string, number>();
     for (const row of currentTotals) {
       currentByCategory.set(row.category, row.total);

--- a/src/services/analytics/spending-analytics.ts
+++ b/src/services/analytics/spending-analytics.ts
@@ -2,6 +2,7 @@
 import { format, getDaysInMonth, startOfMonth, subDays, subMonths } from 'date-fns';
 import { BASE_CURRENCY, type CurrencyCode } from '../../config/constants';
 import { database } from '../../database';
+import type { Budget } from '../../database/types';
 import { convertCurrency } from '../currency/converter';
 import {
   buildCategoryProfiles,
@@ -20,6 +21,7 @@ import type {
   CategoryChange,
   CategoryProfile,
   CategoryProjection,
+  CategoryTotal,
   DayOfWeekPattern,
   FinancialSnapshot,
   IntervalProfile,
@@ -59,6 +61,10 @@ export class SpendingAnalytics {
     const profiles = this.getCategoryProfiles(groupId, now);
     const projectionCtx = this.getProjectionContext(groupId, now, currentMonthStart, today);
 
+    // Pre-fetch shared data to avoid redundant queries
+    const budgets = database.budgets.getAllBudgetsForMonth(groupId, currentMonthStr);
+    const categoryTotals = database.expenses.getCategoryTotals(groupId, currentMonthStart, today);
+
     return {
       burnRates: this.computeBurnRates(
         groupId,
@@ -68,10 +74,12 @@ export class SpendingAnalytics {
         today,
         profiles,
         projectionCtx,
+        budgets,
+        categoryTotals,
       ),
       weekTrend: this.computeWeekOverWeek(groupId, today),
       monthTrend: this.computeMonthOverMonth(groupId, now, currentMonthStart, today),
-      anomalies: this.computeAnomalies(groupId, now, currentMonthStart, today),
+      anomalies: this.computeAnomalies(groupId, now, currentMonthStart, today, categoryTotals),
       dayOfWeekPatterns: this.computeDayPatterns(groupId, today),
       velocity: this.computeVelocity(groupId, today),
       budgetUtilization: this.computeBudgetUtilization(
@@ -79,6 +87,7 @@ export class SpendingAnalytics {
         currentMonthStr,
         currentMonthStart,
         today,
+        budgets,
       ),
       streak: this.computeStreak(groupId, today),
       projection: this.computeProjection(
@@ -89,6 +98,8 @@ export class SpendingAnalytics {
         today,
         profiles,
         projectionCtx,
+        budgets,
+        categoryTotals,
       ),
       technicalAnalysis: this.computeTechnicalAnalysis(groupId, now, currentMonthStart, today),
     };
@@ -109,11 +120,15 @@ export class SpendingAnalytics {
       lastTxByCategory: Record<string, number>;
       intervalProfiles: Map<string, IntervalProfile>;
     },
+    prefetchedBudgets?: Budget[],
+    prefetchedCategoryTotals?: CategoryTotal[],
   ): BudgetBurnRate[] {
-    const budgets = database.budgets.getAllBudgetsForMonth(groupId, currentMonth);
+    const budgets =
+      prefetchedBudgets ?? database.budgets.getAllBudgetsForMonth(groupId, currentMonth);
     if (budgets.length === 0) return [];
 
-    const categoryTotals = database.expenses.getCategoryTotals(groupId, monthStart, today);
+    const categoryTotals =
+      prefetchedCategoryTotals ?? database.expenses.getCategoryTotals(groupId, monthStart, today);
     const categorySpentEur: Record<string, number> = {};
     const categoryTxCount: Record<string, number> = {};
     for (const ct of categoryTotals) {
@@ -394,9 +409,12 @@ export class SpendingAnalytics {
     now: Date,
     currentMonthStart: string,
     today: string,
+    prefetchedCategoryTotals?: CategoryTotal[],
   ): CategoryAnomaly[] {
     // Get current month category totals
-    const currentTotals = database.expenses.getCategoryTotals(groupId, currentMonthStart, today);
+    const currentTotals =
+      prefetchedCategoryTotals ??
+      database.expenses.getCategoryTotals(groupId, currentMonthStart, today);
     const currentMap: Record<string, number> = {};
     for (const ct of currentTotals) {
       currentMap[ct.category] = ct.total;
@@ -557,8 +575,10 @@ export class SpendingAnalytics {
     currentMonth: string,
     monthStart: string,
     today: string,
+    prefetchedBudgets?: Budget[],
   ): BudgetUtilization | null {
-    const budgets = database.budgets.getAllBudgetsForMonth(groupId, currentMonth);
+    const budgets =
+      prefetchedBudgets ?? database.budgets.getAllBudgetsForMonth(groupId, currentMonth);
     if (budgets.length === 0) return null;
 
     // Sum all budgets in EUR
@@ -678,6 +698,8 @@ export class SpendingAnalytics {
       lastTxByCategory: Record<string, number>;
       intervalProfiles: Map<string, IntervalProfile>;
     },
+    prefetchedBudgets?: Budget[],
+    prefetchedCategoryTotals?: CategoryTotal[],
   ): MonthlyProjection | null {
     const daysElapsed = now.getDate();
     const daysInMonth = getDaysInMonth(now);
@@ -734,8 +756,10 @@ export class SpendingAnalytics {
     }
 
     // Category projections — with stall detection and interval-based projection
-    const currentCatTotals = database.expenses.getCategoryTotals(groupId, monthStart, today);
-    const budgets = database.budgets.getAllBudgetsForMonth(groupId, currentMonth);
+    const currentCatTotals =
+      prefetchedCategoryTotals ?? database.expenses.getCategoryTotals(groupId, monthStart, today);
+    const budgets =
+      prefetchedBudgets ?? database.budgets.getAllBudgetsForMonth(groupId, currentMonth);
     const budgetMap: Record<string, { limit: number; currency: string }> = {};
     for (const b of budgets) {
       budgetMap[b.category] = { limit: b.limit_amount, currency: b.currency };


### PR DESCRIPTION
Pre-fetch budgets and category totals once at the top of
getFinancialSnapshot() and pass to compute methods, reducing
query count from 16 to 11 per call.

https://claude.ai/code/session_01QbB6BSBWf4u5h5mom6bC8q