### PR TITLE
Suppress auto-advice, log trigger + context

### DIFF
--- a/src/bot/commands/ask.test.ts
+++ b/src/bot/commands/ask.test.ts
@@ -429,6 +429,7 @@ describe('maybeSmartAdvice', () => {
   beforeEach(() => {
     mockAiStreamRound.mockClear();
     mockAdviceLogs.create.mockClear();
+    recordAdviceSentMock.mockClear();
     writerCalls.appended.length = 0;
     writerCalls.finalized.length = 0;
     writerCalls.finalizedErrors.length = 0;
@@ -447,21 +448,43 @@ describe('maybeSmartAdvice', () => {
     spy.mockRestore();
   });
 
-  test('fires aiStreamRound when trigger is returned', async () => {
-    successfulStream(['quick insight']);
-    const spy = spyOnChecker({
-      type: 'budget_threshold',
-      tier: 'quick',
+  test('logs suppressed advice and persists cooldown when trigger fires', async () => {
+    const trigger = {
+      type: 'budget_threshold' as const,
+      tier: 'quick' as const,
       topic: 'budget_threshold:Food:warning',
       data: { category: 'Food' },
-    });
+    };
+    const spy = spyOnChecker(trigger);
 
     await maybeSmartAdvice(1);
 
-    expect(mockAiStreamRound).toHaveBeenCalledTimes(1);
-    const [opts] = mockAiStreamRound.mock.calls[0] as unknown as [StreamRoundOptions];
-    // Quick tier uses 500 max tokens
-    expect(opts.maxTokens).toBe(500);
+    // Auto-advice must NOT hit the AI provider or Telegram.
+    expect(mockAiStreamRound).not.toHaveBeenCalled();
+
+    // Trigger, severity, and context snapshot are logged for offline review.
+    const suppressedLog = logMock.info.mock.calls.find((c) =>
+      JSON.stringify(c).includes('Auto-advice suppressed'),
+    );
+    expect(suppressedLog).toBeDefined();
+    const [logPayload] = suppressedLog as [Record<string, unknown>, string];
+    expect(logPayload).toMatchObject({
+      groupId: 1,
+      trigger: { type: 'budget_threshold', tier: 'quick', topic: trigger.topic },
+    });
+    expect(typeof logPayload['context']).toBe('string');
+
+    // Cooldown is recorded so the same topic is not re-logged on every call.
+    expect(recordAdviceSentMock).toHaveBeenCalledWith(1, 'quick');
+    expect(mockAdviceLogs.create).toHaveBeenCalledTimes(1);
+    const createArg = mockAdviceLogs.create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(createArg).toMatchObject({
+      group_id: 1,
+      tier: 'quick',
+      trigger_type: 'budget_threshold',
+      topic: trigger.topic,
+      advice_text: '[auto-advice suppressed]',
+    });
     spy.mockRestore();
   });
 
@@ -477,8 +500,7 @@ describe('maybeSmartAdvice', () => {
     expect(logMock.error).toHaveBeenCalled();
   });
 
-  test('uses alert tier config (1000 max_tokens) when trigger.tier=alert', async () => {
-    successfulStream(['alert text']);
+  test('persists the trigger tier verbatim for alert triggers', async () => {
     const spy = spyOnChecker({
       type: 'budget_threshold',
       tier: 'alert',
@@ -488,8 +510,10 @@ describe('maybeSmartAdvice', () => {
 
     await maybeSmartAdvice(1);
 
-    const [opts] = mockAiStreamRound.mock.calls[0] as unknown as [StreamRoundOptions];
-    expect(opts.maxTokens).toBe(1000);
+    expect(mockAiStreamRound).not.toHaveBeenCalled();
+    expect(recordAdviceSentMock).toHaveBeenCalledWith(1, 'alert');
+    const createArg = mockAdviceLogs.create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(createArg?.['tier']).toBe('alert');
     spy.mockRestore();
   });
 });

--- a/src/bot/commands/ask.ts
+++ b/src/bot/commands/ask.ts
@@ -212,7 +212,9 @@ export async function handleAdviceCommand(ctx: Ctx['Command'], group: Group): Pr
 }
 
 /**
- * Check smart triggers and maybe send advice
+ * Check smart triggers. Auto-advice is disabled — we log the trigger and its
+ * context (expenses, budgets, anomalies) instead of sending to chat.
+ * Manual /advice (tier: 'deep') still works via handleAdviceCommand → sendSmartAdvice.
  */
 export async function maybeSmartAdvice(groupId: number): Promise<void> {
   try {
@@ -221,10 +223,36 @@ export async function maybeSmartAdvice(groupId: number): Promise<void> {
 
     if (!trigger) return;
 
+    const group = database.groups.findById(groupId);
+    const displayCurrency = group?.default_currency ?? BASE_CURRENCY;
+    const snapshotText = formatSnapshotForPrompt(snapshot, groupId, displayCurrency);
+    const severity = computeOverallSeverity(snapshot);
+
     logger.info(
-      `[ADVICE] Smart trigger fired: ${trigger.type} (tier: ${trigger.tier}) for group ${groupId}`,
+      {
+        groupId,
+        trigger: {
+          type: trigger.type,
+          tier: trigger.tier,
+          topic: trigger.topic,
+          data: trigger.data,
+        },
+        severity,
+        context: snapshotText,
+      },
+      '[ADVICE] Auto-advice suppressed — trigger would have fired',
     );
-    await sendSmartAdvice(groupId, trigger, snapshot);
+
+    // Persist cooldowns so the same topic/tier is not re-logged every run.
+    recordAdviceSent(groupId, trigger.tier);
+    database.adviceLogs.create({
+      group_id: groupId,
+      tier: trigger.tier,
+      trigger_type: trigger.type,
+      trigger_data: JSON.stringify(trigger.data),
+      topic: trigger.topic,
+      advice_text: '[auto-advice suppressed]',
+    });
   } catch (error) {
     logger.error({ err: error }, '[ADVICE] Error in smart advice check');
   }


### PR DESCRIPTION
## Summary

- `maybeSmartAdvice` больше не шлёт сообщения в чат и не зовёт AI провайдера. Вместо этого логирует сработавший триггер (type/tier/topic/data), severity и полный формированный снэпшот контекста (траты, бюджеты, аномалии, velocity и т.д.) — чтобы было видно **что именно** вызвало бы инсайт.
- Cooldown записи (`recordAdviceSent` + `advice_log`) продолжают персиститься с `advice_text = '[auto-advice suppressed]'`. Это сохраняет работу `hasTopicThisMonth` dedup — один и тот же топик не будет повторно логироваться на каждый новый expense.
- Ручной `/advice` (tier `deep`, через `handleAdviceCommand` → `sendSmartAdvice`) работает как раньше.
- Тесты `maybeSmartAdvice` обновлены: вместо ожидания `aiStreamRound` теперь проверяют что AI НЕ вызывается, а `advice_log` / `recordAdviceSent` получают корректные аргументы.

## Test plan

- [x] `bun run type-check` — зелёный
- [x] `bun run lint` — зелёный
- [x] `bun test src/bot/commands/ask.test.ts` — 19/19 pass
- [ ] На проде: убедиться что при `/sum`, `/stats`, `/budget` и т.д. инсайты не приходят в чат, но появляются в `pm2 logs` с `[ADVICE] Auto-advice suppressed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)