### PR TITLE
feat(oauth): narrow Google scope to drive.file only

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -211,10 +211,9 @@
 
     <div class="section">
       <h2>How It Uses Google APIs</h2>
-      <p style="font-size: .95rem; margin-bottom: 1rem;">When you connect your Google account, the bot creates a dedicated spreadsheet and writes your expenses into it. It also reads back changes you make manually — so you can edit expenses and budgets directly in the spreadsheet. The bot requests only two scopes:</p>
+      <p style="font-size: .95rem; margin-bottom: 1rem;">When you connect your Google account, the bot creates a dedicated spreadsheet and writes your expenses into it. It also reads back changes you make manually — so you can edit expenses and budgets directly in the spreadsheet. The bot requests only one scope:</p>
       <ul class="scope-list">
-        <li><strong>Google Sheets API</strong> — to read and write expense data in the spreadsheet the bot creates for you.</li>
-        <li><strong>Google Drive API (drive.file)</strong> — to create new spreadsheet files. This scope is limited to files created by the bot — it does not access any other files on your Drive.</li>
+        <li><strong>Google Drive API (drive.file)</strong> — to create spreadsheet files and to read and write expense data in spreadsheets the bot creates for you. This scope is limited to files created by the bot — it does not access any other files on your Drive.</li>
       </ul>
       <p style="font-size: .9rem; color: var(--muted); margin-top: .75rem;">You can revoke access at any time through your <a href="https://myaccount.google.com/permissions" target="_blank" rel="noopener">Google Account permissions</a> or by using the <code>/disconnect</code> command in Telegram.</p>
     </div>

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -38,16 +38,14 @@
 
       <h2>2. How We Use Your Data</h2>
       <ul>
-        <li><strong>Creating and updating Google Sheets</strong> — we use Google Sheets API (<code>spreadsheets</code> scope) to create a spreadsheet and write your expenses into it.</li>
-        <li><strong>Creating spreadsheet files</strong> — we use Google Drive API (<code>drive.file</code> scope) solely to create new spreadsheet files. We do not access any other files on your Google Drive.</li>
+        <li><strong>Creating and updating Google Sheets</strong> — we use Google Drive API (<code>drive.file</code> scope) to create a spreadsheet for you and to read and write your expenses into it. This scope is limited to files created by the Bot and does not grant access to any other files on your Google Drive.</li>
         <li><strong>Expense tracking</strong> — we store expenses locally to provide statistics, budgets, and AI-powered analysis.</li>
       </ul>
 
       <h2>3. Google API Scopes</h2>
-      <p>The Bot requests the following Google API scopes:</p>
+      <p>The Bot requests the following Google API scope:</p>
       <ul>
-        <li><code>https://www.googleapis.com/auth/spreadsheets</code> — to read and write expense data in your Google Sheets spreadsheet.</li>
-        <li><code>https://www.googleapis.com/auth/drive.file</code> — to create new spreadsheet files. This scope is limited to files created by the Bot and does not grant access to any other files on your Drive.</li>
+        <li><code>https://www.googleapis.com/auth/drive.file</code> — to create spreadsheet files and to read and write expense data in spreadsheets created by the Bot. This scope is limited to files created by the Bot and does not grant access to any other files on your Drive.</li>
       </ul>
 
       <h2>4. Data Sharing</h2>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -571,12 +571,14 @@ export type CurrencyCode = (typeof SUPPORTED_CURRENCIES)[number];
 export const BASE_CURRENCY = 'EUR' as const satisfies CurrencyCode;
 
 /**
- * Google API Scopes
+ * Google API Scopes.
+ *
+ * `drive.file` is a non-sensitive scope that grants access only to files the
+ * app itself creates. Because the bot creates every spreadsheet it touches,
+ * this single scope covers both Sheets read/write and Drive operations
+ * (copy/list/update) — the broader `spreadsheets` scope is not needed.
  */
-export const GOOGLE_SCOPES = [
-  'https://www.googleapis.com/auth/spreadsheets',
-  'https://www.googleapis.com/auth/drive.file',
-];
+export const GOOGLE_SCOPES = ['https://www.googleapis.com/auth/drive.file'];
 
 /**
  * Default spreadsheet configuration


### PR DESCRIPTION
Google's verification team flagged the sensitive `spreadsheets` scope and
recommended migrating to the narrower `drive.file` scope, which is
non-sensitive and does not require verification.

`drive.file` grants access only to files the app itself creates. Since the
bot creates every spreadsheet it touches, this single scope covers both
Sheets read/write (append, update, batchUpdate, values.get) and Drive
operations (copy, list, update) that are already in use. Tests,
typecheck, and lint pass unchanged.

Privacy policy and landing page updated to reflect the single-scope model.