### PR TITLE
fix: delete_expense removes from sheet + /reconnect auto-recreates lost spreadsheets

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,9 @@
       "Bash(./node_modules/.bin/jest)",
       "Bash(/usr/bin/git diff:*)",
       "Bash(./node_modules/.bin/biome check:*)",
-      "Bash(npm info:*)"
+      "Bash(npm info:*)",
+      "Bash(node_modules/.bin/tsc --noEmit)",
+      "Bash(GIT_EDITOR=true git rebase --continue)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,11 +285,12 @@ Defined in [src/bot/index.ts](src/bot/index.ts):
 - `/start` - Welcome & setup status
 - `/connect` - OAuth & initial setup
 - `/disconnect` - Disconnect from Google Sheets
-- `/reconnect` - Refresh OAuth
+- `/reconnect` - Refresh OAuth (also audits + auto-recreates any spreadsheets the bot has lost access to, e.g. after a scope downgrade or if the sheet was trashed)
+- `/repair` - Audit every year spreadsheet and recreate any that are 404/403. Manual entry point for users who didn't trigger /reconnect (e.g. deleted sheet by hand). No OAuth flow.
 - `/spreadsheet` - View spreadsheet URL
 - `/stats` - Expense statistics
 - `/sum` (alias: `/total`) - Sum expenses by filters
-- `/sync` - Manual sync to sheets
+- `/sync` - Manual sync to sheets (subcommand: `/sync rollback` restores the latest snapshot if recent sync lost data)
 - `/budget` - Manage budgets
 - `/categories` - List categories
 - `/settings` - View settings

--- a/src/bot/command-descriptions.ts
+++ b/src/bot/command-descriptions.ts
@@ -18,6 +18,7 @@ export const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: 'settings', description: 'Настройки группы' },
   { command: 'feedback', description: 'Отправить отзыв или баг-репорт' },
   { command: 'reconnect', description: 'Переподключить Google аккаунт' },
+  { command: 'repair', description: 'Проверить и пересоздать недоступные Google-таблицы' },
   { command: 'advice', description: 'AI-анализ расходов с советами' },
   { command: 'prompt', description: 'Настроить AI-промпт группы' },
   { command: 'topic', description: 'Привязать бота к топику форума' },

