### PR TITLE
test: introduce makeExpense and makeBankTransaction factories

### DIFF
--- a/src/bot/commands/bank.confirm.test.ts
+++ b/src/bot/commands/bank.confirm.test.ts
@@ -15,6 +15,7 @@ import {
 import type { TelegramMessage } from '@gramio/types';
 import type { BankTransaction, Expense, Group, User } from '../../database/types';
 import * as senderModule from '../../services/bank/telegram-sender';
+import { makeBankTransaction, makeExpense } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 
 // ─── Mutable mock state ───────────────────────────────────────────────────────
@@ -211,8 +212,9 @@ const user: User = {
   updated_at: '2026-01-01T00:00:00Z',
 };
 
+/** Local shortcut wrapping the shared factory with domain-specific defaults */
 function makeTx(overrides: Partial<BankTransaction> = {}): BankTransaction {
-  return {
+  return makeBankTransaction({
     id: 7,
     connection_id: 3,
     external_id: 'ext-1',
@@ -220,25 +222,15 @@ function makeTx(overrides: Partial<BankTransaction> = {}): BankTransaction {
     date: '2026-03-29',
     time: '14:35',
     amount: 25.5,
-    sign_type: 'debit',
     currency: 'GEL',
     merchant: 'Starbucks',
     merchant_normalized: 'Starbucks Coffee',
     mcc: 5812,
-    raw_data: '{}',
-    matched_expense_id: null,
-    matched_receipt_id: null,
     telegram_message_id: 555,
-    edit_in_progress: 0,
-    awaiting_comment: 0,
     prefill_category: 'Кафе',
-    prefill_comment: null,
-    invoice_amount: null,
-    invoice_currency: null,
-    status: 'pending',
     created_at: '2026-03-29T10:00:00Z',
     ...overrides,
-  };
+  });
 }
 
 function makeCallbackCtx(overrides: Record<string, unknown> = {}) {
@@ -258,22 +250,18 @@ function makeMsgCtx(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeExpense(overrides: Partial<Expense> = {}): Expense {
-  return {
+/** Local shortcut wrapping the shared factory with domain-specific defaults */
+function makeConfirmExpense(overrides: Partial<Expense> = {}): Expense {
+  return makeExpense({
     id: 50,
-    group_id: 1,
-    user_id: 1,
     date: '2026-03-29',
     category: 'Кафе',
     comment: '',
     amount: 25.5,
-    currency: 'EUR',
     eur_amount: 25.5,
-    receipt_id: null,
-    receipt_file_id: null,
     created_at: '2026-03-29T09:00:00Z',
     ...overrides,
-  };
+  });
 }
 
 // ─── Tests: handleBankConfirmCallback ─────────────────────────────────────────
@@ -379,7 +367,7 @@ describe('handleBankConfirmCallback', () => {
 
   test('auto-merges when exact duplicate found', async () => {
     const tx = makeTx();
-    const existing = makeExpense();
+    const existing = makeConfirmExpense();
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findPotentialDuplicates.mockImplementation(() => ({
       exact: [existing],
@@ -404,7 +392,7 @@ describe('handleBankConfirmCallback', () => {
 
   test('shows merge prompt when fuzzy duplicate found', async () => {
     const tx = makeTx();
-    const nearby = makeExpense({ date: '2026-03-28', id: 51 });
+    const nearby = makeConfirmExpense({ date: '2026-03-28', id: 51 });
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findPotentialDuplicates.mockImplementation(() => ({
       exact: [],
@@ -443,7 +431,7 @@ describe('handleBankMergeCallback', () => {
 
   test('links transaction to existing expense', async () => {
     const tx = makeTx({ edit_in_progress: 1 });
-    const expense = makeExpense({ id: 50 });
+    const expense = makeConfirmExpense({ id: 50 });
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findById.mockImplementation(() => expense);
 
@@ -466,7 +454,7 @@ describe('handleBankMergeCallback', () => {
 
   test('rejects when expense belongs to different group', async () => {
     const tx = makeTx();
-    const expense = makeExpense({ group_id: 999 });
+    const expense = makeConfirmExpense({ group_id: 999 });
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findById.mockImplementation(() => expense);
 
@@ -482,7 +470,7 @@ describe('handleBankMergeCallback', () => {
 
   test('rejects already-processed transaction', async () => {
     const tx = makeTx({ status: 'confirmed' });
-    const expense = makeExpense();
+    const expense = makeConfirmExpense();
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findById.mockImplementation(() => expense);
 
@@ -498,7 +486,7 @@ describe('handleBankMergeCallback', () => {
 
   test('rejects when expense is already linked to another transaction (race condition)', async () => {
     const tx = makeTx({ edit_in_progress: 1 });
-    const expense = makeExpense({ id: 50 });
+    const expense = makeConfirmExpense({ id: 50 });
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findById.mockImplementation(() => expense);
     mockQueryOne.mockImplementation(() => ({ n: 1 }));
@@ -518,7 +506,7 @@ describe('handleBankMergeCallback', () => {
     // matched_receipt_id must be treated as "taken" — even though no bank_tx
     // points at this expense directly via matched_expense_id.
     const tx = makeTx({ edit_in_progress: 1 });
-    const expense = makeExpense({ id: 50, receipt_id: 42 });
+    const expense = makeConfirmExpense({ id: 50, receipt_id: 42 });
     mockBankTransactions.findById.mockImplementation(() => tx);
     mockExpenses.findById.mockImplementation(() => expense);
 

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { Budget, Category, Expense, Group } from '../../database/types';
+import { makeExpense } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 import type { AgentContext } from './types';
 
@@ -424,20 +425,16 @@ describe('executeTool routing', () => {
   });
 
   test('routes delete_expense to correct handler', async () => {
-    mockExpenses.findById.mockReturnValue({
-      id: 10,
-      group_id: 1,
-      user_id: 123,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: 'lunch',
-      amount: 15,
-      currency: 'EUR',
-      eur_amount: 15,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    });
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({
+        id: 10,
+        user_id: 123,
+        date: '2026-03-01',
+        comment: 'lunch',
+        amount: 15,
+        eur_amount: 15,
+      }),
+    );
     const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
     expect(result.success).toBe(true);
     expect(mockExpenses.delete).toHaveBeenCalledWith(10);
@@ -449,34 +446,23 @@ describe('executeGetExpenses', () => {
 
   test('returns formatted expense list', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-01',
-        category: 'Food',
         comment: 'lunch',
         amount: 15,
-        currency: 'EUR',
         eur_amount: 15,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-02',
         category: 'Transport',
         comment: '',
         amount: 5,
-        currency: 'EUR',
         eur_amount: 5,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool('get_expenses', {}, ctx);
@@ -490,20 +476,15 @@ describe('executeGetExpenses', () => {
 
   test('expense with no comment shows (no comment) in output', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-14',
         category: 'Путешествия',
         comment: '',
         amount: 1149.47,
-        currency: 'EUR',
         eur_amount: 1149.47,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool('get_expenses', {}, ctx);
@@ -513,20 +494,15 @@ describe('executeGetExpenses', () => {
 
   test('expense with whitespace-only comment shows (no comment) in output', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-14',
         category: 'Лена',
         comment: '   ',
         amount: 94.37,
-        currency: 'EUR',
         eur_amount: 94.37,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool('get_expenses', {}, ctx);
@@ -535,20 +511,15 @@ describe('executeGetExpenses', () => {
 
   test('expense with real comment shows the comment', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 3,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-14',
         category: 'Еда',
         comment: 'обед',
         amount: 25,
-        currency: 'EUR',
         eur_amount: 25,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool('get_expenses', {}, ctx);
@@ -558,34 +529,23 @@ describe('executeGetExpenses', () => {
 
   test('respects category filter (case-insensitive)', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-01',
-        category: 'Food',
         comment: 'pizza',
         amount: 10,
-        currency: 'EUR',
         eur_amount: 10,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-02',
         category: 'Transport',
         comment: 'taxi',
         amount: 20,
-        currency: 'EUR',
         eur_amount: 20,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool('get_expenses', { category: 'food' }, ctx);
@@ -604,20 +564,16 @@ describe('executeGetExpenses', () => {
   });
 
   test('paginates results with page and page_size', async () => {
-    const expenses = Array.from({ length: 150 }, (_, i) => ({
-      id: i + 1,
-      group_id: 1,
-      user_id: 123,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: `item ${i + 1}`,
-      amount: 10,
-      currency: 'EUR' as const,
-      eur_amount: 10,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    }));
+    const expenses = Array.from({ length: 150 }, (_, i) =>
+      makeExpense({
+        id: i + 1,
+        user_id: 123,
+        date: '2026-03-01',
+        comment: `item ${i + 1}`,
+        amount: 10,
+        eur_amount: 10,
+      }),
+    );
     mockExpenses.findByDateRange.mockReturnValue(expenses);
 
     const page1 = await executeTool('get_expenses', { page: 1 }, ctx);
@@ -636,20 +592,16 @@ describe('executeGetExpenses', () => {
   });
 
   test('custom page_size works', async () => {
-    const expenses = Array.from({ length: 30 }, (_, i) => ({
-      id: i + 1,
-      group_id: 1,
-      user_id: 123,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: '',
-      amount: 10,
-      currency: 'EUR' as const,
-      eur_amount: 10,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    }));
+    const expenses = Array.from({ length: 30 }, (_, i) =>
+      makeExpense({
+        id: i + 1,
+        user_id: 123,
+        date: '2026-03-01',
+        comment: '',
+        amount: 10,
+        eur_amount: 10,
+      }),
+    );
     mockExpenses.findByDateRange.mockReturnValue(expenses);
 
     const result = await executeTool('get_expenses', { page: 1, page_size: 10 }, ctx);
@@ -678,20 +630,14 @@ describe('executeGetBudgets', () => {
     ]);
     // Expenses for spending calculation
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-05',
-        category: 'Food',
         comment: '',
         amount: 100,
-        currency: 'EUR',
         eur_amount: 100,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool('get_budgets', {}, ctx);
@@ -785,20 +731,14 @@ describe('get_budgets enriched output', () => {
       },
     ]);
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: `${currentMonth}-05`,
-        category: 'Food',
         comment: '',
         amount: 200,
-        currency: 'EUR',
         eur_amount: 200,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
     // EMA-based burn rate from spendingAnalytics
     mockGetFinancialSnapshot.mockReturnValue({
@@ -880,20 +820,14 @@ describe('get_budgets enriched output', () => {
       },
     ]);
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: `${currentMonth}-05`,
-        category: 'Food',
         comment: '',
         amount: 150,
-        currency: 'EUR',
         eur_amount: 150,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
     mockGetFinancialSnapshot.mockReturnValue({
       technicalAnalysis: null,
@@ -1032,20 +966,16 @@ describe('executeDeleteExpense', () => {
   beforeEach(resetAllMocks);
 
   test('deletes expense belonging to this group', async () => {
-    mockExpenses.findById.mockReturnValue({
-      id: 10,
-      group_id: 1,
-      user_id: 123,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: 'pizza',
-      amount: 12,
-      currency: 'EUR',
-      eur_amount: 12,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    });
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({
+        id: 10,
+        user_id: 123,
+        date: '2026-03-01',
+        comment: 'pizza',
+        amount: 12,
+        eur_amount: 12,
+      }),
+    );
 
     const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
     expect(result.success).toBe(true);
@@ -1054,20 +984,17 @@ describe('executeDeleteExpense', () => {
   });
 
   test('rejects deletion of expense from different group', async () => {
-    mockExpenses.findById.mockReturnValue({
-      id: 10,
-      group_id: 999,
-      user_id: 456,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: '',
-      amount: 12,
-      currency: 'EUR',
-      eur_amount: 12,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    });
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({
+        id: 10,
+        group_id: 999,
+        user_id: 456,
+        date: '2026-03-01',
+        comment: '',
+        amount: 12,
+        eur_amount: 12,
+      }),
+    );
 
     const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
     expect(result.success).toBe(false);
@@ -1088,20 +1015,15 @@ describe('delete_expense batch', () => {
   beforeEach(resetAllMocks);
 
   test('batch delete with expense_id array', async () => {
-    mockExpenses.findById.mockImplementation(((id: number) => ({
-      id,
-      group_id: 1,
-      user_id: 123,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: 'test',
-      amount: 10,
-      currency: 'EUR' as const,
-      eur_amount: 10,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    })) as unknown as () => Expense | null);
+    mockExpenses.findById.mockImplementation(((id: number) =>
+      makeExpense({
+        id,
+        user_id: 123,
+        date: '2026-03-01',
+        comment: 'test',
+        amount: 10,
+        eur_amount: 10,
+      })) as unknown as () => Expense | null);
 
     const result = await executeTool('delete_expense', { expense_id: [10, 11, 12] }, ctx);
 
@@ -1112,34 +1034,27 @@ describe('delete_expense batch', () => {
 
   test('batch delete rejects expense from another group', async () => {
     mockExpenses.findById
-      .mockReturnValueOnce({
-        id: 10,
-        group_id: 1,
-        user_id: 123,
-        date: '2026-03-01',
-        category: 'Food',
-        comment: '',
-        amount: 10,
-        currency: 'EUR',
-        eur_amount: 10,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      })
-      .mockReturnValueOnce({
-        id: 11,
-        group_id: 999,
-        user_id: 123,
-        date: '2026-03-01',
-        category: 'Food',
-        comment: '',
-        amount: 10,
-        currency: 'EUR',
-        eur_amount: 10,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      });
+      .mockReturnValueOnce(
+        makeExpense({
+          id: 10,
+          user_id: 123,
+          date: '2026-03-01',
+          comment: '',
+          amount: 10,
+          eur_amount: 10,
+        }),
+      )
+      .mockReturnValueOnce(
+        makeExpense({
+          id: 11,
+          group_id: 999,
+          user_id: 123,
+          date: '2026-03-01',
+          comment: '',
+          amount: 10,
+          eur_amount: 10,
+        }),
+      );
 
     const result = await executeTool('delete_expense', { expense_id: [10, 11] }, ctx);
 
@@ -1148,20 +1063,16 @@ describe('delete_expense batch', () => {
   });
 
   test('single delete still works', async () => {
-    mockExpenses.findById.mockReturnValue({
-      id: 10,
-      group_id: 1,
-      user_id: 123,
-      date: '2026-03-01',
-      category: 'Food',
-      comment: 'lunch',
-      amount: 15,
-      currency: 'EUR',
-      eur_amount: 15,
-      receipt_id: null,
-      receipt_file_id: null,
-      created_at: '',
-    });
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({
+        id: 10,
+        user_id: 123,
+        date: '2026-03-01',
+        comment: 'lunch',
+        amount: 15,
+        eur_amount: 15,
+      }),
+    );
 
     const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
     expect(result.success).toBe(true);
@@ -1654,48 +1565,33 @@ describe('executeGetExpenses — batch periods and stats', () => {
 
   test('summary_only includes stats block', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-05',
         category: 'Еда',
         comment: 'Хлеб',
         amount: 120,
-        currency: 'EUR',
         eur_amount: 1.02,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-10',
         category: 'Еда',
         comment: 'Молоко',
         amount: 250,
-        currency: 'EUR',
         eur_amount: 2.13,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 3,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-15',
         category: 'Развлечения',
         comment: 'Кино',
         amount: 1500,
-        currency: 'EUR',
         eur_amount: 12.77,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool(
@@ -1722,78 +1618,53 @@ describe('executeGetExpenses — batch periods and stats', () => {
 
   test('batch periods returns per-period stats and diff', async () => {
     const januaryExpenses: Expense[] = [
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-05',
         category: 'Еда',
         comment: 'Хлеб',
         amount: 120,
-        currency: 'EUR',
         eur_amount: 1.02,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-10',
         category: 'Еда',
         comment: 'Молоко',
         amount: 250,
-        currency: 'EUR',
         eur_amount: 2.13,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 3,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-15',
         category: 'Развлечения',
         comment: 'Кино',
         amount: 1500,
-        currency: 'EUR',
         eur_amount: 12.77,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ];
     const februaryExpenses: Expense[] = [
-      {
+      makeExpense({
         id: 4,
-        group_id: 1,
         user_id: 123,
         date: '2026-02-03',
         category: 'Еда',
         comment: 'Сыр',
         amount: 800,
-        currency: 'EUR',
         eur_amount: 6.88,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 5,
-        group_id: 1,
         user_id: 123,
         date: '2026-02-14',
         category: 'Развлечения',
         comment: 'Ресторан',
         amount: 5000,
-        currency: 'EUR',
         eur_amount: 42.5,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ];
 
     let callCount = 0;
@@ -1821,48 +1692,33 @@ describe('executeGetExpenses — batch periods and stats', () => {
 
   test('category array filters multiple categories', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-05',
         category: 'Еда',
         comment: 'Хлеб',
         amount: 120,
-        currency: 'EUR',
         eur_amount: 1.02,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-15',
         category: 'Развлечения',
         comment: 'Кино',
         amount: 1500,
-        currency: 'EUR',
         eur_amount: 12.77,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 3,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-20',
         category: 'Транспорт',
         comment: 'Такси',
         amount: 700,
-        currency: 'EUR',
         eur_amount: 5.95,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool(
@@ -1878,48 +1734,33 @@ describe('executeGetExpenses — batch periods and stats', () => {
 
   test('detail output includes stats for all expenses', async () => {
     mockExpenses.findByDateRange.mockReturnValue([
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-05',
         category: 'Еда',
         comment: 'Хлеб',
         amount: 120,
-        currency: 'EUR',
         eur_amount: 1.02,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-10',
         category: 'Еда',
         comment: 'Молоко',
         amount: 250,
-        currency: 'EUR',
         eur_amount: 2.13,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
-      {
+      }),
+      makeExpense({
         id: 3,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-15',
         category: 'Развлечения',
         comment: 'Кино',
         amount: 1500,
-        currency: 'EUR',
         eur_amount: 12.77,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ]);
 
     const result = await executeTool(
@@ -1936,52 +1777,37 @@ describe('executeGetExpenses — batch periods and stats', () => {
 
   test('3+ periods returns trend instead of diff', async () => {
     const janExpenses: Expense[] = [
-      {
+      makeExpense({
         id: 1,
-        group_id: 1,
         user_id: 123,
         date: '2026-01-05',
         category: 'Еда',
         comment: 'Хлеб',
         amount: 120,
-        currency: 'EUR',
         eur_amount: 1.02,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ];
     const febExpenses: Expense[] = [
-      {
+      makeExpense({
         id: 2,
-        group_id: 1,
         user_id: 123,
         date: '2026-02-03',
         category: 'Еда',
         comment: 'Сыр',
         amount: 800,
-        currency: 'EUR',
         eur_amount: 6.88,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ];
     const marExpenses: Expense[] = [
-      {
+      makeExpense({
         id: 3,
-        group_id: 1,
         user_id: 123,
         date: '2026-03-01',
         category: 'Транспорт',
         comment: 'Такси',
         amount: 700,
-        currency: 'EUR',
         eur_amount: 5.95,
-        receipt_id: null,
-        receipt_file_id: null,
-        created_at: '',
-      },
+      }),
     ];
 
     let trendCallCount = 0;

--- a/src/services/analytics/formatters.test.ts
+++ b/src/services/analytics/formatters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import type { BankAccount, BankTransaction } from '../../database/types';
+import { makeBankTransaction } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 
 const bankAccountsFindByGroupId = mock(() => [] as BankAccount[]);
@@ -110,36 +111,6 @@ function makeBankAccount(overrides: Partial<BankAccount> = {}): BankAccount {
     type: 'card',
     is_excluded: 0,
     updated_at: '2026-04-01T00:00:00Z',
-    ...overrides,
-  };
-}
-
-function makeBankTransaction(overrides: Partial<BankTransaction> = {}): BankTransaction {
-  return {
-    id: 1,
-    connection_id: 1,
-    external_id: 'tx1',
-    account_id: 'acc1',
-    date: '2026-04-10',
-    time: '12:00',
-    amount: -50,
-    sign_type: 'debit',
-    currency: 'EUR',
-    merchant: 'Grocery Store',
-    merchant_normalized: null,
-    mcc: 5411,
-    raw_data: '{}',
-    invoice_amount: null,
-    invoice_currency: null,
-    matched_expense_id: null,
-    matched_receipt_id: null,
-    telegram_message_id: null,
-    edit_in_progress: 0,
-    awaiting_comment: 0,
-    prefill_category: null,
-    prefill_comment: null,
-    status: 'confirmed',
-    created_at: '2026-04-10T12:00:00Z',
     ...overrides,
   };
 }

--- a/src/services/bank/old-transactions-actions.test.ts
+++ b/src/services/bank/old-transactions-actions.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { format } from 'date-fns';
 import type { BankAccount, BankConnection, BankTransaction, Group } from '../../database/types';
+import { makeBankTransaction } from '../../test-utils/fixtures';
 
 // ── Mock repositories (defined before mock.module so spyOn can target them) ──
 const mockBankConnections = { findById: () => null as BankConnection | null };
@@ -67,33 +68,19 @@ const GROUP: Group = {
 };
 
 function makeTx(overrides: Partial<BankTransaction> = {}): BankTransaction {
-  return {
-    id: 1,
+  return makeBankTransaction({
     connection_id: 10,
     external_id: 'ext-1',
     account_id: null,
     date: '2026-03-28',
     time: null,
     amount: 500,
-    sign_type: 'debit',
     currency: 'RSD',
     merchant: 'METRO',
-    merchant_normalized: null,
-    mcc: null,
-    raw_data: '{}',
-    matched_expense_id: null,
-    matched_receipt_id: null,
-    telegram_message_id: null,
-    edit_in_progress: 0,
-    awaiting_comment: 0,
     prefill_category: 'food',
-    prefill_comment: null,
-    invoice_amount: null,
-    invoice_currency: null,
-    status: 'pending',
     created_at: '2026-03-28T10:00:00Z',
     ...overrides,
-  };
+  });
 }
 
 let findConnectionByIdSpy: ReturnType<typeof mock>;

--- a/src/services/bank/old-transactions-summary.test.ts
+++ b/src/services/bank/old-transactions-summary.test.ts
@@ -2,36 +2,19 @@
 
 import { describe, expect, test } from 'bun:test';
 import type { BankTransaction } from '../../database/types';
+import { makeBankTransaction } from '../../test-utils/fixtures';
 import { buildOldTxSummaryText } from './transaction-summary';
 
 function makeTx(overrides: Partial<BankTransaction> = {}): BankTransaction {
-  return {
-    id: 1,
-    connection_id: 1,
-    external_id: 'ext-1',
-    account_id: null,
+  return makeBankTransaction({
     date: '2026-03-28',
     time: null,
     amount: 100,
-    sign_type: 'debit',
     currency: 'RSD',
     merchant: 'METRO',
-    merchant_normalized: null,
-    mcc: null,
-    raw_data: '{}',
-    matched_expense_id: null,
-    matched_receipt_id: null,
-    telegram_message_id: null,
-    edit_in_progress: 0,
-    awaiting_comment: 0,
-    prefill_category: null,
-    prefill_comment: null,
-    invoice_amount: null,
-    invoice_currency: null,
-    status: 'pending',
     created_at: '2026-03-28T10:00:00Z',
     ...overrides,
-  };
+  });
 }
 
 function makeTxList(count: number): { tx: BankTransaction; category: string }[] {

--- a/src/services/bank/panel-builder.test.ts
+++ b/src/services/bank/panel-builder.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, mock, test } from 'bun:test';
 import type { BankAccount, BankTransaction } from '../../database/types';
+import { makeBankTransaction } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 
 // Mutable mock state — individual tests can override these to inject fixture data.
@@ -112,32 +113,13 @@ describe('buildBankStatusText', () => {
 
   test('includes pending transactions section when pending txs exist', () => {
     mockTxs.findPendingByConnectionId = () => [
-      {
-        id: 1,
-        connection_id: 1,
-        external_id: 'e1',
-        account_id: null,
+      makeBankTransaction({
         date: '2026-03-27',
-        time: null,
         amount: 50,
-        sign_type: 'debit',
         currency: 'GEL',
         merchant: 'Cafe',
         merchant_normalized: 'Cafe',
-        mcc: null,
-        raw_data: '{}',
-        status: 'pending',
-        matched_expense_id: null,
-        matched_receipt_id: null,
-        telegram_message_id: null,
-        prefill_category: null,
-        prefill_comment: null,
-        invoice_amount: null,
-        invoice_currency: null,
-        edit_in_progress: 0,
-        awaiting_comment: 0,
-        created_at: '',
-      },
+      }),
     ];
 
     try {

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,6 +1,7 @@
 // Shared test fixture factories
 
 import type { Database } from 'bun:sqlite';
+import type { BankTransaction, Expense } from '../database/types';
 
 let nextId = 100_000;
 
@@ -40,32 +41,52 @@ export function seedGroupAndUser(
   return { groupId: group.id, userId: user.id };
 }
 
-/** Standard expense fields with sensible defaults */
-export interface ExpenseFixture {
-  group_id: number;
-  user_id: number;
-  date: string;
-  category: string;
-  comment: string;
-  amount: number;
-  currency: string;
-  eur_amount: number;
-}
-
-export function makeExpense(
-  groupId: number,
-  userId: number,
-  overrides: Partial<ExpenseFixture> = {},
-): ExpenseFixture {
+/** Build a full Expense object with sensible defaults. Override only what each test cares about. */
+export function makeExpense(overrides: Partial<Expense> = {}): Expense {
   return {
-    group_id: groupId,
-    user_id: userId,
+    id: 1,
+    group_id: 1,
+    user_id: 1,
     date: '2024-01-15',
     category: 'Food',
     comment: 'Lunch',
     amount: 25.0,
     currency: 'EUR',
     eur_amount: 25.0,
+    receipt_id: null,
+    receipt_file_id: null,
+    created_at: '',
+    ...overrides,
+  };
+}
+
+/** Build a full BankTransaction object with sensible defaults. */
+export function makeBankTransaction(overrides: Partial<BankTransaction> = {}): BankTransaction {
+  return {
+    id: 1,
+    connection_id: 1,
+    external_id: 'tx1',
+    account_id: 'acc1',
+    date: '2024-01-15',
+    time: '12:00',
+    amount: -50,
+    sign_type: 'debit',
+    currency: 'EUR',
+    merchant: 'Store',
+    merchant_normalized: null,
+    mcc: null,
+    raw_data: '{}',
+    invoice_amount: null,
+    invoice_currency: null,
+    matched_expense_id: null,
+    matched_receipt_id: null,
+    telegram_message_id: null,
+    edit_in_progress: 0,
+    awaiting_comment: 0,
+    prefill_category: null,
+    prefill_comment: null,
+    status: 'pending',
+    created_at: '',
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Closes #74

- **Redesigned `makeExpense()`** in `test-utils/fixtures.ts` to return full `Expense` type with all fields (was partial `ExpenseFixture` missing `id`, `receipt_id`, `receipt_file_id`, `created_at`)
- **Added `makeBankTransaction()`** factory for bank transaction test data
- **Migrated 7 test files** from inline object literals to shared factories:
  - `tool-executor.test.ts` — 36 inline Expense literals → `makeExpense()`
  - `bank.confirm.test.ts` — local `makeExpense`/`makeTx` → shared factories
  - `formatters.test.ts` — local `makeBankTransaction` → shared
  - `panel-builder.test.ts` �� 1 inline BankTransaction → shared
  - `old-transactions-actions.test.ts` — local `makeTx` → delegates to shared
  - `old-transactions-summary.test.ts` — local `makeTx` → delegates to shared

**Net: -453 lines, +211 lines** across 7 files. Adding a new required field to `Expense` or `BankTransaction` now requires updating only the factory default, not dozens of test files.

### Not migrated (intentionally)
- `stats.test.ts` — uses `Pick<Expense, ...>` partial objects that won't break on new fields
- `expense-saver.test.ts` — has extra `synced` field not in `Expense` type (2 literals)
- `miniapp-api.test.ts` — already has its own `stubExpense()` with domain-specific shape

## Test plan
- [x] `bun run test` — 2384 tests pass, 113 files
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] Both `makeExpense` and `makeBankTransaction` imported in multiple test files (no longer reported unused)

https://claude.ai/code/session_01QbB6BSBWf4u5h5mom6bC8q