--- a/src/bot/commands/reconnect.repair.integration.test.ts
+++ b/src/bot/commands/reconnect.repair.integration.test.ts
@@ -71,11 +71,6 @@ mock.module('googleapis', () => ({
 
 // ── Mock outbound side effects we don't care about ───────────────────────────
 
-mock.module('./oauth', () => ({
-  getAuthenticatedClient: () => ({}),
-  isTokenExpiredError: () => false,
-}));
-
 mock.module('../../services/google/oauth', () => ({
   generateAuthUrl: () => 'https://oauth-fake-url',
   getAuthenticatedClient: () => ({}),
@@ -419,8 +414,8 @@ describe('auditAndRepairSpreadsheets — integration', () => {
       if (createCount === 1) {
         return {
           data: {
-            spreadsheetId: 'NEW-2025-ok',
-            spreadsheetUrl: 'https://docs.google.com/d/NEW-2025-ok',
+            spreadsheetId: 'NEW-recreated',
+            spreadsheetUrl: 'https://docs.google.com/d/NEW-recreated',
           },
         };
       }
@@ -430,16 +425,11 @@ describe('auditAndRepairSpreadsheets — integration', () => {
 
     await expect(auditAndRepairSpreadsheets(group)).rejects.toThrow('Drive API quota exceeded');
 
-    // First (2025) succeeded — DB pointer updated
-    // Note: audits are sorted year DESC by listAll, so 2026 is processed first
-    // and 2025 second. But the deterministic detail is: when one succeeds and
-    // one fails, only the successful one updates the DB.
-    const updated2025 = groupSpreadsheets.getByYear(group.id, 2025);
-    const updated2026 = groupSpreadsheets.getByYear(group.id, 2026);
-    // Exactly one of them should still be 'LOST-...' — the one that failed
-    const lostCount = [updated2025, updated2026].filter((id) => id?.startsWith('LOST-')).length;
-    const newCount = [updated2025, updated2026].filter((id) => id === 'NEW-2025-ok').length;
-    expect(lostCount).toBe(1);
-    expect(newCount).toBe(1);
+    // listAll returns ORDER BY year DESC → [2026, 2025]. Audit preserves order,
+    // recreateLostSpreadsheets iterates in the same order. So:
+    //   - 2026 is processed first → createCount=1 → gets 'NEW-recreated'
+    //   - 2025 is processed second → createCount=2 → throws, LOST-2025 stays
+    expect(groupSpreadsheets.getByYear(group.id, 2026)).toBe('NEW-recreated');
+    expect(groupSpreadsheets.getByYear(group.id, 2025)).toBe('LOST-2025');
   });
 });

--- a/src/bot/commands/reconnect.repair.integration.test.ts
+++ b/src/bot/commands/reconnect.repair.integration.test.ts
@@ -1,0 +1,445 @@
+// Integration tests for auditAndRepairSpreadsheets — wires the real DB
+// (in-memory SQLite + production repositories) against a fully-mocked
+// googleapis client. Verifies the orchestrator end-to-end: per-year audit,
+// selective recreate, DB pointer updates, year-scoped data copy.
+
+import type { Database as SqliteDb } from 'bun:sqlite';
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { database } from '../../database';
+import { BudgetRepository } from '../../database/repositories/budget.repository';
+import { ExpenseRepository } from '../../database/repositories/expense.repository';
+import { GroupRepository } from '../../database/repositories/group.repository';
+import { GroupSpreadsheetRepository } from '../../database/repositories/group-spreadsheet.repository';
+import { UserRepository } from '../../database/repositories/user.repository';
+import { clearTestDb, createTestDb } from '../../test-utils/db';
+
+// ── Mock googleapis at the network boundary ───────────────────────────────────
+
+interface ValuesGetResponse {
+  data: { values: unknown[][] };
+}
+
+const mockSpreadsheetsGet = mock(
+  async (_args: { spreadsheetId: string }): Promise<{ data: unknown }> => ({ data: {} }),
+);
+const mockSpreadsheetsCreate = mock(
+  async (_args: unknown): Promise<{ data: { spreadsheetId: string; spreadsheetUrl: string } }> => ({
+    data: { spreadsheetId: 'NEW', spreadsheetUrl: 'https://docs.google.com/d/NEW' },
+  }),
+);
+const mockSpreadsheetsBatchUpdate = mock(
+  async (_args: unknown): Promise<{ data: Record<string, never> }> => ({ data: {} }),
+);
+const mockValuesGet = mock(
+  async (_args: unknown): Promise<ValuesGetResponse> => ({ data: { values: [[]] } }),
+);
+const mockValuesAppend = mock(
+  async (
+    _args: unknown,
+  ): Promise<{ data: { updates: { updatedRange: string; updatedRows: number } } }> => ({
+    data: { updates: { updatedRange: 'Expenses!A2:F2', updatedRows: 1 } },
+  }),
+);
+const mockValuesUpdate = mock(
+  async (_args: unknown): Promise<{ data: Record<string, never> }> => ({ data: {} }),
+);
+const mockValuesBatchUpdate = mock(
+  async (_args: unknown): Promise<{ data: Record<string, never> }> => ({ data: {} }),
+);
+
+const mockSheetsClient = {
+  spreadsheets: {
+    get: mockSpreadsheetsGet,
+    create: mockSpreadsheetsCreate,
+    batchUpdate: mockSpreadsheetsBatchUpdate,
+    values: {
+      get: mockValuesGet,
+      append: mockValuesAppend,
+      update: mockValuesUpdate,
+      batchUpdate: mockValuesBatchUpdate,
+    },
+  },
+};
+
+mock.module('googleapis', () => ({
+  google: {
+    sheets: () => mockSheetsClient,
+    // drive() — used only by backupSpreadsheet, which we don't exercise here
+    drive: () => ({ files: { copy: mock(async () => ({ data: { id: 'BACKUP' } })) } }),
+  },
+}));
+
+// ── Mock outbound side effects we don't care about ───────────────────────────
+
+mock.module('./oauth', () => ({
+  getAuthenticatedClient: () => ({}),
+  isTokenExpiredError: () => false,
+}));
+
+mock.module('../../services/google/oauth', () => ({
+  generateAuthUrl: () => 'https://oauth-fake-url',
+  getAuthenticatedClient: () => ({}),
+  isTokenExpiredError: () => false,
+}));
+
+mock.module('../../services/bank/telegram-sender', () => ({
+  sendMessage: mock(async () => null),
+  withChatContext: async <T>(_chatId: number, _threadId: number | null, fn: () => Promise<T>) =>
+    fn(),
+  editMessageText: mock(async () => {}),
+  sendDirect: mock(async () => null),
+}));
+
+// Import after mocks are wired
+const { auditAndRepairSpreadsheets } = await import('./reconnect');
+
+// ── Test infrastructure ──────────────────────────────────────────────────────
+
+let db: SqliteDb;
+let groups: GroupRepository;
+let groupSpreadsheets: GroupSpreadsheetRepository;
+let expenses: ExpenseRepository;
+let budgets: BudgetRepository;
+let users: UserRepository;
+
+beforeAll(() => {
+  db = createTestDb();
+  groups = new GroupRepository(db);
+  groupSpreadsheets = new GroupSpreadsheetRepository(db);
+  expenses = new ExpenseRepository(db);
+  budgets = new BudgetRepository(db);
+  users = new UserRepository(db);
+});
+
+afterAll(() => {
+  db.close();
+});
+
+beforeEach(() => {
+  clearTestDb(db);
+
+  // Reset all googleapis mocks to default OK behavior.
+  mockSpreadsheetsGet.mockReset().mockResolvedValue({ data: {} });
+  mockSpreadsheetsCreate.mockReset();
+  mockSpreadsheetsBatchUpdate.mockReset().mockResolvedValue({ data: {} });
+  mockValuesGet.mockReset().mockResolvedValue({ data: { values: [[]] } });
+  mockValuesAppend.mockReset().mockResolvedValue({
+    data: { updates: { updatedRange: 'Expenses!A2:F2', updatedRows: 1 } },
+  });
+  mockValuesUpdate.mockReset().mockResolvedValue({ data: {} });
+  mockValuesBatchUpdate.mockReset().mockResolvedValue({ data: {} });
+
+  // Wire the global `database` singleton through our in-memory repos. The
+  // production code uses `database.X` everywhere; spyOn forwards each call
+  // to our test repos so production code stays unmodified.
+  spyOn(database.groups, 'findById').mockImplementation((id) => groups.findById(id));
+  spyOn(database.groupSpreadsheets, 'listAll').mockImplementation((id) =>
+    groupSpreadsheets.listAll(id),
+  );
+  spyOn(database.groupSpreadsheets, 'setYear').mockImplementation((g, y, s) =>
+    groupSpreadsheets.setYear(g, y, s),
+  );
+  spyOn(database.groupSpreadsheets, 'getByYear').mockImplementation((g, y) =>
+    groupSpreadsheets.getByYear(g, y),
+  );
+  spyOn(database.expenses, 'findByGroupId').mockImplementation((id, limit) =>
+    expenses.findByGroupId(id, limit),
+  );
+  spyOn(database.budgets, 'findByGroupId').mockImplementation((id) => budgets.findByGroupId(id));
+});
+
+// Default Expenses-tab headers used when the "new spreadsheet" is read by
+// appendExpenseRows to discover its column order.
+const DEFAULT_HEADERS = [
+  'Дата',
+  'Категория',
+  'Комментарий',
+  'EUR (calc)',
+  'RSD (дин.)',
+  'EUR (€)',
+  'Rate (→EUR)',
+];
+
+function seedGroupWithSpreadsheets(spec: {
+  telegramId: number;
+  spreadsheets: { year: number; id: string }[];
+}): { group: ReturnType<GroupRepository['findById']>; userId: number } {
+  const group = groups.create({ telegram_group_id: spec.telegramId });
+  groups.update(spec.telegramId, {
+    google_refresh_token: 'enc:test-token',
+    enabled_currencies: ['RSD', 'EUR'],
+  });
+  // expenses.create() requires a real user_id (FK constraint)
+  const user = users.create({ telegram_id: 1000 + spec.telegramId, group_id: group.id });
+  for (const s of spec.spreadsheets) {
+    groupSpreadsheets.setYear(group.id, s.year, s.id);
+  }
+  return { group: groups.findById(group.id), userId: user.id };
+}
+
+function makeNotFoundError(id: string) {
+  return {
+    code: 404,
+    response: {
+      data: {
+        error: {
+          code: 404,
+          errors: [{ reason: 'notFound', message: `File not found: ${id}.` }],
+        },
+      },
+    },
+  };
+}
+
+describe('auditAndRepairSpreadsheets — integration', () => {
+  test('returns empty audit when group has no registered spreadsheets', async () => {
+    const group = groups.create({ telegram_group_id: -100100 });
+    groups.update(-100100, { google_refresh_token: 'tok' });
+    const fresh = groups.findById(group.id);
+    if (!fresh) throw new Error('group seed failed');
+
+    const result = await auditAndRepairSpreadsheets(fresh);
+
+    expect(result.audit).toEqual([]);
+    expect(result.recreated).toEqual([]);
+    expect(mockSpreadsheetsGet).not.toHaveBeenCalled();
+  });
+
+  test('returns empty when group has no Google token (silent skip)', async () => {
+    const group = groups.create({ telegram_group_id: -100200 });
+    groupSpreadsheets.setYear(group.id, 2025, 'old-id');
+    const fresh = groups.findById(group.id);
+    if (!fresh) throw new Error('group seed failed');
+
+    const result = await auditAndRepairSpreadsheets(fresh);
+
+    expect(result.audit).toEqual([]);
+    expect(result.recreated).toEqual([]);
+    expect(mockSpreadsheetsGet).not.toHaveBeenCalled();
+  });
+
+  test('all years accessible — reports ok, recreates nothing', async () => {
+    const { group } = seedGroupWithSpreadsheets({
+      telegramId: -100300,
+      spreadsheets: [
+        { year: 2025, id: 'OK-2025' },
+        { year: 2026, id: 'OK-2026' },
+      ],
+    });
+    if (!group) throw new Error('group seed failed');
+
+    // Default mockSpreadsheetsGet returns OK for any ID
+    const result = await auditAndRepairSpreadsheets(group);
+
+    expect(result.audit).toHaveLength(2);
+    expect(result.audit.every((a) => a.status === 'ok')).toBe(true);
+    expect(result.recreated).toHaveLength(0);
+    expect(mockSpreadsheetsGet).toHaveBeenCalledTimes(2);
+    expect(mockSpreadsheetsCreate).not.toHaveBeenCalled();
+  });
+
+  test('one year lost — only that year is recreated, the other untouched', async () => {
+    const { group, userId } = seedGroupWithSpreadsheets({
+      telegramId: -100400,
+      spreadsheets: [
+        { year: 2025, id: 'OK-2025' },
+        { year: 2026, id: 'LOST-2026' },
+      ],
+    });
+    if (!group) throw new Error('group seed failed');
+
+    // Seed expenses: one in 2025, two in 2026 — only 2026 should be migrated
+    expenses.create({
+      group_id: group.id,
+      user_id: userId,
+      date: '2025-12-31',
+      category: 'Old',
+      comment: '',
+      amount: 100,
+      currency: 'RSD',
+      eur_amount: 0.85,
+    });
+    expenses.create({
+      group_id: group.id,
+      user_id: userId,
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Ноут',
+      amount: 41000,
+      currency: 'RSD',
+      eur_amount: 348.5,
+    });
+    expenses.create({
+      group_id: group.id,
+      user_id: userId,
+      date: '2026-04-16',
+      category: 'Еда',
+      comment: 'Pizza',
+      amount: 1000,
+      currency: 'RSD',
+      eur_amount: 8.5,
+    });
+
+    // googleapis: 404 for LOST-2026, OK for everyone else
+    mockSpreadsheetsGet.mockImplementation(async ({ spreadsheetId }) => {
+      if (spreadsheetId === 'LOST-2026') throw makeNotFoundError(spreadsheetId);
+      return { data: { sheets: [{ properties: { title: 'Expenses', sheetId: 0 } }] } };
+    });
+
+    // Sheets API for the new spreadsheet creation
+    mockSpreadsheetsCreate.mockResolvedValue({
+      data: { spreadsheetId: 'NEW-2026', spreadsheetUrl: 'https://docs.google.com/d/NEW-2026' },
+    });
+    // appendExpenseRows reads Expenses!1:1 first to discover headers
+    mockValuesGet.mockResolvedValue({ data: { values: [DEFAULT_HEADERS] } });
+
+    const result = await auditAndRepairSpreadsheets(group);
+
+    // Audit found one lost
+    expect(result.audit).toHaveLength(2);
+    const audit2025 = result.audit.find((a) => a.year === 2025);
+    const audit2026 = result.audit.find((a) => a.year === 2026);
+    expect(audit2025?.status).toBe('ok');
+    expect(audit2026?.status).toBe('not_found');
+
+    // Only the lost year was recreated
+    expect(result.recreated).toHaveLength(1);
+    expect(result.recreated[0]?.year).toBe(2026);
+    expect(result.recreated[0]?.oldSpreadsheetId).toBe('LOST-2026');
+    expect(result.recreated[0]?.newSpreadsheetId).toBe('NEW-2026');
+    expect(result.recreated[0]?.expensesCopied).toBe(2); // only 2026 expenses
+
+    // DB pointer updated for 2026, untouched for 2025
+    expect(groupSpreadsheets.getByYear(group.id, 2025)).toBe('OK-2025');
+    expect(groupSpreadsheets.getByYear(group.id, 2026)).toBe('NEW-2026');
+
+    // Exactly one new spreadsheet created
+    expect(mockSpreadsheetsCreate).toHaveBeenCalledTimes(1);
+
+    // Append happened on the new spreadsheet, with only 2026 rows
+    const appendCalls = mockValuesAppend.mock.calls;
+    expect(appendCalls.length).toBeGreaterThan(0);
+    // Find the append targeting NEW-2026
+    const appendToNewSheet = appendCalls.find(
+      (c) => (c[0] as { spreadsheetId?: string })?.spreadsheetId === 'NEW-2026',
+    );
+    expect(appendToNewSheet).toBeDefined();
+    const appendArgs = appendToNewSheet?.[0] as {
+      requestBody: { values: unknown[][] };
+    };
+    expect(appendArgs.requestBody.values).toHaveLength(2); // 2 expenses for 2026
+  });
+
+  test('all years lost — every year recreated, each with own data', async () => {
+    const { group, userId } = seedGroupWithSpreadsheets({
+      telegramId: -100500,
+      spreadsheets: [
+        { year: 2025, id: 'LOST-2025' },
+        { year: 2026, id: 'LOST-2026' },
+      ],
+    });
+    if (!group) throw new Error('group seed failed');
+
+    expenses.create({
+      group_id: group.id,
+      user_id: userId,
+      date: '2025-06-01',
+      category: 'A',
+      comment: '',
+      amount: 50,
+      currency: 'RSD',
+      eur_amount: 0.4,
+    });
+    expenses.create({
+      group_id: group.id,
+      user_id: userId,
+      date: '2026-04-15',
+      category: 'B',
+      comment: '',
+      amount: 200,
+      currency: 'RSD',
+      eur_amount: 1.7,
+    });
+
+    mockSpreadsheetsGet.mockImplementation(async ({ spreadsheetId }) => {
+      if (spreadsheetId.startsWith('LOST-')) throw makeNotFoundError(spreadsheetId);
+      return { data: { sheets: [{ properties: { title: 'Expenses', sheetId: 0 } }] } };
+    });
+
+    let createCount = 0;
+    mockSpreadsheetsCreate.mockImplementation(async () => {
+      createCount++;
+      return {
+        data: {
+          spreadsheetId: `NEW-${createCount}`,
+          spreadsheetUrl: `https://docs.google.com/d/NEW-${createCount}`,
+        },
+      };
+    });
+    mockValuesGet.mockResolvedValue({ data: { values: [DEFAULT_HEADERS] } });
+
+    const result = await auditAndRepairSpreadsheets(group);
+
+    expect(result.recreated).toHaveLength(2);
+    // Each year gets its own new spreadsheet ID
+    const new2025 = result.recreated.find((r) => r.year === 2025);
+    const new2026 = result.recreated.find((r) => r.year === 2026);
+    expect(new2025?.expensesCopied).toBe(1);
+    expect(new2026?.expensesCopied).toBe(1);
+    expect(new2025?.newSpreadsheetId).not.toBe(new2026?.newSpreadsheetId);
+
+    // Both DB pointers updated
+    expect(groupSpreadsheets.getByYear(group.id, 2025)).toMatch(/^NEW-/);
+    expect(groupSpreadsheets.getByYear(group.id, 2026)).toMatch(/^NEW-/);
+    expect(groupSpreadsheets.getByYear(group.id, 2025)).not.toBe(
+      groupSpreadsheets.getByYear(group.id, 2026),
+    );
+
+    expect(mockSpreadsheetsCreate).toHaveBeenCalledTimes(2);
+  });
+
+  test('partial failure — first year recreated, second fails, DB reflects committed work only', async () => {
+    const { group } = seedGroupWithSpreadsheets({
+      telegramId: -100600,
+      spreadsheets: [
+        { year: 2025, id: 'LOST-2025' },
+        { year: 2026, id: 'LOST-2026' },
+      ],
+    });
+    if (!group) throw new Error('group seed failed');
+
+    mockSpreadsheetsGet.mockImplementation(async ({ spreadsheetId }) => {
+      if (spreadsheetId.startsWith('LOST-')) throw makeNotFoundError(spreadsheetId);
+      return { data: { sheets: [{ properties: { title: 'Expenses', sheetId: 0 } }] } };
+    });
+
+    let createCount = 0;
+    mockSpreadsheetsCreate.mockImplementation(async () => {
+      createCount++;
+      if (createCount === 1) {
+        return {
+          data: {
+            spreadsheetId: 'NEW-2025-ok',
+            spreadsheetUrl: 'https://docs.google.com/d/NEW-2025-ok',
+          },
+        };
+      }
+      throw new Error('Drive API quota exceeded');
+    });
+    mockValuesGet.mockResolvedValue({ data: { values: [DEFAULT_HEADERS] } });
+
+    await expect(auditAndRepairSpreadsheets(group)).rejects.toThrow('Drive API quota exceeded');
+
+    // First (2025) succeeded — DB pointer updated
+    // Note: audits are sorted year DESC by listAll, so 2026 is processed first
+    // and 2025 second. But the deterministic detail is: when one succeeds and
+    // one fails, only the successful one updates the DB.
+    const updated2025 = groupSpreadsheets.getByYear(group.id, 2025);
+    const updated2026 = groupSpreadsheets.getByYear(group.id, 2026);
+    // Exactly one of them should still be 'LOST-...' — the one that failed
+    const lostCount = [updated2025, updated2026].filter((id) => id?.startsWith('LOST-')).length;
+    const newCount = [updated2025, updated2026].filter((id) => id === 'NEW-2025-ok').length;
+    expect(lostCount).toBe(1);
+    expect(newCount).toBe(1);
+  });
+});

--- a/src/bot/commands/reconnect.ts
+++ b/src/bot/commands/reconnect.ts
@@ -7,10 +7,12 @@ import { database } from '../../database';
 import type { Expense, Group } from '../../database/types';
 import { sendMessage } from '../../services/bank/telegram-sender';
 import { getBudgetManager } from '../../services/budget-manager';
+import { getExchangeRate } from '../../services/currency/converter';
 import { getExpenseRecorder } from '../../services/expense-recorder';
 import { MONTH_ABBREVS, type MonthAbbr, monthAbbrFromDate } from '../../services/google/month-abbr';
 import { generateAuthUrl, getAuthenticatedClient } from '../../services/google/oauth';
 import {
+  appendExpenseRows,
   createEmptyMonthTab,
   createExpenseSpreadsheet,
   type GoogleConn,
@@ -21,6 +23,12 @@ import {
   type SheetRow,
   writeMonthBudgetRow,
 } from '../../services/google/sheets';
+import {
+  type AuditEntry,
+  auditAllYears,
+  type RecreateResult,
+  recreateLostSpreadsheets,
+} from '../../services/google/spreadsheet-repair';
 import { createLogger } from '../../utils/logger.ts';
 import { pluralize } from '../../utils/pluralize';
 import type { Ctx } from '../types';
@@ -93,6 +101,75 @@ interface FullSyncReport {
   sheetToDbBudgets: number;
   budgetTabsCreated: string[];
   budgetRowsWritten: number;
+  audit: AuditEntry[];
+  recreated: RecreateResult[];
+}
+
+/**
+ * Probe a single spreadsheet via spreadsheets.get to test access. Throws on
+ * any failure (404, 403, network, etc.) so the surrounding `auditAllYears`
+ * can classify it.
+ */
+async function probeSpreadsheetAccess(conn: GoogleConn, spreadsheetId: string): Promise<void> {
+  const auth = getAuthenticatedClient(conn.refreshToken, conn.oauthClient);
+  const sheets = google.sheets({ version: 'v4', auth });
+  await sheets.spreadsheets.get({ spreadsheetId });
+}
+
+/**
+ * Audit every spreadsheet registered for the group and recreate any that the
+ * bot can no longer reach (404 / 403). Each recreated spreadsheet is freshly
+ * created with the new OAuth token, so `drive.file` scope owns it
+ * unambiguously. Data is repopulated from the local DB.
+ *
+ * Returns the audit + recreate results so the caller can include them in a
+ * user-facing report.
+ */
+export async function auditAndRepairSpreadsheets(
+  group: Group,
+): Promise<{ audit: AuditEntry[]; recreated: RecreateResult[] }> {
+  if (!group.google_refresh_token) {
+    return { audit: [], recreated: [] };
+  }
+
+  const conn = googleConn(group);
+  const registered = database.groupSpreadsheets.listAll(group.id);
+  if (registered.length === 0) {
+    return { audit: [], recreated: [] };
+  }
+
+  const audit = await auditAllYears(probeSpreadsheetAccess, conn, registered);
+  const lost = audit.filter((a) => a.status === 'not_found' || a.status === 'forbidden');
+  if (lost.length === 0) {
+    return { audit, recreated: [] };
+  }
+
+  logger.warn(
+    { groupId: group.id, lost: lost.map((a) => ({ year: a.year, status: a.status })) },
+    '[REPAIR] Lost spreadsheets detected — recreating',
+  );
+
+  const recreated = await recreateLostSpreadsheets(
+    {
+      createExpenseSpreadsheet,
+      appendExpenseRows,
+      writeMonthBudgetRow,
+      loadExpensesForYear: (groupId, year) =>
+        database.expenses
+          .findByGroupId(groupId, 100000)
+          .filter((e) => e.date.startsWith(`${year}-`)),
+      loadBudgetsForYear: (groupId, year) =>
+        database.budgets.findByGroupId(groupId).filter((b) => b.month.startsWith(`${year}-`)),
+      setSpreadsheetIdForYear: (groupId, year, spreadsheetId) =>
+        database.groupSpreadsheets.setYear(groupId, year, spreadsheetId),
+      getExchangeRate,
+    },
+    conn,
+    group,
+    audit,
+  );
+
+  return { audit, recreated };
 }
 
 /**
@@ -119,44 +196,81 @@ export async function fullSyncAfterReconnect(groupId: number): Promise<void> {
     sheetToDbBudgets: 0,
     budgetTabsCreated: [],
     budgetRowsWritten: 0,
+    audit: [],
+    recreated: [],
   };
 
   try {
     await sendMessage('🔄 Полная синхронизация...');
 
-    const freshGroup = database.groups.findById(groupId);
-    if (!freshGroup?.google_refresh_token || !freshGroup.spreadsheet_id) {
-      await sendMessage('❌ Токен или таблица не найдены. Попробуй /reconnect ещё раз.');
+    let freshGroup = database.groups.findById(groupId);
+    if (!freshGroup?.google_refresh_token) {
+      await sendMessage('❌ Токен не найден. Попробуй /reconnect ещё раз.');
+      return;
+    }
+
+    // Step -1: Snapshot DB state BEFORE any spreadsheet changes — recovery point
+    // if a recreate corrupts data.
+    const snapshotExpenses = database.expenses.findByGroupId(freshGroup.id, 100000);
+    const snapshotBudgets = database.budgets.findByGroupId(freshGroup.id);
+    report.snapshotId = database.syncSnapshots.saveSnapshot(
+      freshGroup.id,
+      snapshotExpenses,
+      snapshotBudgets,
+    );
+    report.snapshotExpenses = snapshotExpenses.length;
+    report.snapshotBudgets = snapshotBudgets.length;
+
+    // Step 0: Audit all year spreadsheets for access. If any are unreachable
+    // (file deleted, scope downgraded, permissions revoked) — recreate them
+    // BEFORE any backup/sync attempts that would just fail with the same 404.
+    const { audit, recreated } = await auditAndRepairSpreadsheets(freshGroup);
+    report.audit = audit;
+    report.recreated = recreated;
+
+    if (recreated.length > 0) {
+      // Reload group — recreate updated group_spreadsheets, so the JOIN result
+      // (group.spreadsheet_id) for the current year is now the new ID.
+      const reloaded = database.groups.findById(groupId);
+      if (reloaded) freshGroup = reloaded;
+    }
+
+    if (!freshGroup.spreadsheet_id) {
+      await sendMessage(
+        formatFullSyncReport(report) +
+          '\n\n❌ После проверки таблиц активной таблицы нет. Используй /connect.',
+      );
       return;
     }
 
     const conn = googleConn(freshGroup);
 
-    // Step 0: Create backups before any modifications
-    const expenses = database.expenses.findByGroupId(freshGroup.id, 100000);
-    const budgets = database.budgets.findByGroupId(freshGroup.id);
-    report.snapshotId = database.syncSnapshots.saveSnapshot(freshGroup.id, expenses, budgets);
-    report.snapshotExpenses = expenses.length;
-    report.snapshotBudgets = budgets.length;
-    report.sheetBackupUrl = await backupSpreadsheet(conn, freshGroup.spreadsheet_id);
+    // Step 1: Backup current-year spreadsheet — but only if it wasn't just
+    // recreated (the new sheet has only DB data, nothing to back up).
+    const currentYear = new Date().getFullYear();
+    const wasRecreatedThisYear = recreated.some((r) => r.year === currentYear);
+    if (!wasRecreatedThisYear) {
+      report.sheetBackupUrl = await backupSpreadsheet(conn, freshGroup.spreadsheet_id);
+    }
 
-    // Step 1: Ensure current-year spreadsheet exists
+    // Step 2: Ensure current-year spreadsheet exists (no-op if recreate or
+    // legacy setYear already wrote a row for this year).
     report.yearCreated = await ensureCurrentYearSpreadsheet(freshGroup);
 
-    // Step 2: Sheet → DB expenses (add-only, never deletes)
+    // Step 3: Sheet → DB expenses (add-only, never deletes)
     report.sheetToDbExpenses = await importExpensesFromSheet(
       freshGroup.id,
       conn,
       freshGroup.spreadsheet_id,
     );
 
-    // Step 3: DB → Sheet expenses (push missing)
+    // Step 4: DB → Sheet expenses (push missing)
     report.dbToSheetExpenses = await pushMissingExpensesToSheet(freshGroup);
 
-    // Step 4: Sheet → DB budgets (import from all month tabs)
+    // Step 5: Sheet → DB budgets (import from all month tabs)
     report.sheetToDbBudgets = await importBudgetsFromSheet(freshGroup);
 
-    // Step 5: DB → Sheet budgets (ensure tabs + write rows)
+    // Step 6: DB → Sheet budgets (ensure tabs + write rows)
     const budgetResult = await syncBudgetsToSheet(freshGroup);
     report.budgetTabsCreated = budgetResult.tabsCreated;
     report.budgetRowsWritten = budgetResult.rowsWritten;
@@ -165,7 +279,8 @@ export async function fullSyncAfterReconnect(groupId: number): Promise<void> {
   } catch (err) {
     logger.error({ err }, '[RECONNECT] Full sync failed');
     await sendMessage(
-      '⚠️ Аккаунт подключён, но синхронизация не удалась.\n' + 'Попробуй /sync вручную позже.',
+      '⚠️ Аккаунт подключён, но синхронизация не удалась.\n' +
+        'Попробуй /repair (проверка таблиц) или /sync позже.',
     );
   }
 }
@@ -425,6 +540,40 @@ function formatFullSyncReport(report: FullSyncReport): string {
       );
     }
     if (report.sheetBackupUrl) lines.push(`  Таблица: ${report.sheetBackupUrl}`);
+    lines.push('');
+  }
+
+  // Audit + recreate report
+  if (report.recreated.length > 0) {
+    const lostStatuses = new Set(
+      report.audit.filter((a) => a.status !== 'ok').map((a) => a.status),
+    );
+    const reasonHints: string[] = [];
+    if (lostStatuses.has('not_found')) {
+      reasonHints.push(
+        '• таблица удалена/в Корзине',
+        '• новый набор разрешений Google не видит старую таблицу',
+      );
+    }
+    if (lostStatuses.has('forbidden')) {
+      reasonHints.push('• бот лишился доступа (отозван в Google Account)');
+    }
+
+    lines.push('🔧 <b>Восстановление таблиц</b>');
+    if (reasonHints.length > 0) {
+      lines.push('Возможные причины:');
+      for (const h of reasonHints) lines.push(h);
+    }
+    lines.push('');
+    for (const r of report.recreated) {
+      lines.push(
+        `🆕 ${r.year}: новая таблица создана\n` +
+          `   ${r.newSpreadsheetUrl}\n` +
+          `   Залито: ${r.expensesCopied} ${pluralize(r.expensesCopied, 'расход', 'расхода', 'расходов')}, ${r.budgetsCopied} ${pluralize(r.budgetsCopied, 'бюджет', 'бюджета', 'бюджетов')}`,
+      );
+    }
+    lines.push('');
+    lines.push('ℹ️ Старые таблицы остались в твоём Google Drive — удали их вручную, если нужно.');
     lines.push('');
   }
 

--- a/src/bot/commands/reconnect.ts
+++ b/src/bot/commands/reconnect.ts
@@ -373,13 +373,29 @@ async function ensureCurrentYearSpreadsheet(group: Group): Promise<number | null
 }
 
 /**
- * Push DB expenses missing from the current spreadsheet.
+ * Push DB expenses missing from the current-year spreadsheet.
+ *
+ * Scoped deliberately to the CURRENT year:
+ * - We compare DB expenses only against the current-year sheet (that's what
+ *   `group.spreadsheet_id` resolves to via the LEFT JOIN).
+ * - Since `pushToSheet` now routes each expense to its own year sheet, we
+ *   MUST restrict the input to current-year expenses. Without that, a 2024
+ *   DB expense would be flagged "missing from current sheet" (which is
+ *   trivially true — current sheet is 2026) and then get appended to the
+ *   2024 sheet, where it already exists — a duplicate.
+ * - Prior-year sheets are handled by the recreate flow (which repopulates
+ *   them from DB wholesale) or by running /push manually per year.
+ *
  * Returns count of pushed expenses.
  */
 async function pushMissingExpensesToSheet(group: Group): Promise<number> {
   if (!group.google_refresh_token || !group.spreadsheet_id) return 0;
 
-  const dbExpenses = database.expenses.findByGroupId(group.id, 100000);
+  const currentYear = new Date().getFullYear();
+  const currentYearPrefix = `${currentYear}-`;
+
+  const allDbExpenses = database.expenses.findByGroupId(group.id, 100000);
+  const dbExpenses = allDbExpenses.filter((e) => e.date.startsWith(currentYearPrefix));
   if (dbExpenses.length === 0) return 0;
 
   const { expenses: sheetExpenses } = await readExpensesFromSheet(
@@ -403,7 +419,7 @@ async function pushMissingExpensesToSheet(group: Group): Promise<number> {
 
   if (missing.length === 0) return 0;
 
-  logger.info(`[RECONNECT] Pushing ${missing.length} missing expenses to sheet`);
+  logger.info(`[RECONNECT] Pushing ${missing.length} missing current-year expenses to sheet`);
   const recorder = getExpenseRecorder();
   try {
     await recorder.pushToSheet(group.id, missing);

--- a/src/bot/commands/reconnect.ts
+++ b/src/bot/commands/reconnect.ts
@@ -209,9 +209,16 @@ export async function fullSyncAfterReconnect(groupId: number): Promise<void> {
       return;
     }
 
-    // Step -1: Snapshot DB state BEFORE any spreadsheet changes — recovery point
-    // if a recreate corrupts data.
-    const snapshotExpenses = database.expenses.findByGroupId(freshGroup.id, 100000);
+    // Step -1: Snapshot DB state BEFORE any spreadsheet changes. This is NOT
+    // auto-rollback — we never restore automatically because we can't
+    // distinguish "bad sync corrupted DB" from "user added expenses between
+    // snapshot and failure". Instead the snapshot is a manual recovery point:
+    // if the user sees data loss after /reconnect, they run `/sync rollback`
+    // (handled in sync.ts) to restore from the latest snapshot.
+    //
+    // Limit bump: findByGroupId caps the result. 1M is effectively unbounded
+    // for realistic group sizes while still defending against runaway queries.
+    const snapshotExpenses = database.expenses.findByGroupId(freshGroup.id, 1_000_000);
     const snapshotBudgets = database.budgets.findByGroupId(freshGroup.id);
     report.snapshotId = database.syncSnapshots.saveSnapshot(
       freshGroup.id,
@@ -280,7 +287,8 @@ export async function fullSyncAfterReconnect(groupId: number): Promise<void> {
     logger.error({ err }, '[RECONNECT] Full sync failed');
     await sendMessage(
       '⚠️ Аккаунт подключён, но синхронизация не удалась.\n' +
-        'Попробуй /repair (проверка таблиц) или /sync позже.',
+        'Попробуй /repair (проверка таблиц) или /sync позже.\n' +
+        'Если заметишь потерю данных — /sync rollback откатит последний снэпшот.',
     );
   }
 }

--- a/src/bot/commands/repair.test.ts
+++ b/src/bot/commands/repair.test.ts
@@ -1,0 +1,107 @@
+// Tests for /repair command — rate limiting, error paths
+
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import type { GoogleConnectedGroup } from '../guards';
+import type { Ctx } from '../types';
+
+// ── Mock telegram-sender ──────────────────────────────────────────────────
+
+const sendMessageMock = mock(
+  (_text: string, _options?: unknown): Promise<null> => Promise.resolve(null),
+);
+
+mock.module('../../services/bank/telegram-sender', () => ({
+  sendMessage: sendMessageMock,
+  withChatContext: async <T>(_c: number, _t: number | null, fn: () => Promise<T>) => fn(),
+  editMessageText: mock(() => Promise.resolve()),
+  sendDirect: mock(() => Promise.resolve(null)),
+}));
+
+// Stub auditAndRepairSpreadsheets so the test doesn't go near real googleapis
+const auditAndRepairMock = mock(async () => ({ audit: [], recreated: [] }));
+mock.module('./reconnect', () => ({
+  auditAndRepairSpreadsheets: auditAndRepairMock,
+}));
+
+const { handleRepairCommand, _resetRepairCooldownForTests } = await import('./repair');
+
+function fakeCtx(): Ctx['Command'] {
+  return { chat: { id: -100 }, from: { id: 1 } } as unknown as Ctx['Command'];
+}
+
+function fakeGroup(id = 1): GoogleConnectedGroup {
+  return {
+    id,
+    telegram_group_id: -100,
+    title: null,
+    invite_link: null,
+    google_refresh_token: 'tok',
+    spreadsheet_id: 'sheet-123',
+    default_currency: 'RSD',
+    enabled_currencies: ['RSD'],
+    custom_prompt: null,
+    active_topic_id: null,
+    oauth_client: 'current',
+    bank_panel_summary_message_id: null,
+    created_at: '',
+    updated_at: '',
+  } as GoogleConnectedGroup;
+}
+
+beforeEach(() => {
+  sendMessageMock.mockReset().mockResolvedValue(null);
+  auditAndRepairMock.mockReset().mockResolvedValue({ audit: [], recreated: [] });
+  _resetRepairCooldownForTests();
+});
+
+describe('/repair rate-limit', () => {
+  test('first call within cooldown window proceeds', async () => {
+    await handleRepairCommand(fakeCtx(), fakeGroup());
+    expect(auditAndRepairMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('second call within cooldown window is rejected without hitting audit', async () => {
+    const now = Date.now();
+    const dateSpy = spyOn(Date, 'now').mockReturnValue(now);
+
+    await handleRepairCommand(fakeCtx(), fakeGroup());
+    expect(auditAndRepairMock).toHaveBeenCalledTimes(1);
+
+    // 1 minute later — still inside the 5-minute cooldown
+    dateSpy.mockReturnValue(now + 60_000);
+    await handleRepairCommand(fakeCtx(), fakeGroup());
+
+    // audit was NOT called a second time
+    expect(auditAndRepairMock).toHaveBeenCalledTimes(1);
+
+    // User got a cooldown message with time remaining
+    const lastMsg = sendMessageMock.mock.calls.at(-1)?.[0];
+    expect(lastMsg).toContain('Подожди');
+    dateSpy.mockRestore();
+  });
+
+  test('call after cooldown window is allowed again', async () => {
+    const now = Date.now();
+    const dateSpy = spyOn(Date, 'now').mockReturnValue(now);
+
+    await handleRepairCommand(fakeCtx(), fakeGroup());
+    // 6 minutes later — outside cooldown
+    dateSpy.mockReturnValue(now + 6 * 60_000);
+    await handleRepairCommand(fakeCtx(), fakeGroup());
+
+    expect(auditAndRepairMock).toHaveBeenCalledTimes(2);
+    dateSpy.mockRestore();
+  });
+
+  test('cooldown is per-group — other groups are not blocked', async () => {
+    const now = Date.now();
+    const dateSpy = spyOn(Date, 'now').mockReturnValue(now);
+
+    await handleRepairCommand(fakeCtx(), fakeGroup(1));
+    // Different group immediately — should NOT be blocked
+    await handleRepairCommand(fakeCtx(), fakeGroup(2));
+
+    expect(auditAndRepairMock).toHaveBeenCalledTimes(2);
+    dateSpy.mockRestore();
+  });
+});

--- a/src/bot/commands/repair.ts
+++ b/src/bot/commands/repair.ts
@@ -10,10 +10,37 @@ import { auditAndRepairSpreadsheets } from './reconnect';
 
 const logger = createLogger('repair');
 
+/**
+ * /repair creates new spreadsheets on Drive — a non-trivial side effect.
+ * Limit to once per 5 minutes per group to stop accidental floods
+ * (double-tap, bugged client) from filling the user's Drive with empty sheets.
+ * In-memory is fine: a restart drops the cooldown, which is the correct
+ * behavior (operator intervention = operator trusted).
+ */
+const REPAIR_COOLDOWN_MS = 5 * 60 * 1000;
+const lastRepairByGroup = new Map<number, number>();
+
+/** Test-only: wipe the cooldown map so tests start from a clean state. */
+export function _resetRepairCooldownForTests(): void {
+  lastRepairByGroup.clear();
+}
+
 export async function handleRepairCommand(
   _ctx: Ctx['Command'],
   group: GoogleConnectedGroup,
 ): Promise<void> {
+  const now = Date.now();
+  const last = lastRepairByGroup.get(group.id);
+  if (last !== undefined && now - last < REPAIR_COOLDOWN_MS) {
+    const remainingMs = REPAIR_COOLDOWN_MS - (now - last);
+    const remainingMin = Math.ceil(remainingMs / 60_000);
+    await sendMessage(
+      `⏳ /repair можно запускать не чаще раза в 5 минут. Подожди ~${remainingMin} ${pluralize(remainingMin, 'минуту', 'минуты', 'минут')} и попробуй снова.`,
+    );
+    return;
+  }
+  lastRepairByGroup.set(group.id, now);
+
   await sendMessage('🔍 Проверяю доступ к Google таблицам по всем годам...');
 
   try {

--- a/src/bot/commands/repair.ts
+++ b/src/bot/commands/repair.ts
@@ -1,0 +1,97 @@
+// /repair command — audit all year spreadsheets and recreate any the bot has lost access to
+
+import { sendMessage } from '../../services/bank/telegram-sender';
+import type { AuditEntry, RecreateResult } from '../../services/google/spreadsheet-repair';
+import { createLogger } from '../../utils/logger.ts';
+import { pluralize } from '../../utils/pluralize';
+import type { GoogleConnectedGroup } from '../guards';
+import type { Ctx } from '../types';
+import { auditAndRepairSpreadsheets } from './reconnect';
+
+const logger = createLogger('repair');
+
+export async function handleRepairCommand(
+  _ctx: Ctx['Command'],
+  group: GoogleConnectedGroup,
+): Promise<void> {
+  await sendMessage('🔍 Проверяю доступ к Google таблицам по всем годам...');
+
+  try {
+    const { audit, recreated } = await auditAndRepairSpreadsheets(group);
+
+    if (audit.length === 0) {
+      await sendMessage(
+        'ℹ️ В базе нет ни одной зарегистрированной таблицы для этой группы. Используй /connect.',
+      );
+      return;
+    }
+
+    await sendMessage(formatRepairReport(audit, recreated));
+  } catch (err) {
+    logger.error({ err, groupId: group.id }, '[REPAIR] Failed');
+    await sendMessage(
+      `❌ Не удалось проверить таблицы: ${err instanceof Error ? err.message : 'unknown'}\n\nПопробуй /reconnect для полной переподключения.`,
+    );
+  }
+}
+
+function formatRepairReport(audit: AuditEntry[], recreated: RecreateResult[]): string {
+  const lines: string[] = ['🔧 <b>Проверка таблиц</b>\n'];
+
+  // Audit summary by year
+  lines.push('Состояние:');
+  for (const entry of audit) {
+    const icon =
+      entry.status === 'ok'
+        ? '✅'
+        : entry.status === 'not_found'
+          ? '❌'
+          : entry.status === 'forbidden'
+            ? '🔒'
+            : entry.status === 'token_expired'
+              ? '🔑'
+              : '⚠️';
+    const statusText =
+      entry.status === 'ok'
+        ? 'доступна'
+        : entry.status === 'not_found'
+          ? 'не найдена'
+          : entry.status === 'forbidden'
+            ? 'нет прав доступа'
+            : entry.status === 'token_expired'
+              ? 'токен отозван'
+              : 'ошибка';
+    lines.push(`  ${icon} ${entry.year} — ${statusText}`);
+  }
+
+  if (recreated.length === 0) {
+    if (audit.every((a) => a.status === 'ok')) {
+      lines.push('\n✅ Все таблицы на месте, ничего пересоздавать не нужно.');
+    } else if (audit.some((a) => a.status === 'token_expired')) {
+      lines.push('\n🔑 Токен Google отозван — используй /reconnect.');
+    } else {
+      lines.push(
+        '\n⚠️ Часть таблиц недоступна, но автоматически пересоздать не получилось. Используй /reconnect.',
+      );
+    }
+    return lines.join('\n');
+  }
+
+  lines.push('');
+  lines.push('Возможные причины проблемы:');
+  lines.push('• таблица удалена/в Корзине');
+  lines.push('• после смены конфигурации Google новые разрешения не видят старые таблицы');
+  lines.push('• бот лишился доступа в настройках Google аккаунта');
+  lines.push('');
+  lines.push('🆕 Пересоздано:');
+  for (const r of recreated) {
+    lines.push(
+      `  ${r.year}: ${r.newSpreadsheetUrl}\n` +
+        `    Залито: ${r.expensesCopied} ${pluralize(r.expensesCopied, 'расход', 'расхода', 'расходов')}, ${r.budgetsCopied} ${pluralize(r.budgetsCopied, 'бюджет', 'бюджета', 'бюджетов')}`,
+    );
+  }
+  lines.push('');
+  lines.push('ℹ️ Старые таблицы остались в твоём Google Drive — удали их вручную, если нужно.');
+
+  return lines.join('\n');
+}

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -21,6 +21,7 @@ import { handlePingCommand } from './commands/ping';
 import { handlePromptCommand } from './commands/prompt';
 import { handlePushCommand } from './commands/push';
 import { handleReconnectCommand } from './commands/reconnect';
+import { handleRepairCommand } from './commands/repair';
 import { handleScanCommand } from './commands/scan';
 import { handleSettingsCommand } from './commands/settings';
 import { handleSpreadsheetCommand } from './commands/spreadsheet';
@@ -107,6 +108,7 @@ export function createBot(): Bot {
   bot.command('topic', requireGroup(handleTopicCommand));
   bot.command('dev', requireGroup(handleDevCommand));
   bot.command('sync', requireGroup(requireGoogle(handleSyncCommand)));
+  bot.command('repair', requireGroup(requireGoogle(handleRepairCommand)));
   bot.command('scan', requireGroup(handleScanCommand));
   bot.command(
     'bank',

--- a/src/bot/services/sheet-errors.test.ts
+++ b/src/bot/services/sheet-errors.test.ts
@@ -60,10 +60,15 @@ describe('getSheetErrorMessage', () => {
     expect(msg).toContain('авторизация');
   });
 
-  test('not_found error mentions sheet inaccessible', () => {
+  test('not_found error points at /repair primarily, /reconnect as fallback', () => {
     const msg = getSheetErrorMessage(new Error('404 Not Found'));
     expect(msg).toContain('недоступна');
+    // /repair is the lightweight path — works without redoing OAuth
+    expect(msg).toContain('/repair');
+    // /reconnect stays as a fallback
     expect(msg).toContain('/reconnect');
+    // /repair must be mentioned before /reconnect in the text
+    expect(msg.indexOf('/repair')).toBeLessThan(msg.indexOf('/reconnect'));
   });
 
   test('rate_limit error suggests waiting', () => {

--- a/src/bot/services/sheet-errors.ts
+++ b/src/bot/services/sheet-errors.ts
@@ -60,7 +60,11 @@ export function getSheetErrorMessage(error: unknown): string {
     case 'auth':
       return '❌ Не удалось записать в Google таблицу — авторизация устарела. Выполни /reconnect и повтори попытку.';
     case 'not_found':
-      return '❌ Не удалось записать в Google таблицу — таблица недоступна или удалена. Проверь её и выполни /reconnect.';
+      return (
+        '❌ Не удалось записать в Google таблицу — таблица недоступна или удалена.\n' +
+        'Попробуй /repair — бот проверит все таблицы и пересоздаст недоступные. ' +
+        'Если не помогло — /reconnect.'
+      );
     case 'rate_limit':
       return '⚠️ Google Sheets временно ограничил запросы. Подожди минуту и повтори попытку.';
     case 'network':

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -1010,17 +1010,22 @@ describe('executeDeleteExpense', () => {
     expect(result.output).toContain('not found in sheet');
   });
 
-  test('still deletes from DB if sheet operation fails (and warns)', async () => {
+  test('preserves DB row when sheet delete fails — no silent resurrection via /sync', async () => {
+    // If we deleted the DB row while sheet delete failed, the sheet still holds
+    // the row, and the next /sync (or auto-sync) would re-import it. So we leave
+    // DB untouched and surface a clear error that points at /repair.
     mockExpenses.findById.mockReturnValue(
       makeExpense({ id: 10, user_id: 123, date: '2026-03-01', comment: 'pizza', amount: 12 }),
     );
     mockDeleteFromSheet.mockReturnValueOnce(Promise.reject(new Error('Sheet API 404 — file gone')));
 
     const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
-    expect(result.success).toBe(true);
-    expect(mockExpenses.delete).toHaveBeenCalledWith(10);
-    expect(result.output).toContain('sheet');
-    expect((result.output ?? '').toLowerCase()).toMatch(/error|failed|404|gone/);
+
+    expect(result.success).toBe(false);
+    expect(mockExpenses.delete).not.toHaveBeenCalled();
+    expect(result.error).toContain('sheet');
+    expect((result.error ?? '').toLowerCase()).toMatch(/404|gone|failed|error/);
+    expect(result.error).toContain('/repair');
   });
 
   test('rejects deletion of expense from different group', async () => {

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -192,10 +192,11 @@ mock.module('../google/sheets', () => ({
   readBudgetData: mock(() => Promise.resolve([])),
 }));
 
-// Mock ExpenseRecorder (used by add_expense tool)
+// Mock ExpenseRecorder (used by add_expense / delete_expense tools)
 const mockRecord = mock(() => Promise.resolve({ expense: { id: 42 }, eurAmount: 25.5 }));
+const mockDeleteFromSheet = mock(() => Promise.resolve({ deletedRowIndex: 5 as number | null }));
 mock.module('../expense-recorder', () => ({
-  getExpenseRecorder: () => ({ record: mockRecord }),
+  getExpenseRecorder: () => ({ record: mockRecord, deleteFromSheet: mockDeleteFromSheet }),
 }));
 
 // Mock BudgetManager (used by set_budget and delete_budget tools)
@@ -270,6 +271,8 @@ function resetAllMocks() {
 
   mockRecord.mockReset();
   mockRecord.mockReturnValue(Promise.resolve({ expense: { id: 42 }, eurAmount: 25.5 }));
+  mockDeleteFromSheet.mockReset();
+  mockDeleteFromSheet.mockReturnValue(Promise.resolve({ deletedRowIndex: 5 as number | null }));
 
   mockCategories.findByGroupId.mockReset();
   mockCategories.findByGroupId.mockReturnValue([]);
@@ -966,21 +969,58 @@ describe('executeDeleteExpense', () => {
   beforeEach(resetAllMocks);
 
   test('deletes expense belonging to this group', async () => {
-    mockExpenses.findById.mockReturnValue(
-      makeExpense({
-        id: 10,
-        user_id: 123,
-        date: '2026-03-01',
-        comment: 'pizza',
-        amount: 12,
-        eur_amount: 12,
-      }),
-    );
+    const expense = makeExpense({
+      id: 10,
+      user_id: 123,
+      date: '2026-03-01',
+      comment: 'pizza',
+      amount: 12,
+      eur_amount: 12,
+    });
+    mockExpenses.findById.mockReturnValue(expense);
 
     const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
     expect(result.success).toBe(true);
     expect(result.output).toContain('Expense 10 deleted');
+    // Removes the row from Google Sheets BEFORE deleting from DB
+    expect(mockDeleteFromSheet).toHaveBeenCalledWith(1, expense);
     expect(mockExpenses.delete).toHaveBeenCalledWith(10);
+  });
+
+  test('removes legacy "run /sync" hint from response (regression)', async () => {
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({ id: 10, user_id: 123, date: '2026-03-01', comment: 'pizza', amount: 12 }),
+    );
+
+    const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
+    expect(result.output).not.toContain('/sync');
+  });
+
+  test('reports when sheet row was not found (already removed manually)', async () => {
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({ id: 10, user_id: 123, date: '2026-03-01', comment: 'pizza', amount: 12 }),
+    );
+    mockDeleteFromSheet.mockReturnValueOnce(Promise.resolve({ deletedRowIndex: null }));
+
+    const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
+    // Still succeeds — DB delete is the authoritative action
+    expect(result.success).toBe(true);
+    expect(mockExpenses.delete).toHaveBeenCalledWith(10);
+    // The output mentions sheet row was not present
+    expect(result.output).toContain('not found in sheet');
+  });
+
+  test('still deletes from DB if sheet operation fails (and warns)', async () => {
+    mockExpenses.findById.mockReturnValue(
+      makeExpense({ id: 10, user_id: 123, date: '2026-03-01', comment: 'pizza', amount: 12 }),
+    );
+    mockDeleteFromSheet.mockReturnValueOnce(Promise.reject(new Error('Sheet API 404 — file gone')));
+
+    const result = await executeTool('delete_expense', { expense_id: 10 }, ctx);
+    expect(result.success).toBe(true);
+    expect(mockExpenses.delete).toHaveBeenCalledWith(10);
+    expect(result.output).toContain('sheet');
+    expect((result.output ?? '').toLowerCase()).toMatch(/error|failed|404|gone/);
   });
 
   test('rejects deletion of expense from different group', async () => {

--- a/src/services/ai/tool-executor.ts
+++ b/src/services/ai/tool-executor.ts
@@ -698,7 +698,10 @@ async function executeDeleteExpense(
   return executeDeleteExpenseSingle(rawId as number, ctx);
 }
 
-function executeDeleteExpenseSingle(expenseId: number, ctx: AgentContext): ToolResult {
+async function executeDeleteExpenseSingle(
+  expenseId: number,
+  ctx: AgentContext,
+): Promise<ToolResult> {
   if (!expenseId) {
     return { success: false, error: 'expense_id is required' };
   }
@@ -713,11 +716,27 @@ function executeDeleteExpenseSingle(expenseId: number, ctx: AgentContext): ToolR
     return { success: false, error: 'Access denied: expense belongs to a different group' };
   }
 
+  // Remove the matching row from Google Sheets BEFORE deleting from DB.
+  // If we deleted from DB first and the next /sync ran (auto-sync runs before
+  // get_expenses), the expense would be re-imported from the sheet — that's
+  // exactly the bug this fix addresses.
+  const { getExpenseRecorder } = await import('../expense-recorder');
+  let sheetSuffix = '';
+  try {
+    const sheetResult = await getExpenseRecorder().deleteFromSheet(ctx.groupId, expense);
+    if (sheetResult.deletedRowIndex === null) {
+      sheetSuffix = ' (not found in sheet — already removed manually?)';
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    sheetSuffix = ` ⚠️ sheet delete failed: ${msg}. Run /repair to recreate the sheet if access is lost.`;
+  }
+
   database.expenses.delete(expenseId);
 
   return {
     success: true,
-    output: `Expense ${expenseId} deleted (${expense.date} | ${expense.category} | ${expense.amount} ${expense.currency}). Note: run /sync to update Google Sheets.`,
+    output: `Expense ${expenseId} deleted (${expense.date} | ${expense.category} | ${expense.amount} ${expense.currency}).${sheetSuffix}`,
   };
 }
 

--- a/src/services/ai/tool-executor.ts
+++ b/src/services/ai/tool-executor.ts
@@ -717,9 +717,10 @@ async function executeDeleteExpenseSingle(
   }
 
   // Remove the matching row from Google Sheets BEFORE deleting from DB.
-  // If we deleted from DB first and the next /sync ran (auto-sync runs before
-  // get_expenses), the expense would be re-imported from the sheet — that's
-  // exactly the bug this fix addresses.
+  // The DB delete is the LAST step: if sheet delete fails, we must NOT touch
+  // the DB — the next /sync (auto-sync fires before get_expenses) would
+  // re-import the still-present sheet row, silently resurrecting the expense.
+  // That's the exact bug this whole fix addresses.
   const { getExpenseRecorder } = await import('../expense-recorder');
   let sheetSuffix = '';
   try {
@@ -729,7 +730,10 @@ async function executeDeleteExpenseSingle(
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown';
-    sheetSuffix = ` ⚠️ sheet delete failed: ${msg}. Run /repair to recreate the sheet if access is lost.`;
+    return {
+      success: false,
+      error: `Could not delete expense ${expenseId} from the sheet: ${msg}. DB row preserved to avoid silent resurrection on next sync. Run /repair if the sheet is inaccessible.`,
+    };
   }
 
   database.expenses.delete(expenseId);

--- a/src/services/expense-recorder.test.ts
+++ b/src/services/expense-recorder.test.ts
@@ -6,6 +6,7 @@ import type { CurrencyCode } from '../config/constants';
 import { ExpenseRepository } from '../database/repositories/expense.repository';
 import { ExpenseItemsRepository } from '../database/repositories/expense-items.repository';
 import { GroupRepository } from '../database/repositories/group.repository';
+import { GroupSpreadsheetRepository } from '../database/repositories/group-spreadsheet.repository';
 import { UserRepository } from '../database/repositories/user.repository';
 import { clearTestDb, createTestDb } from '../test-utils/db';
 import {
@@ -59,6 +60,7 @@ describe('ExpenseRecorder', () => {
   let users: UserRepository;
   let expenses: ExpenseRepository;
   let expenseItems: ExpenseItemsRepository;
+  let groupSpreadsheets: GroupSpreadsheetRepository;
   let mockSheetWriter: SheetWriter;
   let mockConverter: EurConverter;
   let recorder: ExpenseRecorder;
@@ -69,6 +71,7 @@ describe('ExpenseRecorder', () => {
     users = new UserRepository(db);
     expenses = new ExpenseRepository(db);
     expenseItems = new ExpenseItemsRepository(db);
+    groupSpreadsheets = new GroupSpreadsheetRepository(db);
 
     mockSheetWriter = {
       appendExpenseRow: mock(() => Promise.resolve()),
@@ -90,6 +93,7 @@ describe('ExpenseRecorder', () => {
       groups,
       expenses,
       expenseItems,
+      groupSpreadsheets,
       sheetWriter: mockSheetWriter,
       eurConverter: mockConverter,
       // Tests run on a single in-memory DB per file; identity wrapper is fine.
@@ -709,6 +713,34 @@ describe('ExpenseRecorder', () => {
 
       expect(mockSheetWriter.findAndDeleteExpenseRow).not.toHaveBeenCalled();
       expect(result.deletedRowIndex).toBeNull();
+    });
+
+    it('uses the spreadsheet for the expense YEAR, not the group current-year sheet (regression)', async () => {
+      // Sheet registered for current year (via seedGroup default). Also register an
+      // older year with a DIFFERENT spreadsheet ID — that's the one delete must target.
+      const { groupId, userId } = seedGroup();
+      const group = groups.findById(groupId);
+      if (!group) throw new Error('seed failed');
+      groupSpreadsheets.setYear(groupId, 2024, 'old-year-sheet-id');
+
+      const expense = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2024-07-04', // past year — NOT current
+        category: 'Алекс',
+        comment: 'Old trip',
+        amount: 500,
+        currency: 'EUR',
+        eur_amount: 500,
+      });
+
+      await recorder.deleteFromSheet(groupId, expense);
+
+      const call = (mockSheetWriter.findAndDeleteExpenseRow as ReturnType<typeof mock>).mock
+        .calls[0];
+      if (!call) throw new Error('Expected sheet delete call');
+      // Must target the 2024 sheet, NOT the default sheet-123 (current year).
+      expect(call[1]).toBe('old-year-sheet-id');
     });
 
     it('propagates sheet errors so the caller can surface them', async () => {

--- a/src/services/expense-recorder.test.ts
+++ b/src/services/expense-recorder.test.ts
@@ -250,6 +250,43 @@ describe('ExpenseRecorder', () => {
       ).rejects.toThrow('not found');
     });
 
+    it('writes backdated expense into the spreadsheet for THAT year, not current (regression)', async () => {
+      const { groupId, userId } = seedGroup();
+      // Register a separate 2024 spreadsheet on top of the current-year default
+      groupSpreadsheets.setYear(groupId, 2024, 'sheet-2024');
+
+      await recorder.record(groupId, userId, {
+        date: '2024-07-04',
+        category: 'Trip',
+        comment: 'Paris',
+        amount: 250,
+        currency: 'EUR',
+      });
+
+      const call = (mockSheetWriter.appendExpenseRow as ReturnType<typeof mock>).mock.calls[0];
+      if (!call) throw new Error('Expected sheet write call');
+      // Must write into the 2024 sheet, NOT the default current-year sheet-123
+      expect(call[1]).toBe('sheet-2024');
+    });
+
+    it('falls back to current-year spreadsheet when expense year has no registration', async () => {
+      const { groupId, userId } = seedGroup();
+      // Note: no setYear for 2024 — only the default current-year sheet exists
+
+      await recorder.record(groupId, userId, {
+        date: '2024-07-04',
+        category: 'Trip',
+        comment: '',
+        amount: 100,
+        currency: 'EUR',
+      });
+
+      const call = (mockSheetWriter.appendExpenseRow as ReturnType<typeof mock>).mock.calls[0];
+      if (!call) throw new Error('Expected sheet write call');
+      // No 2024 sheet registered → fallback to current year sheet-123
+      expect(call[1]).toBe('sheet-123');
+    });
+
     it('does NOT create DB expense if sheet write fails', async () => {
       const { groupId, userId } = seedGroup();
       (mockSheetWriter.appendExpenseRow as ReturnType<typeof mock>).mockImplementation(() => {
@@ -627,6 +664,72 @@ describe('ExpenseRecorder', () => {
       await recorder.pushToSheet(groupId, []);
       expect(mockSheetWriter.appendExpenseRows).not.toHaveBeenCalled();
       expect(mockSheetWriter.appendExpenseRow).not.toHaveBeenCalled();
+    });
+
+    it('splits multi-year expense list into per-year batches, each to the matching sheet', async () => {
+      const { groupId, userId } = seedGroup();
+      groupSpreadsheets.setYear(groupId, 2024, 'sheet-2024');
+      groupSpreadsheets.setYear(groupId, 2025, 'sheet-2025');
+      // 2026 uses the default sheet-123 registered by seedGroup's current-year setYear.
+
+      const e2024 = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2024-06-10',
+        category: 'A',
+        comment: '',
+        amount: 100,
+        currency: 'EUR',
+        eur_amount: 100,
+      });
+      const e2025 = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2025-03-15',
+        category: 'B',
+        comment: '',
+        amount: 200,
+        currency: 'EUR',
+        eur_amount: 200,
+      });
+      const e2026a = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2026-01-05',
+        category: 'C',
+        comment: '',
+        amount: 300,
+        currency: 'EUR',
+        eur_amount: 300,
+      });
+      const e2026b = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2026-04-15',
+        category: 'D',
+        comment: '',
+        amount: 400,
+        currency: 'EUR',
+        eur_amount: 400,
+      });
+
+      await recorder.pushToSheet(groupId, [e2024, e2025, e2026a, e2026b]);
+
+      // Three batched calls, one per year
+      expect(mockSheetWriter.appendExpenseRows).toHaveBeenCalledTimes(3);
+
+      const calls = (mockSheetWriter.appendExpenseRows as ReturnType<typeof mock>).mock.calls;
+      // Collect (spreadsheetId, row count) per call — order depends on Map iteration
+      // but groupings must be exact.
+      const summary = calls
+        .map((c) => ({ sheet: c[1] as string, count: (c[2] as unknown[]).length }))
+        .sort((a, b) => a.sheet.localeCompare(b.sheet));
+
+      expect(summary).toEqual([
+        { sheet: 'sheet-123', count: 2 }, // 2026: two expenses
+        { sheet: 'sheet-2024', count: 1 },
+        { sheet: 'sheet-2025', count: 1 },
+      ]);
     });
 
     it('throws when no Google connection (refreshToken null)', async () => {

--- a/src/services/expense-recorder.test.ts
+++ b/src/services/expense-recorder.test.ts
@@ -73,6 +73,7 @@ describe('ExpenseRecorder', () => {
     mockSheetWriter = {
       appendExpenseRow: mock(() => Promise.resolve()),
       appendExpenseRows: mock(() => Promise.resolve()),
+      findAndDeleteExpenseRow: mock(() => Promise.resolve({ deletedRowIndex: 7 as number | null })),
     };
 
     const testRates: Record<string, number> = { EUR: 1, USD: 0.86, RSD: 0.0085, RUB: 0.01 };
@@ -632,6 +633,104 @@ describe('ExpenseRecorder', () => {
 
     it('throws if group not found', async () => {
       await expect(recorder.pushToSheet(999, [])).rejects.toThrow('not found');
+    });
+  });
+
+  describe('deleteFromSheet()', () => {
+    it('finds and deletes the matching sheet row by expense match criteria', async () => {
+      const { groupId, userId } = seedGroup();
+
+      const expense = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2026-04-15',
+        category: 'Алекс',
+        comment: 'Ноут для умного дома',
+        amount: 41000,
+        currency: 'RSD',
+        eur_amount: 348.5,
+      });
+
+      const result = await recorder.deleteFromSheet(groupId, expense);
+
+      expect(result.deletedRowIndex).toBe(7);
+      expect(mockSheetWriter.findAndDeleteExpenseRow).toHaveBeenCalledTimes(1);
+      const call = (mockSheetWriter.findAndDeleteExpenseRow as ReturnType<typeof mock>).mock
+        .calls[0];
+      if (!call) throw new Error('Expected sheet delete call');
+      expect(call[0]).toEqual({ refreshToken: 'token-abc', oauthClient: 'legacy' });
+      expect(call[1]).toBe('sheet-123');
+      expect(call[2]).toEqual({
+        date: '2026-04-15',
+        category: 'Алекс',
+        comment: 'Ноут для умного дома',
+        amount: 41000,
+        currency: 'RSD',
+      });
+    });
+
+    it('returns deletedRowIndex=null when sheet has no matching row', async () => {
+      const { groupId, userId } = seedGroup();
+      (mockSheetWriter.findAndDeleteExpenseRow as ReturnType<typeof mock>).mockReturnValueOnce(
+        Promise.resolve({ deletedRowIndex: null }),
+      );
+
+      const expense = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2026-04-15',
+        category: 'Алекс',
+        comment: 'Ноут для умного дома',
+        amount: 41000,
+        currency: 'RSD',
+        eur_amount: 348.5,
+      });
+
+      const result = await recorder.deleteFromSheet(groupId, expense);
+
+      expect(result.deletedRowIndex).toBeNull();
+    });
+
+    it('skips sheet operation entirely when group has no Google connection', async () => {
+      const { groupId, userId } = seedGroupWithoutGoogle();
+
+      const expense = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2026-04-15',
+        category: 'X',
+        comment: '',
+        amount: 100,
+        currency: 'EUR',
+        eur_amount: 100,
+      });
+
+      const result = await recorder.deleteFromSheet(groupId, expense);
+
+      expect(mockSheetWriter.findAndDeleteExpenseRow).not.toHaveBeenCalled();
+      expect(result.deletedRowIndex).toBeNull();
+    });
+
+    it('propagates sheet errors so the caller can surface them', async () => {
+      const { groupId, userId } = seedGroup();
+      (mockSheetWriter.findAndDeleteExpenseRow as ReturnType<typeof mock>).mockImplementation(
+        () => {
+          throw new Error('Sheets API 404');
+        },
+      );
+
+      const expense = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2026-04-15',
+        category: 'X',
+        comment: '',
+        amount: 100,
+        currency: 'EUR',
+        eur_amount: 100,
+      });
+
+      await expect(recorder.deleteFromSheet(groupId, expense)).rejects.toThrow('Sheets API 404');
     });
   });
 });

--- a/src/services/expense-recorder.test.ts
+++ b/src/services/expense-recorder.test.ts
@@ -829,6 +829,33 @@ describe('ExpenseRecorder', () => {
       expect(result.deletedRowIndex).toBeNull();
     });
 
+    it('falls back to current-year sheet for delete when expense year has no registration (symmetric with record)', async () => {
+      // Symmetry with record() fallback: if record() wrote a 2024 expense to
+      // the current-year sheet (because no 2024 registration existed), delete
+      // must look there too — otherwise we'd mark the row "not found", delete
+      // the DB row, and /sync would resurrect it from the still-present row.
+      const { groupId, userId } = seedGroup();
+      // NO setYear(groupId, 2024, ...) — expense's year has no registration
+
+      const expense = expenses.create({
+        group_id: groupId,
+        user_id: userId,
+        date: '2024-07-04',
+        category: 'Trip',
+        comment: 'Paris',
+        amount: 250,
+        currency: 'EUR',
+        eur_amount: 250,
+      });
+
+      await recorder.deleteFromSheet(groupId, expense);
+
+      const call = (mockSheetWriter.findAndDeleteExpenseRow as ReturnType<typeof mock>).mock
+        .calls[0];
+      if (!call) throw new Error('Expected sheet delete call — fallback to current sheet missing');
+      expect(call[1]).toBe('sheet-123'); // current-year fallback
+    });
+
     it('uses the spreadsheet for the expense YEAR, not the group current-year sheet (regression)', async () => {
       // Sheet registered for current year (via seedGroup default). Also register an
       // older year with a DIFFERENT spreadsheet ID — that's the one delete must target.

--- a/src/services/expense-recorder.test.ts
+++ b/src/services/expense-recorder.test.ts
@@ -605,17 +605,28 @@ describe('ExpenseRecorder', () => {
 
       await recorder.pushToSheet(groupId, [e1, e2]);
 
-      // Sheet write called 2 times
-      expect(mockSheetWriter.appendExpenseRow).toHaveBeenCalledTimes(2);
+      // One batched call — not two per-row calls (quota protection)
+      expect(mockSheetWriter.appendExpenseRows).toHaveBeenCalledTimes(1);
+      expect(mockSheetWriter.appendExpenseRow).not.toHaveBeenCalled();
 
       // Uses eurAmount from expense, NOT recalculated
-      const call1 = (mockSheetWriter.appendExpenseRow as ReturnType<typeof mock>).mock.calls[0];
-      if (!call1) throw new Error('Expected sheet write call');
-      expect(call1[2].eurAmount).toBe(8.5); // From DB, not recalculated
+      const call = (mockSheetWriter.appendExpenseRows as ReturnType<typeof mock>).mock.calls[0];
+      if (!call) throw new Error('Expected batched sheet write call');
+      const rows = call[2] as Array<{ eurAmount: number }>;
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.eurAmount).toBe(8.5); // From DB, not recalculated
+      expect(rows[1]?.eurAmount).toBe(43);
 
       // DB count unchanged (still 2)
       const all = expenses.findByGroupId(groupId);
       expect(all).toHaveLength(2);
+    });
+
+    it('is a no-op (no API call) for empty array', async () => {
+      const { groupId } = seedGroup();
+      await recorder.pushToSheet(groupId, []);
+      expect(mockSheetWriter.appendExpenseRows).not.toHaveBeenCalled();
+      expect(mockSheetWriter.appendExpenseRow).not.toHaveBeenCalled();
     });
 
     it('throws when no Google connection (refreshToken null)', async () => {

--- a/src/services/expense-recorder.ts
+++ b/src/services/expense-recorder.ts
@@ -455,26 +455,14 @@ export class ExpenseRecorder implements RecorderApi {
     groupId: number,
     expense: Expense,
   ): Promise<{ deletedRowIndex: number | null }> {
-    const { conn } = this.getGroupConfig(groupId);
-    if (!conn) {
-      return { deletedRowIndex: null };
-    }
-
-    // CRITICAL: resolve the spreadsheet by the expense's YEAR, not the group's
-    // current spreadsheet_id. A user can delete a 2024 expense in 2026 — that
-    // row lives in the 2024 sheet. Using the current-year sheet here would
-    // silently miss, mark the row "not found", delete the DB row, and then
-    // /sync would resurrect it from the 2024 sheet.
-    const year = Number.parseInt(expense.date.slice(0, 4), 10);
-    const spreadsheetId = Number.isFinite(year)
-      ? this.groupSpreadsheets.getByYear(groupId, year)
-      : null;
-
-    if (!spreadsheetId) {
-      logger.warn(
-        { expenseId: expense.id, groupId, year, date: expense.date },
-        '[DELETE] No spreadsheet registered for expense year — skipping sheet delete',
-      );
+    // Resolve the target sheet symmetrically with writes: year-specific if
+    // registered, otherwise fall back to the current-year sheet. Without the
+    // fallback, a 2024 expense written into the current sheet (because there
+    // was no 2024 registration at write time) would be marked "not found in
+    // sheet" on delete, the DB row would be removed, and /sync would then
+    // resurrect it from the still-present row in the current sheet.
+    const { conn, spreadsheetId } = this.resolveWriteConfigForDate(groupId, expense.date);
+    if (!conn || !spreadsheetId) {
       return { deletedRowIndex: null };
     }
 
@@ -487,7 +475,11 @@ export class ExpenseRecorder implements RecorderApi {
     });
 
     logger.info(
-      { expenseId: expense.id, year, spreadsheetId, deletedRowIndex: result.deletedRowIndex },
+      {
+        expenseId: expense.id,
+        spreadsheetId,
+        deletedRowIndex: result.deletedRowIndex,
+      },
       `[DELETE] Sheet row delete attempt`,
     );
 

--- a/src/services/expense-recorder.ts
+++ b/src/services/expense-recorder.ts
@@ -4,6 +4,7 @@ import type { CurrencyCode } from '../config/constants';
 import type { ExpenseRepository } from '../database/repositories/expense.repository';
 import type { ExpenseItemsRepository } from '../database/repositories/expense-items.repository';
 import type { GroupRepository } from '../database/repositories/group.repository';
+import type { GroupSpreadsheetRepository } from '../database/repositories/group-spreadsheet.repository';
 import type { Expense } from '../database/types';
 import { createLogger } from '../utils/logger.ts';
 import type { ExpenseRowData, GoogleConn } from './google/sheets';
@@ -29,6 +30,7 @@ export function getExpenseRecorder(): RecorderApi {
       groups: database.groups,
       expenses: database.expenses,
       expenseItems: database.expenseItems,
+      groupSpreadsheets: database.groupSpreadsheets,
       sheetWriter: { appendExpenseRow, appendExpenseRows, findAndDeleteExpenseRow },
       eurConverter: { convertToEUR, getExchangeRate },
       runInTransaction: (fn: () => void) => database.transaction(fn),
@@ -145,6 +147,11 @@ interface ExpenseRecorderDeps {
   groups: GroupRepository;
   expenses: ExpenseRepository;
   expenseItems: ExpenseItemsRepository;
+  /**
+   * Needed so delete (and future per-year writes) can target the correct
+   * spreadsheet by the expense's year — not the group's current-year sheet.
+   */
+  groupSpreadsheets: GroupSpreadsheetRepository;
   sheetWriter: SheetWriter;
   eurConverter: EurConverter;
   /**
@@ -202,6 +209,7 @@ export class ExpenseRecorder implements RecorderApi {
   private groups: GroupRepository;
   private expenses: ExpenseRepository;
   private expenseItems: ExpenseItemsRepository;
+  private groupSpreadsheets: GroupSpreadsheetRepository;
   private sheetWriter: SheetWriter;
   private eurConverter: EurConverter;
   private runInTransaction: (fn: () => void) => void;
@@ -210,6 +218,7 @@ export class ExpenseRecorder implements RecorderApi {
     this.groups = deps.groups;
     this.expenses = deps.expenses;
     this.expenseItems = deps.expenseItems;
+    this.groupSpreadsheets = deps.groupSpreadsheets;
     this.sheetWriter = deps.sheetWriter;
     this.eurConverter = deps.eurConverter;
     this.runInTransaction = deps.runInTransaction;
@@ -430,9 +439,26 @@ export class ExpenseRecorder implements RecorderApi {
     groupId: number,
     expense: Expense,
   ): Promise<{ deletedRowIndex: number | null }> {
-    const { conn, spreadsheetId } = this.getGroupConfig(groupId);
+    const { conn } = this.getGroupConfig(groupId);
+    if (!conn) {
+      return { deletedRowIndex: null };
+    }
 
-    if (!conn || !spreadsheetId) {
+    // CRITICAL: resolve the spreadsheet by the expense's YEAR, not the group's
+    // current spreadsheet_id. A user can delete a 2024 expense in 2026 — that
+    // row lives in the 2024 sheet. Using the current-year sheet here would
+    // silently miss, mark the row "not found", delete the DB row, and then
+    // /sync would resurrect it from the 2024 sheet.
+    const year = Number.parseInt(expense.date.slice(0, 4), 10);
+    const spreadsheetId = Number.isFinite(year)
+      ? this.groupSpreadsheets.getByYear(groupId, year)
+      : null;
+
+    if (!spreadsheetId) {
+      logger.warn(
+        { expenseId: expense.id, groupId, year, date: expense.date },
+        '[DELETE] No spreadsheet registered for expense year — skipping sheet delete',
+      );
       return { deletedRowIndex: null };
     }
 
@@ -445,7 +471,7 @@ export class ExpenseRecorder implements RecorderApi {
     });
 
     logger.info(
-      { expenseId: expense.id, deletedRowIndex: result.deletedRowIndex },
+      { expenseId: expense.id, year, spreadsheetId, deletedRowIndex: result.deletedRowIndex },
       `[DELETE] Sheet row delete attempt`,
     );
 

--- a/src/services/expense-recorder.ts
+++ b/src/services/expense-recorder.ts
@@ -242,7 +242,10 @@ export class ExpenseRecorder implements RecorderApi {
     userId: number,
     data: RecordExpenseData,
   ): Promise<RecordExpenseResult> {
-    const { conn, spreadsheetId, enabledCurrencies } = this.getGroupConfig(groupId);
+    const { conn, spreadsheetId, enabledCurrencies } = this.resolveWriteConfigForDate(
+      groupId,
+      data.date,
+    );
 
     const rate = this.eurConverter.getExchangeRate(data.currency);
     const eurAmount = this.eurConverter.convertToEUR(data.amount, data.currency);
@@ -309,7 +312,10 @@ export class ExpenseRecorder implements RecorderApi {
       return { expenses: [], categoriesAffected: [] };
     }
 
-    const { conn, spreadsheetId, enabledCurrencies } = this.getGroupConfig(groupId);
+    const { conn, spreadsheetId, enabledCurrencies } = this.resolveWriteConfigForDate(
+      groupId,
+      data.date,
+    );
 
     // Group items by (category, currency). We group by both — not category
     // alone — because a receipt may legitimately contain items in different
@@ -492,29 +498,50 @@ export class ExpenseRecorder implements RecorderApi {
    * Push existing DB expenses to sheet (no new DB entries)
    */
   async pushToSheet(groupId: number, expenseList: Expense[]): Promise<void> {
-    const { conn, spreadsheetId, enabledCurrencies } = this.getGroupConfig(groupId);
-
-    if (!conn || !spreadsheetId) {
+    const base = this.getGroupConfig(groupId);
+    if (!base.conn || !base.spreadsheetId) {
       throw new Error(`Group ${groupId} not connected to Google Sheets`);
     }
 
     if (expenseList.length === 0) return;
 
-    // Single batched append — one API call regardless of row count, so
-    // pushing 500+ expenses (e.g. after /reconnect) doesn't exhaust the
-    // Sheets 60-writes/min/user quota the way a per-row loop would.
-    const rows = expenseList.map((expense) => ({
-      date: expense.date,
-      category: expense.category,
-      comment: expense.comment,
-      amounts: buildAmountsRecord(expense.amount, expense.currency, enabledCurrencies),
-      eurAmount: expense.eur_amount,
-      rate: this.eurConverter.getExchangeRate(expense.currency as CurrencyCode),
-    }));
+    const { conn, enabledCurrencies } = base;
 
-    await this.sheetWriter.appendExpenseRows(conn, spreadsheetId, rows);
+    // Split expenses by their YEAR so each year's rows go to the correct
+    // spreadsheet. Expense list may span multiple years (e.g. /reconnect
+    // after long inactivity, or /push with a custom range).
+    const byYear = new Map<string, Expense[]>();
+    for (const expense of expenseList) {
+      const year = expense.date.slice(0, 4);
+      const arr = byYear.get(year);
+      if (arr) {
+        arr.push(expense);
+      } else {
+        byYear.set(year, [expense]);
+      }
+    }
 
-    logger.info(`[PUSH] Pushed ${expenseList.length} expenses to sheet (1 batched call)`);
+    for (const [year, expenses] of byYear) {
+      const { spreadsheetId: targetSheet } = this.resolveWriteConfigForDate(
+        groupId,
+        `${year}-01-01`,
+      );
+      if (!targetSheet) continue;
+
+      const rows = expenses.map((expense) => ({
+        date: expense.date,
+        category: expense.category,
+        comment: expense.comment,
+        amounts: buildAmountsRecord(expense.amount, expense.currency, enabledCurrencies),
+        eurAmount: expense.eur_amount,
+        rate: this.eurConverter.getExchangeRate(expense.currency as CurrencyCode),
+      }));
+
+      await this.sheetWriter.appendExpenseRows(conn, targetSheet, rows);
+      logger.info(
+        `[PUSH] Pushed ${rows.length} expenses for ${year} to sheet ${targetSheet} (1 batched call)`,
+      );
+    }
   }
 
   private getGroupConfig(groupId: number): {
@@ -536,5 +563,42 @@ export class ExpenseRecorder implements RecorderApi {
       spreadsheetId: group.spreadsheet_id,
       enabledCurrencies: group.enabled_currencies,
     };
+  }
+
+  /**
+   * Resolve sheet config for a WRITE that has a specific date (record,
+   * recordReceipt, pushToSheet). Backdated expenses must land in the
+   * spreadsheet for THEIR year, not the group's current-year sheet —
+   * otherwise a 2024 expense added in 2026 would end up in the 2026 sheet.
+   *
+   * Fallback: if the expense's year has no registered spreadsheet (e.g.
+   * user only started with the bot this year), fall back to the current
+   * spreadsheet so the row isn't silently lost.
+   */
+  private resolveWriteConfigForDate(
+    groupId: number,
+    dateString: string,
+  ): {
+    conn: GoogleConn | null;
+    spreadsheetId: string | null;
+    enabledCurrencies: CurrencyCode[];
+  } {
+    const base = this.getGroupConfig(groupId);
+    const year = Number.parseInt(dateString.slice(0, 4), 10);
+    if (!Number.isFinite(year)) return base;
+
+    const yearSpreadsheetId = this.groupSpreadsheets.getByYear(groupId, year);
+    if (yearSpreadsheetId) {
+      return { ...base, spreadsheetId: yearSpreadsheetId };
+    }
+
+    // No year-specific sheet — fall back to current-year sheet with a warning
+    if (base.spreadsheetId && base.spreadsheetId !== null) {
+      logger.warn(
+        { groupId, date: dateString, year, fallbackSpreadsheetId: base.spreadsheetId },
+        '[RESOLVE] No spreadsheet registered for expense year — writing to current-year sheet',
+      );
+    }
+    return base;
   }
 }

--- a/src/services/expense-recorder.ts
+++ b/src/services/expense-recorder.ts
@@ -18,14 +18,18 @@ export function getExpenseRecorder(): RecorderApi {
   if (!_instance) {
     // Lazy-import to break circular dependency chains
     const { database } = require('../database');
-    const { appendExpenseRow, appendExpenseRows } = require('./google/sheets');
+    const {
+      appendExpenseRow,
+      appendExpenseRows,
+      findAndDeleteExpenseRow,
+    } = require('./google/sheets');
     const { convertToEUR, getExchangeRate } = require('./currency/converter');
 
     _instance = new ExpenseRecorder({
       groups: database.groups,
       expenses: database.expenses,
       expenseItems: database.expenseItems,
-      sheetWriter: { appendExpenseRow, appendExpenseRows },
+      sheetWriter: { appendExpenseRow, appendExpenseRows, findAndDeleteExpenseRow },
       eurConverter: { convertToEUR, getExchangeRate },
       runInTransaction: (fn: () => void) => database.transaction(fn),
     });
@@ -36,15 +40,39 @@ export function getExpenseRecorder(): RecorderApi {
 const logger = createLogger('expense-recorder');
 
 /**
- * Abstraction over Google Sheets append — injected for testability.
+ * Identifying fields used to locate a sheet row when deleting an expense.
+ * EUR amount is intentionally excluded — sheet stores it as a formula, so the
+ * recomputed value can drift from the DB-stored eur_amount across exchange-rate
+ * changes. The four-tuple (date, category, amount, currency) plus comment is
+ * unique enough in practice; if multiple rows match, the first one wins.
+ */
+export interface DeleteRowCriteria {
+  date: string;
+  category: string;
+  comment: string;
+  amount: number;
+  currency: CurrencyCode;
+}
+
+/**
+ * Abstraction over Google Sheets writes — injected for testability.
  * `appendExpenseRow` is used for single-row writes (manual expenses).
  * `appendExpenseRows` is used for multi-row batch writes (receipts) — one API call
  * regardless of row count, so the Google Sheets 60 writes/min/user quota isn't
  * exhausted by large receipts.
+ * `findAndDeleteExpenseRow` removes a single matching row from the sheet —
+ * symmetric counterpart to append, used by AI delete_expense and any future
+ * delete UX. Returns the 1-based row index that was deleted, or null if no
+ * matching row was found.
  */
 export interface SheetWriter {
   appendExpenseRow(conn: GoogleConn, spreadsheetId: string, data: ExpenseRowData): Promise<void>;
   appendExpenseRows(conn: GoogleConn, spreadsheetId: string, rows: ExpenseRowData[]): Promise<void>;
+  findAndDeleteExpenseRow(
+    conn: GoogleConn,
+    spreadsheetId: string,
+    criteria: DeleteRowCriteria,
+  ): Promise<{ deletedRowIndex: number | null }>;
 }
 
 /**
@@ -163,6 +191,7 @@ export interface RecorderApi {
     data: RecordReceiptData,
   ): Promise<RecordReceiptResult>;
   pushToSheet(groupId: number, expenseList: Expense[]): Promise<void>;
+  deleteFromSheet(groupId: number, expense: Expense): Promise<{ deletedRowIndex: number | null }>;
 }
 
 /**
@@ -387,6 +416,40 @@ export class ExpenseRecorder implements RecorderApi {
     );
 
     return { expenses: results, categoriesAffected };
+  }
+
+  /**
+   * Remove a single matching row from Google Sheets — symmetric counterpart
+   * to `record()`. Used by AI delete_expense and any future delete UX.
+   *
+   * No-op (returns deletedRowIndex=null) when the group has no Google connection.
+   * Errors from the sheet layer (404, auth, network) propagate so the caller
+   * can decide whether to still proceed with DB deletion.
+   */
+  async deleteFromSheet(
+    groupId: number,
+    expense: Expense,
+  ): Promise<{ deletedRowIndex: number | null }> {
+    const { conn, spreadsheetId } = this.getGroupConfig(groupId);
+
+    if (!conn || !spreadsheetId) {
+      return { deletedRowIndex: null };
+    }
+
+    const result = await this.sheetWriter.findAndDeleteExpenseRow(conn, spreadsheetId, {
+      date: expense.date,
+      category: expense.category,
+      comment: expense.comment,
+      amount: expense.amount,
+      currency: expense.currency as CurrencyCode,
+    });
+
+    logger.info(
+      { expenseId: expense.id, deletedRowIndex: result.deletedRowIndex },
+      `[DELETE] Sheet row delete attempt`,
+    );
+
+    return result;
   }
 
   /**

--- a/src/services/expense-recorder.ts
+++ b/src/services/expense-recorder.ts
@@ -42,11 +42,21 @@ export function getExpenseRecorder(): RecorderApi {
 const logger = createLogger('expense-recorder');
 
 /**
- * Identifying fields used to locate a sheet row when deleting an expense.
- * EUR amount is intentionally excluded — sheet stores it as a formula, so the
- * recomputed value can drift from the DB-stored eur_amount across exchange-rate
- * changes. The four-tuple (date, category, amount, currency) plus comment is
- * unique enough in practice; if multiple rows match, the first one wins.
+ * Identifying fields used to locate a sheet row when DELETING an expense.
+ *
+ * Notes on fields:
+ * - EUR amount is intentionally excluded — sheet stores it as an INDIRECT
+ *   formula, so the recomputed value can drift from DB-stored eur_amount
+ *   across exchange-rate changes.
+ * - Comment IS included (unlike the dedup key used in sync's
+ *   pushMissingExpensesToSheet, which uses only (date, category, amount,
+ *   currency)). The reason for asymmetry: push-dedup should be fuzzy —
+ *   "don't duplicate-push an expense that's already in the sheet even with
+ *   a different comment". Delete, in contrast, should be precise — "remove
+ *   THIS particular row, not an unrelated expense that happens to share
+ *   date+category+amount".
+ * - If multiple rows match, the first (topmost) one wins. Repeated delete
+ *   calls handle duplicate scenarios naturally.
  */
 export interface DeleteRowCriteria {
   date: string;
@@ -488,21 +498,23 @@ export class ExpenseRecorder implements RecorderApi {
       throw new Error(`Group ${groupId} not connected to Google Sheets`);
     }
 
-    for (const expense of expenseList) {
-      const amounts = buildAmountsRecord(expense.amount, expense.currency, enabledCurrencies);
-      const rate = this.eurConverter.getExchangeRate(expense.currency as CurrencyCode);
+    if (expenseList.length === 0) return;
 
-      await this.sheetWriter.appendExpenseRow(conn, spreadsheetId, {
-        date: expense.date,
-        category: expense.category,
-        comment: expense.comment,
-        amounts,
-        eurAmount: expense.eur_amount,
-        rate,
-      });
-    }
+    // Single batched append — one API call regardless of row count, so
+    // pushing 500+ expenses (e.g. after /reconnect) doesn't exhaust the
+    // Sheets 60-writes/min/user quota the way a per-row loop would.
+    const rows = expenseList.map((expense) => ({
+      date: expense.date,
+      category: expense.category,
+      comment: expense.comment,
+      amounts: buildAmountsRecord(expense.amount, expense.currency, enabledCurrencies),
+      eurAmount: expense.eur_amount,
+      rate: this.eurConverter.getExchangeRate(expense.currency as CurrencyCode),
+    }));
 
-    logger.info(`[PUSH] Pushed ${expenseList.length} expenses to sheet`);
+    await this.sheetWriter.appendExpenseRows(conn, spreadsheetId, rows);
+
+    logger.info(`[PUSH] Pushed ${expenseList.length} expenses to sheet (1 batched call)`);
   }
 
   private getGroupConfig(groupId: number): {

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -518,6 +518,49 @@ describe('findAndDeleteExpenseRow', () => {
     expect(mockSpreadsheetsBatchUpdate).toHaveBeenCalledTimes(1);
   });
 
+  test('serializes concurrent deletes through the per-spreadsheet queue (regression)', async () => {
+    // Two concurrent deletes must not run read-then-delete in parallel —
+    // otherwise both can read the pre-delete row numbers and the second
+    // deleteDimension shifts a stale index, removing the wrong row.
+    // The queue guarantees strict sequencing: second values.get runs only
+    // after the first batchUpdate has resolved.
+    const callOrder: string[] = [];
+
+    mockValuesGet.mockImplementation(async () => {
+      callOrder.push('read');
+      // Small delay lets a racy implementation interleave reads
+      await Bun.sleep(5);
+      return {
+        data: {
+          values: [
+            ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'RSD (дин.)', 'Rate (→EUR)'],
+            ['2026-04-15', 'Алекс', 'Coffee', 4.3, 500, 0.0086],
+          ],
+        },
+      };
+    });
+
+    mockSpreadsheetsBatchUpdate.mockImplementation(async () => {
+      callOrder.push('delete');
+      return { data: {} };
+    });
+
+    const criteria = {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Coffee',
+      amount: 500,
+      currency: 'RSD',
+    };
+
+    const p1 = findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, criteria);
+    const p2 = findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, criteria);
+    await Promise.all([p1, p2]);
+
+    // Expected strict interleaving: read → delete → read → delete
+    expect(callOrder).toEqual(['read', 'delete', 'read', 'delete']);
+  });
+
   test('handles date stored as Sheets serial number (UNFORMATTED_VALUE)', async () => {
     // 2026-04-15 = serial 46127 (days since 1899-12-30)
     mockValuesGet.mockResolvedValueOnce({

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -443,6 +443,34 @@ describe('findAndDeleteExpenseRow', () => {
     expect(mockSpreadsheetsBatchUpdate).not.toHaveBeenCalled();
   });
 
+  test('does NOT match "EUR (calc)" column when looking up EUR currency (regression)', async () => {
+    // Layout where EUR (calc) comes BEFORE the EUR currency column —
+    // defensive against future column reorders.
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'EUR (€)', 'Rate (→EUR)'],
+          // EUR (calc) column holds the computed value 100.  EUR currency column holds 100 too.
+          // Without the fix, findIndex would match "EUR (calc)" first (index 3)
+          // and read the computed EUR from the wrong column.
+          ['2026-04-15', 'Алекс', 'Coffee', 100, 100, 1.0],
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Coffee',
+      amount: 100,
+      currency: 'EUR',
+    });
+
+    // Even with both columns present in the wrong order, the correct row is found.
+    expect(result.deletedRowIndex).toBe(2);
+    expect(mockSpreadsheetsBatchUpdate).toHaveBeenCalledTimes(1);
+  });
+
   test('handles date stored as Sheets serial number (UNFORMATTED_VALUE)', async () => {
     // 2026-04-15 = serial 46127 (days since 1899-12-30)
     mockValuesGet.mockResolvedValueOnce({

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -443,6 +443,53 @@ describe('findAndDeleteExpenseRow', () => {
     expect(mockSpreadsheetsBatchUpdate).not.toHaveBeenCalled();
   });
 
+  test('tolerates float round-trip error for fractional amounts (regression)', async () => {
+    // Sheets round-trip often drifts fractional floats by ~1e-14.
+    // Strict === would miss the row and silently leave it in the sheet.
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'USD ($)', 'Rate (→EUR)'],
+          // criteria.amount = 12.34; sheet returns what Sheets actually stores
+          ['2026-04-15', 'Coffee', 'latte', 10.61, 12.339999999999996, 0.86],
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Coffee',
+      comment: 'latte',
+      amount: 12.34,
+      currency: 'USD',
+    });
+
+    expect(result.deletedRowIndex).toBe(2);
+    expect(mockSpreadsheetsBatchUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test('still rejects amounts that differ by more than half a cent', async () => {
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'USD ($)', 'Rate (→EUR)'],
+          ['2026-04-15', 'Coffee', 'latte', 10.61, 12.35, 0.86],
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Coffee',
+      comment: 'latte',
+      amount: 12.34, // sheet has 12.35 — a real different amount
+      currency: 'USD',
+    });
+
+    expect(result.deletedRowIndex).toBeNull();
+    expect(mockSpreadsheetsBatchUpdate).not.toHaveBeenCalled();
+  });
+
   test('does NOT match "EUR (calc)" column when looking up EUR currency (regression)', async () => {
     // Layout where EUR (calc) comes BEFORE the EUR currency column —
     // defensive against future column reorders.

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -5,7 +5,7 @@ import type { GoogleConn } from './sheets';
 // ── Mock googleapis sheets client ─────────────────────────────────────────────
 
 interface ValuesGetResponse {
-  data: { values: string[][] };
+  data: { values: unknown[][] };
 }
 interface ValuesAppendResponse {
   data: { updates: { updatedRange: string; updatedRows: number } };
@@ -61,7 +61,12 @@ mock.module('./oauth', () => ({
   isTokenExpiredError: () => false,
 }));
 
-import { appendExpenseRows, isRateLimitError, withSheetsRetry } from './sheets';
+import {
+  appendExpenseRows,
+  findAndDeleteExpenseRow,
+  isRateLimitError,
+  withSheetsRetry,
+} from './sheets';
 
 const TEST_CONN: GoogleConn = { refreshToken: 'token', oauthClient: 'legacy' };
 const TEST_SPREADSHEET = 'sheet-123';
@@ -322,6 +327,142 @@ describe('appendExpenseRows', () => {
 
     await Promise.all([p1, p2]);
     expect(mockValuesAppend).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── findAndDeleteExpenseRow ────────────────────────────────────────────────
+
+describe('findAndDeleteExpenseRow', () => {
+  beforeEach(() => {
+    mockSpreadsheetsBatchUpdate.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  test('finds matching row and deletes via batchUpdate; returns 1-based row index', async () => {
+    // Headers row + 3 data rows. The match is on row 3 (1-based: header=1, data start=2).
+    // Headers: Дата | Категория | Комментарий | EUR (calc) | RSD (дин.) | Rate (→EUR)
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'RSD (дин.)', 'Rate (→EUR)'],
+          ['2026-04-15', 'Алекс', 'Кофе', '4.3', 500, 0.0086], // row 2
+          ['2026-04-15', 'Алекс', 'Ноут для умного дома', '348.5', 41000, 0.0085], // row 3 — match
+          ['2026-04-15', 'Еда', 'Пицца', '8.5', 1000, 0.0085], // row 4
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Ноут для умного дома',
+      amount: 41000,
+      currency: 'RSD',
+    });
+
+    expect(result.deletedRowIndex).toBe(3);
+    expect(mockSpreadsheetsBatchUpdate).toHaveBeenCalledTimes(1);
+    const call = mockSpreadsheetsBatchUpdate.mock.calls[0]?.[0] as {
+      requestBody: {
+        requests: Array<{
+          deleteDimension: { range: { dimension: string; startIndex: number; endIndex: number } };
+        }>;
+      };
+    };
+    const req = call.requestBody.requests[0];
+    expect(req?.deleteDimension.range.dimension).toBe('ROWS');
+    expect(req?.deleteDimension.range.startIndex).toBe(2); // 0-based: row 3 -> startIndex 2
+    expect(req?.deleteDimension.range.endIndex).toBe(3);
+  });
+
+  test('returns deletedRowIndex=null when no row matches', async () => {
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'RSD (дин.)', 'Rate (→EUR)'],
+          ['2026-04-15', 'Еда', 'Пицца', '8.5', 1000, 0.0085],
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Ноут для умного дома',
+      amount: 41000,
+      currency: 'RSD',
+    });
+
+    expect(result.deletedRowIndex).toBeNull();
+    expect(mockSpreadsheetsBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('matches first row when multiple identical rows exist (delete-one-per-call semantics)', async () => {
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'RSD (дин.)', 'Rate (→EUR)'],
+          ['2026-04-15', 'Алекс', 'Ноут', '348.5', 41000, 0.0085], // row 2 — first match
+          ['2026-04-15', 'Алекс', 'Ноут', '348.5', 41000, 0.0085], // row 3 — also matches
+          ['2026-04-15', 'Алекс', 'Ноут', '348.5', 41000, 0.0085], // row 4 — also matches
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Ноут',
+      amount: 41000,
+      currency: 'RSD',
+    });
+
+    // First match (row 2) is deleted — repeated calls handle dups
+    expect(result.deletedRowIndex).toBe(2);
+    expect(mockSpreadsheetsBatchUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not match if comment differs (avoids deleting unrelated expense)', async () => {
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'RSD (дин.)', 'Rate (→EUR)'],
+          ['2026-04-15', 'Алекс', 'Совершенно другой расход', '348.5', 41000, 0.0085],
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Ноут',
+      amount: 41000,
+      currency: 'RSD',
+    });
+
+    expect(result.deletedRowIndex).toBeNull();
+    expect(mockSpreadsheetsBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('handles date stored as Sheets serial number (UNFORMATTED_VALUE)', async () => {
+    // 2026-04-15 = serial 46127 (days since 1899-12-30)
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Дата', 'Категория', 'Комментарий', 'EUR (calc)', 'RSD (дин.)', 'Rate (→EUR)'],
+          [46127, 'Алекс', 'Ноут', '348.5', 41000, 0.0085],
+        ],
+      },
+    });
+
+    const result = await findAndDeleteExpenseRow(TEST_CONN, TEST_SPREADSHEET, {
+      date: '2026-04-15',
+      category: 'Алекс',
+      comment: 'Ноут',
+      amount: 41000,
+      currency: 'RSD',
+    });
+
+    expect(result.deletedRowIndex).toBe(2);
   });
 });
 

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -1330,6 +1330,29 @@ export async function findAndDeleteExpenseRow(
     currency: string;
   },
 ): Promise<{ deletedRowIndex: number | null }> {
+  // Serialize with other operations on this spreadsheet. Without this, two
+  // concurrent deletes can both read the same pre-delete row indices; the
+  // first deleteDimension shifts row numbers, and the second batchUpdate
+  // ends up targeting a stale index — removing the wrong row. Appends use
+  // the same queue for the same reason (row-relative EUR formulas).
+  let capturedResult: { deletedRowIndex: number | null } = { deletedRowIndex: null };
+  await enqueueSheetWrite(spreadsheetId, async () => {
+    capturedResult = await findAndDeleteExpenseRowImpl(conn, spreadsheetId, criteria);
+  });
+  return capturedResult;
+}
+
+async function findAndDeleteExpenseRowImpl(
+  conn: GoogleConn,
+  spreadsheetId: string,
+  criteria: {
+    date: string;
+    category: string;
+    comment: string;
+    amount: number;
+    currency: string;
+  },
+): Promise<{ deletedRowIndex: number | null }> {
   const auth = authClient(conn);
   const sheets = google.sheets({ version: 'v4', auth });
 

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -1381,7 +1381,13 @@ export async function findAndDeleteExpenseRow(
     const cellAmount = row[currencyCol];
     const numAmount =
       typeof cellAmount === 'number' ? cellAmount : Number.parseFloat(String(cellAmount ?? ''));
-    if (!Number.isFinite(numAmount) || numAmount !== criteria.amount) continue;
+    // Epsilon 0.005 = half of the smallest unit for 2-decimal currencies
+    // (cents/копейки). Float round-trip through Sheets can drift by ~1e-14
+    // for fractional values like $12.34; strict equality here would miss
+    // those rows and leave them in the sheet, re-importable via /sync.
+    // The gap between any two realistic neighboring sums (12.34 vs 12.35)
+    // is 0.01 > 0.005, so false positives are impossible.
+    if (!Number.isFinite(numAmount) || Math.abs(numAmount - criteria.amount) > 0.005) continue;
 
     // Match — delete this row (1-based for the public interface).
     const oneBasedRowIndex = i + 1;

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -1295,6 +1295,102 @@ export async function appendExpenseRowsRaw(
  * Sorted and processed in reverse order to avoid index shifting.
  * Uses the Expenses tab's sheetId (resolved from spreadsheet metadata).
  */
+/**
+ * Convert a sheet date cell to ISO yyyy-MM-dd. Handles two storage shapes:
+ *   - UNFORMATTED_VALUE: the date is a Sheets serial number (days since 1899-12-30)
+ *   - formatted string: already ISO-shaped (e.g. "2026-04-15")
+ */
+function normalizeSheetDate(cell: unknown): string {
+  if (typeof cell === 'number' && Number.isFinite(cell) && cell > 25569 && cell < 99999) {
+    const date = new Date((cell - 25569) * 86400 * 1000);
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(date.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+  return String(cell ?? '');
+}
+
+/**
+ * Find the FIRST sheet row matching all criteria fields, delete it, and return
+ * the 1-based row index. Returns `{ deletedRowIndex: null }` if no row matches.
+ *
+ * Matching uses (date, category, comment, amount-in-currency-column). Multiple
+ * matches are intentional: caller deletes one row per call, so repeated calls
+ * naturally clean up duplicates.
+ */
+export async function findAndDeleteExpenseRow(
+  conn: GoogleConn,
+  spreadsheetId: string,
+  criteria: {
+    date: string;
+    category: string;
+    comment: string;
+    amount: number;
+    currency: string;
+  },
+): Promise<{ deletedRowIndex: number | null }> {
+  const auth = authClient(conn);
+  const sheets = google.sheets({ version: 'v4', auth });
+
+  // UNFORMATTED_VALUE so amounts come as numbers (not locale-formatted strings)
+  // and dates as serial numbers (which we normalize back to ISO).
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${EXPENSES_TAB}!A:Z`,
+    valueRenderOption: 'UNFORMATTED_VALUE',
+  });
+
+  const rows = response.data.values ?? [];
+  if (rows.length < 2) return { deletedRowIndex: null };
+
+  const headers = (rows[0] ?? []) as string[];
+  const dateCol = headers.indexOf(SPREADSHEET_CONFIG.headers[0] ?? '');
+  const categoryCol = headers.indexOf(SPREADSHEET_CONFIG.headers[1] ?? '');
+  const commentCol = headers.indexOf(SPREADSHEET_CONFIG.headers[2] ?? '');
+  const currencyCol = headers.findIndex((h) => h.startsWith(`${criteria.currency} `));
+
+  if (dateCol === -1 || categoryCol === -1 || commentCol === -1 || currencyCol === -1) {
+    logger.warn(
+      {
+        dateCol,
+        categoryCol,
+        commentCol,
+        currencyCol,
+        currency: criteria.currency,
+      },
+      '[SHEETS] findAndDeleteExpenseRow: required column not found',
+    );
+    return { deletedRowIndex: null };
+  }
+
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i] as unknown[];
+    if (!row) continue;
+
+    const rowDate = normalizeSheetDate(row[dateCol]);
+    if (rowDate !== criteria.date) continue;
+    if (String(row[categoryCol] ?? '') !== criteria.category) continue;
+    if (String(row[commentCol] ?? '') !== criteria.comment) continue;
+
+    const cellAmount = row[currencyCol];
+    const numAmount =
+      typeof cellAmount === 'number' ? cellAmount : Number.parseFloat(String(cellAmount ?? ''));
+    if (!Number.isFinite(numAmount) || numAmount !== criteria.amount) continue;
+
+    // Match — delete this row (1-based for the public interface).
+    const oneBasedRowIndex = i + 1;
+    await deleteExpenseRowsByIndex(conn, spreadsheetId, [oneBasedRowIndex]);
+    logger.info(
+      { spreadsheetId, rowIndex: oneBasedRowIndex, criteria },
+      '[SHEETS] findAndDeleteExpenseRow: deleted row',
+    );
+    return { deletedRowIndex: oneBasedRowIndex };
+  }
+
+  return { deletedRowIndex: null };
+}
+
 export async function deleteExpenseRowsByIndex(
   conn: GoogleConn,
   spreadsheetId: string,

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -1348,7 +1348,12 @@ export async function findAndDeleteExpenseRow(
   const dateCol = headers.indexOf(SPREADSHEET_CONFIG.headers[0] ?? '');
   const categoryCol = headers.indexOf(SPREADSHEET_CONFIG.headers[1] ?? '');
   const commentCol = headers.indexOf(SPREADSHEET_CONFIG.headers[2] ?? '');
-  const currencyCol = headers.findIndex((h) => h.startsWith(`${criteria.currency} `));
+  // `startsWith("EUR ")` alone would also match "EUR (calc)" — the computed
+  // EUR column, not the EUR currency column. Exclude it explicitly so the
+  // match is column-order-independent.
+  const currencyCol = headers.findIndex(
+    (h) => h.startsWith(`${criteria.currency} `) && h !== SPREADSHEET_CONFIG.eurColumnHeader,
+  );
 
   if (dateCol === -1 || categoryCol === -1 || commentCol === -1 || currencyCol === -1) {
     logger.warn(

--- a/src/services/google/spreadsheet-repair.test.ts
+++ b/src/services/google/spreadsheet-repair.test.ts
@@ -1,0 +1,296 @@
+// Tests for spreadsheet-repair: classify sheet errors, audit access, recreate lost sheets
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { CurrencyCode } from '../../config/constants';
+import type { Budget, Expense } from '../../database/types';
+import { OAuthError } from '../../errors';
+import type { GoogleConn } from './sheets';
+import {
+  auditAllYears,
+  classifySheetError,
+  type RecreateDeps,
+  recreateLostSpreadsheets,
+  recreateSpreadsheet,
+} from './spreadsheet-repair';
+
+describe('classifySheetError', () => {
+  test('classifies 404 (file not found / no access) — common after scope downgrade', () => {
+    const err = {
+      code: 404,
+      response: {
+        data: {
+          error: {
+            code: 404,
+            errors: [{ reason: 'notFound', message: 'File not found: abc123.' }],
+          },
+        },
+      },
+    };
+    const result = classifySheetError(err);
+    expect(result.status).toBe('not_found');
+    expect(result.errorMessage).toContain('not found');
+  });
+
+  test('classifies 403 (forbidden)', () => {
+    const err = {
+      code: 403,
+      response: { data: { error: { code: 403, message: 'The caller does not have permission' } } },
+    };
+    const result = classifySheetError(err);
+    expect(result.status).toBe('forbidden');
+  });
+
+  test('classifies OAuth token expiry', () => {
+    const err = new OAuthError('Token revoked', 'TOKEN_EXPIRED');
+    const result = classifySheetError(err);
+    expect(result.status).toBe('token_expired');
+  });
+
+  test('classifies unknown errors as unknown_error with the message preserved', () => {
+    const err = new Error('ECONNRESET — network glitch');
+    const result = classifySheetError(err);
+    expect(result.status).toBe('unknown_error');
+    expect(result.errorMessage).toContain('ECONNRESET');
+  });
+
+  test('classifies non-Error values without throwing', () => {
+    expect(classifySheetError(null).status).toBe('unknown_error');
+    expect(classifySheetError(undefined).status).toBe('unknown_error');
+    expect(classifySheetError('plain string').status).toBe('unknown_error');
+  });
+});
+
+describe('auditAllYears', () => {
+  const conn: GoogleConn = { refreshToken: 'tok', oauthClient: 'current' };
+
+  test('classifies each spreadsheet via the probe and preserves order', async () => {
+    const probe = mock(async (_c: GoogleConn, id: string) => {
+      if (id === 'good-2025') return;
+      if (id === 'lost-2026') {
+        throw {
+          code: 404,
+          response: { data: { error: { code: 404, errors: [{ reason: 'notFound' }] } } },
+        };
+      }
+      throw new Error('boom');
+    });
+
+    const result = await auditAllYears(probe, conn, [
+      { year: 2025, spreadsheetId: 'good-2025' },
+      { year: 2026, spreadsheetId: 'lost-2026' },
+      { year: 2027, spreadsheetId: 'flaky-2027' },
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ year: 2025, spreadsheetId: 'good-2025', status: 'ok' });
+    expect(result[1]?.year).toBe(2026);
+    expect(result[1]?.status).toBe('not_found');
+    expect(result[2]?.year).toBe(2027);
+    expect(result[2]?.status).toBe('unknown_error');
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  test('returns empty array for empty input without calling probe', async () => {
+    const probe = mock(async () => {});
+    const result = await auditAllYears(probe, conn, []);
+    expect(result).toEqual([]);
+    expect(probe).not.toHaveBeenCalled();
+  });
+});
+
+describe('recreateSpreadsheet', () => {
+  const conn: GoogleConn = { refreshToken: 'tok', oauthClient: 'current' };
+  const group = {
+    id: 1,
+    default_currency: 'RSD' as CurrencyCode,
+    enabled_currencies: ['EUR', 'RSD'] as CurrencyCode[],
+  };
+
+  function buildDeps(overrides: Partial<RecreateDeps> = {}): RecreateDeps {
+    return {
+      createExpenseSpreadsheet: mock(async () => ({
+        spreadsheetId: 'NEW-2026',
+        spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/NEW-2026',
+      })),
+      appendExpenseRows: mock(async () => {}),
+      writeMonthBudgetRow: mock(async () => {}),
+      loadExpensesForYear: mock((): Expense[] => []),
+      loadBudgetsForYear: mock((): Budget[] => []),
+      setSpreadsheetIdForYear: mock(() => {}),
+      getExchangeRate: mock(() => 0.0085),
+      ...overrides,
+    };
+  }
+
+  test('creates new sheet, updates DB pointer, returns RecreateResult', async () => {
+    const deps = buildDeps();
+
+    const result = await recreateSpreadsheet(deps, conn, group, {
+      year: 2026,
+      spreadsheetId: 'OLD-2026',
+      status: 'not_found',
+    });
+
+    expect(result.year).toBe(2026);
+    expect(result.oldSpreadsheetId).toBe('OLD-2026');
+    expect(result.newSpreadsheetId).toBe('NEW-2026');
+    expect(result.newSpreadsheetUrl).toBe('https://docs.google.com/spreadsheets/d/NEW-2026');
+    expect(result.expensesCopied).toBe(0);
+    expect(result.budgetsCopied).toBe(0);
+
+    expect(deps.createExpenseSpreadsheet).toHaveBeenCalledWith(conn, 'RSD', ['EUR', 'RSD']);
+    expect(deps.setSpreadsheetIdForYear).toHaveBeenCalledWith(1, 2026, 'NEW-2026');
+  });
+
+  test('copies expenses for the lost year into the new sheet', async () => {
+    const expenses: Expense[] = [
+      {
+        id: 1,
+        group_id: 1,
+        user_id: 1,
+        date: '2026-04-15',
+        category: 'Алекс',
+        comment: 'Ноут',
+        amount: 41000,
+        currency: 'RSD',
+        eur_amount: 348.5,
+        receipt_id: null,
+        receipt_file_id: null,
+        created_at: '',
+      },
+      {
+        id: 2,
+        group_id: 1,
+        user_id: 1,
+        date: '2026-04-16',
+        category: 'Еда',
+        comment: 'Пицца',
+        amount: 1000,
+        currency: 'RSD',
+        eur_amount: 8.5,
+        receipt_id: null,
+        receipt_file_id: null,
+        created_at: '',
+      },
+    ];
+
+    const deps = buildDeps({
+      loadExpensesForYear: mock(() => expenses),
+    });
+
+    const result = await recreateSpreadsheet(deps, conn, group, {
+      year: 2026,
+      spreadsheetId: 'OLD-2026',
+      status: 'not_found',
+    });
+
+    expect(result.expensesCopied).toBe(2);
+    expect(deps.appendExpenseRows).toHaveBeenCalledTimes(1);
+    const call = (deps.appendExpenseRows as ReturnType<typeof mock>).mock.calls[0];
+    if (!call) throw new Error('Expected appendExpenseRows call');
+    expect(call[0]).toEqual(conn);
+    expect(call[1]).toBe('NEW-2026');
+    const rows = call[2] as Array<{
+      date: string;
+      category: string;
+      amounts: Record<string, unknown>;
+    }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.amounts['RSD']).toBe(41000);
+    expect(rows[0]?.amounts['EUR']).toBeNull();
+  });
+
+  test('copies budgets for the lost year, one writeMonthBudgetRow per budget', async () => {
+    const budgets: Budget[] = [
+      {
+        id: 1,
+        group_id: 1,
+        category: 'Алекс',
+        month: '2026-04',
+        limit_amount: 700,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+      {
+        id: 2,
+        group_id: 1,
+        category: 'Еда',
+        month: '2026-04',
+        limit_amount: 500,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+      {
+        id: 3,
+        group_id: 1,
+        category: 'Транспорт',
+        month: '2026-05',
+        limit_amount: 100,
+        currency: 'EUR',
+        created_at: '',
+        updated_at: '',
+      },
+    ];
+    const deps = buildDeps({ loadBudgetsForYear: mock(() => budgets) });
+
+    const result = await recreateSpreadsheet(deps, conn, group, {
+      year: 2026,
+      spreadsheetId: 'OLD-2026',
+      status: 'not_found',
+    });
+
+    expect(result.budgetsCopied).toBe(3);
+    expect(result.budgetTabsCreated).toEqual(['Apr', 'May']);
+    expect(deps.writeMonthBudgetRow).toHaveBeenCalledTimes(3);
+  });
+
+  test('recreateLostSpreadsheets only recreates not_found and forbidden, skips ok and others', async () => {
+    let creates = 0;
+    const deps = buildDeps({
+      createExpenseSpreadsheet: mock(async () => {
+        creates++;
+        return {
+          spreadsheetId: `NEW-${creates}`,
+          spreadsheetUrl: `https://docs.google.com/spreadsheets/d/NEW-${creates}`,
+        };
+      }),
+    });
+
+    const audits = [
+      { year: 2024, spreadsheetId: 'OK-2024', status: 'ok' as const },
+      { year: 2025, spreadsheetId: 'LOST-2025', status: 'not_found' as const },
+      { year: 2026, spreadsheetId: 'FORBIDDEN-2026', status: 'forbidden' as const },
+      { year: 2027, spreadsheetId: 'TX-2027', status: 'token_expired' as const },
+      { year: 2028, spreadsheetId: 'WTF-2028', status: 'unknown_error' as const },
+    ];
+
+    const results = await recreateLostSpreadsheets(deps, conn, group, audits);
+
+    // Only 2025 and 2026 should be recreated
+    expect(results).toHaveLength(2);
+    expect(results[0]?.year).toBe(2025);
+    expect(results[1]?.year).toBe(2026);
+    expect(deps.createExpenseSpreadsheet).toHaveBeenCalledTimes(2);
+  });
+
+  test('does NOT update DB pointer if createExpenseSpreadsheet fails', async () => {
+    const deps = buildDeps({
+      createExpenseSpreadsheet: mock(() => {
+        throw new Error('Drive quota exceeded');
+      }),
+    });
+
+    await expect(
+      recreateSpreadsheet(deps, conn, group, {
+        year: 2026,
+        spreadsheetId: 'OLD-2026',
+        status: 'not_found',
+      }),
+    ).rejects.toThrow('Drive quota exceeded');
+
+    expect(deps.setSpreadsheetIdForYear).not.toHaveBeenCalled();
+    expect(deps.appendExpenseRows).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/google/spreadsheet-repair.ts
+++ b/src/services/google/spreadsheet-repair.ts
@@ -1,0 +1,236 @@
+// Audit and recreate Google spreadsheets that the bot has lost access to
+// (file deleted, scope downgraded, permission revoked, etc.).
+
+import type { CurrencyCode } from '../../config/constants';
+import type { Budget, Expense } from '../../database/types';
+import { OAuthError } from '../../errors';
+import { buildAmountsRecord } from '../expense-recorder';
+import { type MonthAbbr, monthAbbrFromYYYYMM } from './month-abbr';
+import type { ExpenseRowData, GoogleConn } from './sheets';
+
+/**
+ * Classification of why we can't reach a spreadsheet:
+ *   - ok            — accessible
+ *   - not_found     — Drive returned 404 (file deleted, never created, or
+ *                     drive.file scope can't see it)
+ *   - forbidden     — Drive returned 403 (permission denied without ambiguity)
+ *   - token_expired — refresh token revoked / expired
+ *   - unknown_error — anything else (network, 5xx, malformed response)
+ */
+export type SpreadsheetAccessStatus =
+  | 'ok'
+  | 'not_found'
+  | 'forbidden'
+  | 'token_expired'
+  | 'unknown_error';
+
+interface SpreadsheetAccessResult {
+  status: SpreadsheetAccessStatus;
+  errorMessage?: string;
+}
+
+interface GaxiosLike {
+  code?: number | string;
+  status?: number | string;
+  message?: string;
+  response?: {
+    data?: {
+      error?: {
+        code?: number;
+        message?: string;
+        errors?: Array<{ reason?: string; message?: string }>;
+      };
+    };
+  };
+}
+
+/**
+ * Map a sheets-API error to a SpreadsheetAccessStatus. Pure function — no I/O.
+ */
+export function classifySheetError(err: unknown): SpreadsheetAccessResult {
+  if (err instanceof OAuthError) {
+    return { status: 'token_expired', errorMessage: err.message };
+  }
+
+  if (err === null || err === undefined || typeof err === 'string') {
+    return { status: 'unknown_error', errorMessage: typeof err === 'string' ? err : 'Unknown' };
+  }
+
+  const e = err as GaxiosLike;
+  const code = Number(e.code ?? e.status ?? e.response?.data?.error?.code ?? 0);
+  const reason = e.response?.data?.error?.errors?.[0]?.reason;
+  const message =
+    e.response?.data?.error?.message ?? e.message ?? (err instanceof Error ? err.message : '');
+
+  if (code === 404 || reason === 'notFound') {
+    return { status: 'not_found', errorMessage: message || 'File not found' };
+  }
+  if (code === 403 || reason === 'forbidden') {
+    return { status: 'forbidden', errorMessage: message || 'Permission denied' };
+  }
+
+  return { status: 'unknown_error', errorMessage: message || 'Unknown error' };
+}
+
+export interface AuditEntry {
+  year: number;
+  spreadsheetId: string;
+  status: SpreadsheetAccessStatus;
+  errorMessage?: string;
+}
+
+/**
+ * Probe function: should attempt the cheapest reachable sheets call (e.g.
+ * `spreadsheets.get`) and resolve normally on success, throw on any failure.
+ * Injected so callers can test without a live Sheets API.
+ */
+type SpreadsheetAccessProbe = (conn: GoogleConn, spreadsheetId: string) => Promise<unknown>;
+
+/**
+ * Run the access probe for each (year, spreadsheetId) pair sequentially and
+ * classify each result. Sequential — not parallel — to avoid hammering the
+ * Google API with N parallel requests when a group has many years configured.
+ */
+export async function auditAllYears(
+  probe: SpreadsheetAccessProbe,
+  conn: GoogleConn,
+  spreadsheets: { year: number; spreadsheetId: string }[],
+): Promise<AuditEntry[]> {
+  const results: AuditEntry[] = [];
+  for (const { year, spreadsheetId } of spreadsheets) {
+    try {
+      await probe(conn, spreadsheetId);
+      results.push({ year, spreadsheetId, status: 'ok' });
+    } catch (err) {
+      const { status, errorMessage } = classifySheetError(err);
+      const entry: AuditEntry = { year, spreadsheetId, status };
+      if (errorMessage !== undefined) entry.errorMessage = errorMessage;
+      results.push(entry);
+    }
+  }
+  return results;
+}
+
+export interface RecreateResult {
+  year: number;
+  oldSpreadsheetId: string;
+  newSpreadsheetId: string;
+  newSpreadsheetUrl: string;
+  expensesCopied: number;
+  budgetsCopied: number;
+  budgetTabsCreated: MonthAbbr[];
+}
+
+/**
+ * Dependencies for recreate. Each side-effect is injected so the function
+ * is testable without a live Sheets API or DB. In production, callers wire
+ * these to `sheets.ts` exports + `database` repositories.
+ */
+export interface RecreateDeps {
+  createExpenseSpreadsheet(
+    conn: GoogleConn,
+    defaultCurrency: CurrencyCode,
+    enabledCurrencies: CurrencyCode[],
+  ): Promise<{ spreadsheetId: string; spreadsheetUrl: string }>;
+  appendExpenseRows(conn: GoogleConn, spreadsheetId: string, rows: ExpenseRowData[]): Promise<void>;
+  writeMonthBudgetRow(
+    conn: GoogleConn,
+    spreadsheetId: string,
+    month: MonthAbbr,
+    row: { category: string; limit: number; currency: CurrencyCode },
+  ): Promise<void>;
+  loadExpensesForYear(groupId: number, year: number): Expense[];
+  loadBudgetsForYear(groupId: number, year: number): Budget[];
+  setSpreadsheetIdForYear(groupId: number, year: number, spreadsheetId: string): void;
+  getExchangeRate(currency: CurrencyCode): number;
+}
+
+/**
+ * Recreate a single lost spreadsheet for the given year:
+ *   1. Create a fresh spreadsheet (so drive.file scope owns it definitively).
+ *   2. Copy all DB expenses for that year into the new sheet (one batched
+ *      append per call — relies on appendExpenseRows being already chunk-aware
+ *      and quota-friendly).
+ *   3. Copy all DB budgets for that year, one writeMonthBudgetRow per row
+ *      (writeMonthBudgetRow auto-creates month tabs as needed).
+ *   4. Update the DB pointer in `group_spreadsheets` to the new ID.
+ *
+ * The DB pointer update happens LAST so any failure mid-recreate leaves the
+ * old (broken) ID in place — re-running /repair just retries.
+ */
+export async function recreateSpreadsheet(
+  deps: RecreateDeps,
+  conn: GoogleConn,
+  group: { id: number; default_currency: CurrencyCode; enabled_currencies: CurrencyCode[] },
+  audit: AuditEntry,
+): Promise<RecreateResult> {
+  const { spreadsheetId: newId, spreadsheetUrl } = await deps.createExpenseSpreadsheet(
+    conn,
+    group.default_currency,
+    group.enabled_currencies,
+  );
+
+  const expenses = deps.loadExpensesForYear(group.id, audit.year);
+  if (expenses.length > 0) {
+    const rows: ExpenseRowData[] = expenses.map((e) => {
+      const currency = e.currency as CurrencyCode;
+      return {
+        date: e.date,
+        category: e.category,
+        comment: e.comment,
+        amounts: buildAmountsRecord(e.amount, currency, group.enabled_currencies),
+        eurAmount: e.eur_amount,
+        rate: deps.getExchangeRate(currency),
+      };
+    });
+    await deps.appendExpenseRows(conn, newId, rows);
+  }
+
+  const budgets = deps.loadBudgetsForYear(group.id, audit.year);
+  const budgetTabsCreated: MonthAbbr[] = [];
+  const seenTabs = new Set<MonthAbbr>();
+  for (const b of budgets) {
+    const month = monthAbbrFromYYYYMM(b.month);
+    if (!seenTabs.has(month)) {
+      seenTabs.add(month);
+      budgetTabsCreated.push(month);
+    }
+    await deps.writeMonthBudgetRow(conn, newId, month, {
+      category: b.category,
+      limit: b.limit_amount,
+      currency: b.currency as CurrencyCode,
+    });
+  }
+
+  // Persist the new pointer LAST — only if the data made it across.
+  deps.setSpreadsheetIdForYear(group.id, audit.year, newId);
+
+  return {
+    year: audit.year,
+    oldSpreadsheetId: audit.spreadsheetId,
+    newSpreadsheetId: newId,
+    newSpreadsheetUrl: spreadsheetUrl,
+    expensesCopied: expenses.length,
+    budgetsCopied: budgets.length,
+    budgetTabsCreated,
+  };
+}
+
+/**
+ * Recreate every spreadsheet whose audit status indicates it's unreachable
+ * (`not_found` or `forbidden`). Sequential to keep Drive quota usage modest
+ * and so a partial failure surfaces before kicking off the next year.
+ */
+export async function recreateLostSpreadsheets(
+  deps: RecreateDeps,
+  conn: GoogleConn,
+  group: { id: number; default_currency: CurrencyCode; enabled_currencies: CurrencyCode[] },
+  audits: AuditEntry[],
+): Promise<RecreateResult[]> {
+  const results: RecreateResult[] = [];
+  for (const audit of audits) {
+    if (audit.status !== 'not_found' && audit.status !== 'forbidden') continue;
+    results.push(await recreateSpreadsheet(deps, conn, group, audit));
+  }
+  return results;
+}

--- a/src/web/miniapp-api.test.ts
+++ b/src/web/miniapp-api.test.ts
@@ -153,6 +153,7 @@ const mockGetExpenseRecorder = mock(
     record: mockExpenseRecorderRecord,
     recordReceipt: mockExpenseRecorderRecordReceipt,
     pushToSheet: () => Promise.resolve(),
+    deleteFromSheet: () => Promise.resolve({ deletedRowIndex: null }),
   }),
 );
 const mockEmitForGroup = mock((_groupId: number, _eventType: SseEventType): void => {});


### PR DESCRIPTION
## Summary

Two related bugfixes around Google Sheets sync:

1. **`delete_expense` in the AI agent now actually deletes the matching row from the spreadsheet** — not just the DB row.
   Previously, the AI told the user "Note: run /sync to update Google Sheets", but `/sync` is bidirectional add-only on the sheet→DB pass: any row in the sheet but absent from the DB gets re-created. So deleted-from-DB-only expenses kept resurrecting on every auto-sync. New `findAndDeleteExpenseRow` in sheets.ts + `deleteFromSheet` on `ExpenseRecorder` make the operation symmetric.

2. **`/reconnect` self-heals when the bot has lost access to the spreadsheet.**
   Real scenario from prod logs: after switching OAuth scope from `drive` to `drive.file`, the new refresh token returned 404 on every call to the existing `1ioTRZJ...` spreadsheet. Backup, sync, AI tools — all dead. The user was told to "try /sync later" but /sync also failed.

   New `spreadsheet-repair` service:
   - audits every (year, spreadsheet_id) registered for the group
   - classifies each as ok / not_found / forbidden / token_expired / unknown_error
   - recreates each unreachable one: fresh `createExpenseSpreadsheet` (so the new token's `drive.file` scope owns it), then repopulates from the local DB (expenses + per-month budgets)
   - updates `group_spreadsheets` only after data is in place — partial failure is recoverable via /repair
   - sends a user-friendly report with reason hints and links to the new sheets

   Also exposes `/repair` as a manual entry point (no OAuth flow needed) for users who didn't trigger /reconnect — e.g. someone who deleted the sheet by hand.

Old spreadsheets stay in Drive — bot tells the user to delete them manually if they want.

## How it fixes the production incident

- Old `1ioTRZJ...` 2026 spreadsheet → audit returns `not_found` → recreated as a new `NEW-2026` sheet, all 491 DB expenses + 78 budgets repopulated. User keeps everything.
- The 4 leftover dup rows in the old sheet (the `delete_expense` regression) → not migrated, because the DB only has 1 expense for that key. Fix 1 ensures future deletes are symmetric so this stops happening.

## Test plan

- [x] All 2370 existing tests still pass; 26 new tests cover the new modules
- [x] `findAndDeleteExpenseRow` unit-tested with row-not-found, multi-match (delete-first), comment-mismatch (don't delete unrelated), and Sheets serial-date cells
- [x] `deleteFromSheet` recorder method tested for happy path, no-Google-connection no-op, and error propagation
- [x] `executeDeleteExpenseSingle` tested end-to-end: calls deleteFromSheet, surfaces "not found in sheet", warns on sheet error, removes legacy "/sync" hint
- [x] `classifySheetError`, `auditAllYears`, `recreateSpreadsheet`, `recreateLostSpreadsheets` unit-tested with all status branches
- [ ] Manual: after merge → auto-deploy → run `/repair` in production group `-1003207640556` to recreate the 2026 sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)