### PR TITLE
feat(bank): opt-in automatic bank-sync confirmation cards

### DIFF
--- a/src/bot/commands/bank.confirm.test.ts
+++ b/src/bot/commands/bank.confirm.test.ts
@@ -200,6 +200,7 @@ const group: Group = {
   active_topic_id: null,
   oauth_client: 'legacy' as const,
   bank_panel_summary_message_id: null,
+  bank_cards_enabled: 1,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };

--- a/src/bot/commands/bank.test.ts
+++ b/src/bot/commands/bank.test.ts
@@ -190,6 +190,7 @@ const group: Group = {
   active_topic_id: null,
   oauth_client: 'legacy' as const,
   bank_panel_summary_message_id: null,
+  bank_cards_enabled: 1,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };

--- a/src/bot/commands/bank.test.ts
+++ b/src/bot/commands/bank.test.ts
@@ -495,6 +495,10 @@ describe('bank setup/wizard callbacks', () => {
       reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] };
     };
     expect(call.text).toContain('TBC (GE)');
+    // Cards are off by default — the info screen must say so and point at /settings,
+    // not promise AI categories / confirmation / Sheets sync that won't happen yet.
+    expect(call.text).toMatch(/выключен/i);
+    expect(call.text).toContain('/settings');
     expect(call.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe(
       'bank_wizard_start:tbc-ge',
     );

--- a/src/bot/commands/bank.ts
+++ b/src/bot/commands/bank.ts
@@ -983,11 +983,10 @@ function buildFieldPromptText(field: CredentialField | undefined): string {
 function buildWizardInfoText(bankName: string): string {
   return (
     `🏦 ${bankName}\n\n` +
-    `После подключения бот будет автоматически:\n` +
-    `• Получать транзакции каждые 30 минут\n` +
-    `• Предлагать категорию через ИИ\n` +
-    `• Ждать твоего подтверждения перед записью\n` +
-    `• Синхронизировать с Google Sheets\n\n` +
+    `После подключения бот будет автоматически получать транзакции и баланс каждые 30 минут.\n\n` +
+    `Карточки транзакций в чате (предложить категорию через ИИ, дождаться твоего ` +
+    `подтверждения и записать расход в Google Sheets) по умолчанию выключены — ` +
+    `включи их в /settings, когда будешь готов.\n\n` +
     `Транзакции получаем через ZenPlugins — open-source: github.com/zenmoney/ZenPlugins`
   );
 }

--- a/src/bot/commands/budget.test.ts
+++ b/src/bot/commands/budget.test.ts
@@ -168,6 +168,7 @@ function fakeGroup(overrides: Partial<GoogleConnectedGroup> = {}): GoogleConnect
     active_topic_id: null,
     oauth_client: 'current',
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '',
     updated_at: '',
     ...overrides,

--- a/src/bot/commands/dev.test.ts
+++ b/src/bot/commands/dev.test.ts
@@ -64,6 +64,7 @@ const mockGroups = {
     active_topic_id: null,
     oauth_client: 'legacy',
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '2026-04-19T00:00:00Z',
     updated_at: '2026-04-19T00:00:00Z',
   })),
@@ -166,6 +167,7 @@ const group: Group = {
   active_topic_id: null,
   oauth_client: 'legacy',
   bank_panel_summary_message_id: null,
+  bank_cards_enabled: 1,
   created_at: '2026-04-19T00:00:00Z',
   updated_at: '2026-04-19T00:00:00Z',
 };

--- a/src/bot/commands/push.test.ts
+++ b/src/bot/commands/push.test.ts
@@ -98,6 +98,7 @@ function fakeGroup(): GoogleConnectedGroup {
     active_topic_id: null,
     oauth_client: 'current',
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '',
     updated_at: '',
   } as GoogleConnectedGroup;

--- a/src/bot/commands/repair.test.ts
+++ b/src/bot/commands/repair.test.ts
@@ -43,6 +43,7 @@ function fakeGroup(id = 1): GoogleConnectedGroup {
     active_topic_id: null,
     oauth_client: 'current',
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '',
     updated_at: '',
   } as GoogleConnectedGroup;

--- a/src/bot/commands/settings.test.ts
+++ b/src/bot/commands/settings.test.ts
@@ -28,9 +28,24 @@ mock.module('../../services/bank/telegram-sender', () => ({
   deleteMessage: mock(() => Promise.resolve()),
 }));
 
+// ── Database ──────────────────────────────────────────────────────────────
+
+const groupsFindByTelegramGroupIdMock = mock((_id: number): Group | null => null);
+const groupsUpdateMock = mock((_id: number, _data: Partial<Group>): Group | null => null);
+mock.module('../../database', () => ({
+  database: {
+    groups: {
+      findByTelegramGroupId: groupsFindByTelegramGroupIdMock,
+      update: groupsUpdateMock,
+    },
+  },
+}));
+
 // ── Import after mocks ────────────────────────────────────────────────────
 
-const { handleSettingsCommand } = await import('./settings');
+const { handleSettingsCommand, handleSettingsBankCardsToggle, buildSettingsView } = await import(
+  './settings'
+);
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -52,14 +67,26 @@ function fakeGroup(overrides: Partial<Group> = {}): Group {
     active_topic_id: null,
     oauth_client: 'current',
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 0,
     created_at: '',
     updated_at: '',
     ...overrides,
   } as Group;
 }
 
+function fakeCallbackCtx(): Ctx['CallbackQuery'] {
+  return {
+    message: { chat: { id: -100, type: 'supergroup' } },
+    from: { id: 1 },
+    answerCallbackQuery: mock(() => Promise.resolve()),
+    editText: mock(() => Promise.resolve()),
+  } as unknown as Ctx['CallbackQuery'];
+}
+
 beforeEach(() => {
   sendMessageMock.mockReset().mockResolvedValue(null);
+  groupsFindByTelegramGroupIdMock.mockReset().mockReturnValue(null);
+  groupsUpdateMock.mockReset().mockReturnValue(null);
   logMock.error.mockReset();
   logMock.warn.mockReset();
 });
@@ -132,5 +159,64 @@ describe('/settings', () => {
 
     const errMsg = sendMessageMock.mock.calls[1]?.[0] as string;
     expect(errMsg).toContain('непредвиденная');
+  });
+
+  test('renders bank-cards state and a toggle button reflecting it', async () => {
+    await handleSettingsCommand(fakeCtx(), fakeGroup({ bank_cards_enabled: 0 }));
+
+    const msg = sendMessageMock.mock.calls[0]?.[0] as string;
+    expect(msg).toContain('Карточки банковских транзакций: выкл');
+
+    const opts = sendMessageMock.mock.calls[0]?.[1] as { reply_markup?: unknown } | undefined;
+    expect(opts?.reply_markup).toBeDefined();
+    const view = buildSettingsView(fakeGroup({ bank_cards_enabled: 0 }));
+    expect(view.text).toContain('выкл');
+    expect(JSON.stringify(view.keyboard)).toContain('Включить карточки банка');
+
+    const onView = buildSettingsView(fakeGroup({ bank_cards_enabled: 1 }));
+    expect(onView.text).toContain('Карточки банковских транзакций: вкл');
+    expect(JSON.stringify(onView.keyboard)).toContain('Выключить карточки банка');
+  });
+});
+
+describe('/settings bank-cards toggle', () => {
+  test('flips bank_cards_enabled from 0 to 1 and re-renders', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 0 }));
+    groupsUpdateMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 1 }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsBankCardsToggle(ctx);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 1 });
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const editedText = editText.mock.calls[0]?.[0] as string;
+    expect(editedText).toContain('Карточки банковских транзакций: вкл');
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+
+  test('flips bank_cards_enabled from 1 to 0 and re-renders', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 1 }));
+    groupsUpdateMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 0 }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsBankCardsToggle(ctx);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 0 });
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const editedText = editText.mock.calls[0]?.[0] as string;
+    expect(editedText).toContain('Карточки банковских транзакций: выкл');
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+
+  test('answers with error and does not update when group is missing', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(null);
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsBankCardsToggle(ctx);
+
+    expect(groupsUpdateMock).not.toHaveBeenCalled();
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect(answer.mock.calls[0]?.[0]).toMatchObject({ text: 'Группа не настроена' });
+    expect(logMock.error).not.toHaveBeenCalled();
   });
 });

--- a/src/bot/commands/settings.ts
+++ b/src/bot/commands/settings.ts
@@ -1,4 +1,6 @@
-/** /settings and /reconnect command handlers — show current config and re-authorize Google OAuth */
+/** /settings command — shows current group config and a per-group bank-cards toggle */
+import { InlineKeyboard } from 'gramio';
+import { database } from '../../database';
 import type { Group } from '../../database/types';
 import { sendMessage } from '../../services/bank/telegram-sender';
 import { createLogger } from '../../utils/logger.ts';
@@ -7,20 +9,77 @@ import type { Ctx } from '../types';
 
 const logger = createLogger('cmd-settings');
 
+/** Callback data for the bank-cards toggle button (kept short for the 64-byte limit) */
+const SETTINGS_BANK_CARDS_CALLBACK = 'settings:bankcards';
+
+/**
+ * Build the settings message text and keyboard for a group.
+ * Shared by the /settings command and its toggle callback so both render identically.
+ */
+export function buildSettingsView(group: Group): { text: string; keyboard: InlineKeyboard } {
+  const cardsOn = !!group.bank_cards_enabled;
+
+  let text = '⚙️ Настройки группы:\n\n';
+  text += `💱 Валюта по умолчанию: ${group.default_currency}\n`;
+  text += `💵 Включенные валюты: ${group.enabled_currencies.join(', ')}\n`;
+  text += `📊 Таблица: ${group.spreadsheet_id ? 'настроена' : 'не настроена'}\n`;
+  text += `🔔 Карточки банковских транзакций: ${cardsOn ? 'вкл' : 'выкл'}\n`;
+
+  const keyboard = new InlineKeyboard().text(
+    cardsOn ? '🔕 Выключить карточки банка' : '🔔 Включить карточки банка',
+    SETTINGS_BANK_CARDS_CALLBACK,
+  );
+
+  return { text, keyboard };
+}
+
 /**
  * /settings command handler
  */
 export async function handleSettingsCommand(ctx: Ctx['Command'], group: Group): Promise<void> {
   void ctx;
   try {
-    let message = '⚙️ Настройки группы:\n\n';
-    message += `💱 Валюта по умолчанию: ${group.default_currency}\n`;
-    message += `💵 Включенные валюты: ${group.enabled_currencies.join(', ')}\n`;
-    message += `📊 Таблица: ${group.spreadsheet_id ? 'настроена' : 'не настроена'}\n`;
-
-    await sendMessage(message);
+    const { text, keyboard } = buildSettingsView(group);
+    await sendMessage(text, { reply_markup: keyboard });
   } catch (error) {
     logger.error({ err: error }, '[CMD] Error in /settings');
     await sendMessage(formatErrorForUser(error));
+  }
+}
+
+/**
+ * Toggle the per-group bank_cards_enabled setting from the /settings keyboard,
+ * then re-render the settings view in place.
+ */
+export async function handleSettingsBankCardsToggle(ctx: Ctx['CallbackQuery']): Promise<void> {
+  try {
+    const chatId = ctx.message?.chat?.id;
+    if (!chatId) {
+      await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
+      return;
+    }
+
+    const group = database.groups.findByTelegramGroupId(chatId);
+    if (!group) {
+      await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
+      return;
+    }
+
+    const next = group.bank_cards_enabled ? 0 : 1;
+    const updated = database.groups.update(group.telegram_group_id, { bank_cards_enabled: next });
+    if (!updated) {
+      await ctx.answerCallbackQuery({ text: 'Не удалось сохранить' });
+      return;
+    }
+
+    await ctx.answerCallbackQuery({
+      text: next ? '🔔 Карточки банка включены' : '🔕 Карточки банка выключены',
+    });
+
+    const { text, keyboard } = buildSettingsView(updated);
+    await ctx.editText(text, { reply_markup: keyboard });
+  } catch (error) {
+    logger.error({ err: error }, '[CMD] Error toggling bank cards in /settings');
+    await ctx.answerCallbackQuery({ text: 'Ошибка' });
   }
 }

--- a/src/bot/commands/sync.test.ts
+++ b/src/bot/commands/sync.test.ts
@@ -178,6 +178,7 @@ function fakeGroup(): GoogleConnectedGroup {
     oauth_client: 'current',
     active_topic_id: null,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     title: null,
     invite_link: null,
     custom_prompt: null,

--- a/src/bot/guards.test.ts
+++ b/src/bot/guards.test.ts
@@ -28,6 +28,7 @@ function makeGroup(id: number, telegramGroupId: number): Group {
     active_topic_id: null,
     oauth_client: 'legacy' as const,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
   };

--- a/src/bot/handlers/callback.handler.test.ts
+++ b/src/bot/handlers/callback.handler.test.ts
@@ -134,6 +134,11 @@ mock.module('../commands/feedback', () => ({
   cancelPendingFeedback: cancelFeedbackMock,
 }));
 
+const settingsMocks = {
+  handleSettingsBankCardsToggle: mock(() => Promise.resolve()),
+};
+mock.module('../commands/settings', () => settingsMocks);
+
 // ─── sync-service (sendOldTransactionCards, skipOldTransactions) ──────────────
 const sendOldMock = mock(() => Promise.resolve(0));
 const skipOldMock = mock(() => Promise.resolve(0));
@@ -235,6 +240,7 @@ const resetables: ReturnType<typeof mock>[] = [
   ...Object.values(bankMocks),
   ...Object.values(connectMocks),
   ...Object.values(disconnectMocks),
+  ...Object.values(settingsMocks),
   logMock.error,
   logMock.warn,
   logMock.info,
@@ -311,6 +317,23 @@ describe('handleCallbackQuery — routing table', () => {
       await handleCallbackQuery(ctx as never, fakeBot() as never);
       expect(ctx.answerCallbackQuery).toHaveBeenCalledWith(
         expect.objectContaining({ text: expect.stringContaining('Подтверждено') }),
+      );
+    });
+  });
+
+  describe('settings routing', () => {
+    test('routes "settings:bankcards" → handleSettingsBankCardsToggle', async () => {
+      const ctx = fakeCallbackCtx('settings:bankcards');
+      await handleCallbackQuery(ctx as never, fakeBot() as never);
+      expect(settingsMocks.handleSettingsBankCardsToggle).toHaveBeenCalledTimes(1);
+    });
+
+    test('routes unknown "settings:garbage" → Invalid parameters answer', async () => {
+      const ctx = fakeCallbackCtx('settings:garbage');
+      await handleCallbackQuery(ctx as never, fakeBot() as never);
+      expect(settingsMocks.handleSettingsBankCardsToggle).not.toHaveBeenCalled();
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'Invalid parameters' }),
       );
     });
   });

--- a/src/bot/handlers/callback.handler.ts
+++ b/src/bot/handlers/callback.handler.ts
@@ -42,6 +42,7 @@ import {
 import { handleDevCallback } from '../commands/dev';
 import { handleDisconnectCancel, handleDisconnectConfirm } from '../commands/disconnect';
 import { cancelPendingFeedback } from '../commands/feedback';
+import { handleSettingsBankCardsToggle } from '../commands/settings';
 import { createBudgetPromptKeyboard, createCategoriesListKeyboard } from '../keyboards';
 import { saveExpenseToSheet, saveReceiptExpenses } from '../services/expense-saver';
 import { getSheetErrorMessage } from '../services/sheet-errors';
@@ -103,6 +104,15 @@ export async function handleCallbackQuery(
         const msgId = ctx.message?.id;
         if (msgId && chatId) {
           await bot.api.deleteMessage({ chat_id: chatId, message_id: msgId });
+        }
+        break;
+      }
+
+      case 'settings': {
+        if (params[0] === 'bankcards') {
+          await handleSettingsBankCardsToggle(ctx);
+        } else {
+          await ctx.answerCallbackQuery({ text: 'Invalid parameters' });
         }
         break;
       }

--- a/src/bot/handlers/message.handler.test.ts
+++ b/src/bot/handlers/message.handler.test.ts
@@ -247,6 +247,7 @@ function makeGroup(overrides: Partial<Group> = {}): Group {
     custom_prompt: null,
     active_topic_id: null,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     oauth_client: 'current',
     created_at: '',
     updated_at: '',

--- a/src/bot/services/expense-saver.test.ts
+++ b/src/bot/services/expense-saver.test.ts
@@ -160,6 +160,7 @@ function makeGroup() {
     active_topic_id: null,
     oauth_client: 'legacy' as const,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '2024-01-01',
     updated_at: '2024-01-01',
   };

--- a/src/database/repositories/group.repository.test.ts
+++ b/src/database/repositories/group.repository.test.ts
@@ -60,6 +60,11 @@ describe('GroupRepository', () => {
       expect(group.active_topic_id).toBeNull();
     });
 
+    test('new group has bank_cards_enabled defaulting to 0 (off)', () => {
+      const group = repo.create({ telegram_group_id: 109 });
+      expect(group.bank_cards_enabled).toBe(0);
+    });
+
     test('created_at and updated_at are populated', () => {
       const group = repo.create({ telegram_group_id: 107 });
       expect(group.created_at).toBeTruthy();
@@ -160,6 +165,19 @@ describe('GroupRepository', () => {
       repo.update(407, { active_topic_id: 10 });
       const updated = repo.update(407, { active_topic_id: null });
       expect(updated?.active_topic_id).toBeNull();
+    });
+
+    test('updates bank_cards_enabled to 1 (on)', () => {
+      repo.create({ telegram_group_id: 409 });
+      const updated = repo.update(409, { bank_cards_enabled: 1 });
+      expect(updated?.bank_cards_enabled).toBe(1);
+    });
+
+    test('flips bank_cards_enabled back to 0 (off)', () => {
+      repo.create({ telegram_group_id: 410 });
+      repo.update(410, { bank_cards_enabled: 1 });
+      const updated = repo.update(410, { bank_cards_enabled: 0 });
+      expect(updated?.bank_cards_enabled).toBe(0);
     });
 
     test('returns null for non-existent telegram_group_id', () => {

--- a/src/database/repositories/group.repository.ts
+++ b/src/database/repositories/group.repository.ts
@@ -13,7 +13,7 @@ const GROUP_JOIN_SELECT = `
   SELECT
     g.id, g.telegram_group_id, g.title, g.invite_link, g.google_refresh_token,
     g.default_currency, g.enabled_currencies, g.custom_prompt,
-    g.active_topic_id, g.bank_panel_summary_message_id,
+    g.active_topic_id, g.bank_panel_summary_message_id, g.bank_cards_enabled,
     g.oauth_client, g.created_at, g.updated_at,
     gs.spreadsheet_id
   FROM groups g
@@ -111,6 +111,10 @@ export class GroupRepository {
     if (data.bank_panel_summary_message_id !== undefined) {
       updates.push('bank_panel_summary_message_id = ?');
       values.push(data.bank_panel_summary_message_id);
+    }
+    if (data.bank_cards_enabled !== undefined) {
+      updates.push('bank_cards_enabled = ?');
+      values.push(data.bank_cards_enabled);
     }
     if (data.oauth_client !== undefined) {
       updates.push('oauth_client = ?');

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1371,6 +1371,19 @@ export function runMigrations(db: Database): void {
         }
       },
     },
+    {
+      name: '050_add_bank_cards_enabled_to_groups',
+      up: () => {
+        const check = db.query<{ count: number }, []>(`
+          SELECT COUNT(*) as count FROM pragma_table_info('groups')
+          WHERE name = 'bank_cards_enabled'
+        `);
+        if (check.get()?.count === 0) {
+          db.exec(`ALTER TABLE groups ADD COLUMN bank_cards_enabled INTEGER NOT NULL DEFAULT 0`);
+          logger.info('✓ Added bank_cards_enabled to groups');
+        }
+      },
+    },
   ];
 
   // Check and run migrations

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -18,6 +18,8 @@ export interface Group {
   custom_prompt: string | null;
   active_topic_id: number | null;
   bank_panel_summary_message_id: number | null;
+  /** 0 = bank sync sends no automatic confirmation cards; 1 = cards enabled */
+  bank_cards_enabled: number;
   oauth_client: OAuthClientType;
   created_at: string;
   updated_at: string;
@@ -38,6 +40,7 @@ export interface UpdateGroupData {
   custom_prompt?: string | null;
   active_topic_id?: number | null;
   bank_panel_summary_message_id?: number | null;
+  bank_cards_enabled?: number;
   oauth_client?: OAuthClientType;
 }
 

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -44,6 +44,7 @@ const mockGroups = {
     active_topic_id: null,
     oauth_client: 'legacy' as const,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '',
     updated_at: '',
   })),
@@ -301,6 +302,7 @@ function resetAllMocks() {
     active_topic_id: null,
     oauth_client: 'legacy' as const,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '',
     updated_at: '',
   });
@@ -1321,6 +1323,7 @@ describe('executeGetGroupSettings', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });
@@ -2319,6 +2322,7 @@ describe('get_technical_analysis', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });
@@ -2408,6 +2412,7 @@ describe('get_technical_analysis', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });

--- a/src/services/analytics/advice-triggers.test.ts
+++ b/src/services/analytics/advice-triggers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from 'bun:test';
-import type { BankConnection, BankTransaction } from '../../database/types';
+import type { BankConnection, BankTransaction, Group } from '../../database/types';
 import { buildNeutralSnapshot } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
 import type { CategoryTaAnalysis } from './ta/analyzer';
@@ -32,6 +32,13 @@ const mockBankTransactions = {
   findByGroupId: mock(() => [] as BankTransaction[]),
 };
 
+// Trigger 7 only nags when the group receives bank cards, so it loads the group
+// to read bank_cards_enabled. Default to cards-on so unrelated trigger tests are
+// unaffected; the cards-off test overrides this explicitly.
+const mockGroups = {
+  findById: mock(() => ({ bank_cards_enabled: 1 }) as unknown as Group),
+};
+
 const mockBankAccounts = {
   findByGroupId: mock(() => []),
 };
@@ -42,6 +49,7 @@ const mockRecurringPatterns = {
 
 mock.module('../../database', () => ({
   database: mockDatabase({
+    groups: mockGroups,
     adviceLogs: mockAdviceLogs,
     expenses: mockExpenses,
     bankConnections: mockBankConnections,
@@ -124,6 +132,7 @@ beforeEach(() => {
   mockExpenses.getCountForRange.mockImplementation(() => 0);
   mockBankConnections.findActiveByGroupId.mockImplementation(() => []);
   mockBankTransactions.findPendingByConnectionId.mockImplementation(() => []);
+  mockGroups.findById.mockImplementation(() => ({ bank_cards_enabled: 1 }) as unknown as Group);
 
   // Clear cooldowns by recording a zeroed-out state:
   // Since cooldowns is a private Map, we can't clear it directly.
@@ -908,6 +917,26 @@ describe('edge cases', () => {
     // mockBankConnections returns [] by default (reset in beforeEach)
     const snapshot = buildTriggerSnapshot();
     const result = checkSmartTriggers(8018, snapshot);
+
+    expect(result).toBeNull();
+  });
+
+  test('pending_bank_transactions does NOT fire when bank cards are disabled', () => {
+    // Tuesday — no weekly_check interference
+    setSystemTime(new Date('2026-03-24T10:00:00Z'));
+
+    // Pending txs exist, but the group has cards off: with no in-chat confirm
+    // path the reminder would point at something the user cannot act on.
+    mockGroups.findById.mockImplementation(() => ({ bank_cards_enabled: 0 }) as unknown as Group);
+    mockBankConnections.findActiveByGroupId.mockImplementation(
+      () => [{ id: 42 }] as BankConnection[],
+    );
+    mockBankTransactions.findPendingByConnectionId.mockImplementation(
+      () => [{ id: 1 }, { id: 2 }, { id: 3 }] as BankTransaction[],
+    );
+
+    const snapshot = buildTriggerSnapshot();
+    const result = checkSmartTriggers(8019, snapshot);
 
     expect(result).toBeNull();
   });

--- a/src/services/analytics/advice-triggers.ts
+++ b/src/services/analytics/advice-triggers.ts
@@ -245,22 +245,29 @@ export function checkSmartTriggers(
   }
 
   // === Trigger 7: Pending bank transactions need review ===
-  const pendingConnections = database.bankConnections.findActiveByGroupId(groupId);
-  let totalPending = 0;
-  for (const conn of pendingConnections) {
-    totalPending += database.bankTransactions.findPendingByConnectionId(conn.id).length;
-  }
-  if (totalPending > 0) {
-    // Embed today's date to allow daily reminders (unlike other triggers which use monthly dedup)
-    const topic = `pending_bank_transactions:${today}`;
-    if (!database.adviceLogs.hasTopicThisMonth(groupId, topic, monthStart)) {
-      if (canSendAdvice(groupId, 'quick')) {
-        return {
-          type: 'pending_bank_transactions',
-          tier: 'quick',
-          topic,
-          data: { count: totalPending },
-        };
+  // Only nag when the group actually receives bank confirmation cards. With cards
+  // off (the default), debits are still stored as 'pending' but there is no in-chat
+  // path to confirm them, so a "N pending transactions" reminder points at something
+  // the user deliberately chose not to be bothered by and cannot act on.
+  const group = database.groups.findById(groupId);
+  if (group?.bank_cards_enabled) {
+    const pendingConnections = database.bankConnections.findActiveByGroupId(groupId);
+    let totalPending = 0;
+    for (const conn of pendingConnections) {
+      totalPending += database.bankTransactions.findPendingByConnectionId(conn.id).length;
+    }
+    if (totalPending > 0) {
+      // Embed today's date to allow daily reminders (unlike other triggers which use monthly dedup)
+      const topic = `pending_bank_transactions:${today}`;
+      if (!database.adviceLogs.hasTopicThisMonth(groupId, topic, monthStart)) {
+        if (canSendAdvice(groupId, 'quick')) {
+          return {
+            type: 'pending_bank_transactions',
+            tier: 'quick',
+            topic,
+            data: { count: totalPending },
+          };
+        }
       }
     }
   }

--- a/src/services/bank/old-transactions-actions.test.ts
+++ b/src/services/bank/old-transactions-actions.test.ts
@@ -63,6 +63,7 @@ const GROUP: Group = {
   active_topic_id: 77,
   oauth_client: 'legacy',
   bank_panel_summary_message_id: null,
+  bank_cards_enabled: 1,
   created_at: '',
   updated_at: '',
 };

--- a/src/services/bank/sync-service.test.ts
+++ b/src/services/bank/sync-service.test.ts
@@ -182,6 +182,9 @@ function buildGroup(overrides: Partial<Group> = {}): Group {
     custom_prompt: null,
     active_topic_id: null,
     bank_panel_summary_message_id: null,
+    // On by default in fixtures: the existing suite asserts cards/prefill fire.
+    // The opt-out behaviour is covered by its own describe block with an explicit 0.
+    bank_cards_enabled: 1,
     oauth_client: 'current',
     created_at: '',
     updated_at: '',
@@ -335,13 +338,16 @@ const todayStr = (): string => {
   return `${yyyy}-${mm}-${dd}`;
 };
 
-function seedConnection(overrides: Partial<BankConnection> = {}): BankConnection {
+function seedConnection(
+  overrides: Partial<BankConnection> = {},
+  groupOverrides: Partial<Group> = {},
+): BankConnection {
   const conn = buildConnection(overrides);
   store.connections.set(conn.id, conn);
   store.credentials.set(conn.id, JSON.stringify({ login: 'u', password: 'p' }));
   // Populate plugin state so cron sync path is allowed.
   store.pluginState.set(conn.id, new Map([['auth', '{}']]));
-  store.groups.set(conn.group_id, buildGroup({ id: conn.group_id }));
+  store.groups.set(conn.group_id, buildGroup({ id: conn.group_id, ...groupOverrides }));
   return conn;
 }
 
@@ -814,6 +820,113 @@ describe('runSyncCycle — inactive connection', () => {
     await triggerManualSync(9999);
 
     expect(prefillMock).not.toHaveBeenCalled();
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('runSyncCycle — bank_cards_enabled toggle', () => {
+  function findConfirmationCard() {
+    return sendMessageMock.mock.calls.find((c) => {
+      const opts = c[1] as { reply_markup?: { inline_keyboard?: unknown[][] } } | undefined;
+      const firstRow = opts?.reply_markup?.inline_keyboard?.[0] as
+        | Array<{ callback_data?: string }>
+        | undefined;
+      return firstRow?.[0]?.callback_data?.startsWith('bank_confirm:') ?? false;
+    });
+  }
+
+  function findOldTxSummaryCard() {
+    return sendMessageMock.mock.calls.find((c) => {
+      const opts = c[1] as { reply_markup?: { inline_keyboard?: unknown[][] } } | undefined;
+      const firstRow = opts?.reply_markup?.inline_keyboard?.[0] as
+        | Array<{ callback_data?: string }>
+        | undefined;
+      return firstRow?.[0]?.callback_data?.startsWith('bank_show_old:') ?? false;
+    });
+  }
+
+  it('cards disabled: inserts transactions but sends no cards and skips prefill', async () => {
+    const conn = seedConnection({}, { bank_cards_enabled: 0 });
+
+    const today = todayStr();
+    scrapeImpl.fn = async () => ({
+      accounts: [{ id: 'acc1', title: 'Main', balance: 100, instrument: 'EUR', type: 'checking' }],
+      transactions: [
+        {
+          id: 'tx-today',
+          date: `${today}T12:00:00Z`,
+          sum: -25,
+          currency: 'EUR',
+          account: 'acc1',
+          merchant: 'TodayStore',
+        },
+        {
+          id: 'tx-old',
+          date: '2020-01-15T12:00:00Z',
+          sum: -15,
+          currency: 'EUR',
+          account: 'acc1',
+          merchant: 'OldStore',
+        },
+      ],
+    });
+
+    await triggerManualSync(conn.id);
+
+    // Phase 1 still runs — both transactions inserted into DB.
+    expect(bankTxInsertIgnoreMock).toHaveBeenCalledTimes(2);
+    expect(store.transactions.length).toBe(2);
+
+    // Phase 2 (AI prefill) skipped entirely — no Anthropic spend.
+    expect(prefillMock).not.toHaveBeenCalled();
+
+    // Phase 3 — no per-tx confirmation card.
+    expect(findConfirmationCard()).toBeUndefined();
+
+    // notifyOldTransactions — no summary card.
+    expect(findOldTxSummaryCard()).toBeUndefined();
+
+    // An info log notes cards are disabled for the group.
+    const disabledLog = logMock.info.mock.calls.find(
+      (c) => typeof c[1] === 'string' && c[1].includes('cards disabled'),
+    );
+    expect(disabledLog).toBeTruthy();
+
+    // Success path — failures still reset, no error logs.
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+
+  it('cards enabled: prefill runs, confirmation card and old-tx summary are sent', async () => {
+    const conn = seedConnection({}, { bank_cards_enabled: 1 });
+
+    const today = todayStr();
+    scrapeImpl.fn = async () => ({
+      accounts: [],
+      transactions: [
+        {
+          id: 'tx-today',
+          date: `${today}T12:00:00Z`,
+          sum: -25,
+          currency: 'EUR',
+          account: 'acc1',
+          merchant: 'TodayStore',
+        },
+        {
+          id: 'tx-old',
+          date: '2020-01-15T12:00:00Z',
+          sum: -15,
+          currency: 'EUR',
+          account: 'acc1',
+          merchant: 'OldStore',
+        },
+      ],
+    });
+
+    await triggerManualSync(conn.id);
+
+    expect(prefillMock).toHaveBeenCalledTimes(1);
+    expect(findConfirmationCard()).toBeTruthy();
+    expect(findOldTxSummaryCard()).toBeTruthy();
     expect(logMock.error).not.toHaveBeenCalled();
   });
 });

--- a/src/services/bank/sync-service.ts
+++ b/src/services/bank/sync-service.ts
@@ -376,70 +376,83 @@ async function runSyncCycle(connectionId: number, allowOtp = false): Promise<voi
       }
     }
 
-    // Phase 2: batch AI pre-fill for all new pending transactions
-    const prefillResults = await preFillTransactions(newPendingTxs, group.id);
-    for (let i = 0; i < newPendingTxs.length; i++) {
-      const tx = newPendingTxs[i];
-      const prefilled = prefillResults[i];
-      if (tx && prefilled) {
-        database.bankTransactions.setPrefill(tx.id, prefilled.category, '');
-      }
-    }
-
-    // Phase 3: send confirmation cards — only for today's transactions
-    for (let i = 0; i < newPendingTxs.length; i++) {
-      const inserted = newPendingTxs[i];
-      const prefilled = prefillResults[i];
-      if (!inserted || !prefilled) continue;
-
-      // Skip cards for old transactions — stored in DB but no card sent
-      if (inserted.date !== today) continue;
-
-      // Skip cards for transactions from excluded accounts
-      if (inserted.account_id) {
-        const accounts = database.bankAccounts.findByConnectionId(connectionId);
-        const account = accounts.find((a) => a.account_id === inserted.account_id);
-        if (account?.is_excluded === 1) continue;
+    // Automatic confirmation cards are opt-in per group (bank_cards_enabled).
+    // When off, sync is balance/history-only: transactions stay in the DB as
+    // pending, but no AI prefill is spent and no unsolicited cards are sent.
+    if (group.bank_cards_enabled) {
+      // Phase 2: batch AI pre-fill for all new pending transactions
+      const prefillResults = await preFillTransactions(newPendingTxs, group.id);
+      for (let i = 0; i < newPendingTxs.length; i++) {
+        const tx = newPendingTxs[i];
+        const prefilled = prefillResults[i];
+        if (tx && prefilled) {
+          database.bankTransactions.setPrefill(tx.id, prefilled.category, '');
+        }
       }
 
-      // Large transaction: compare EUR equivalent to threshold
-      const amountInEur = convertAnyToEUR(inserted.amount, inserted.currency);
-      const isLarge = amountInEur >= env.LARGE_TX_THRESHOLD_EUR;
+      // Phase 3: send confirmation cards — only for today's transactions
+      for (let i = 0; i < newPendingTxs.length; i++) {
+        const inserted = newPendingTxs[i];
+        const prefilled = prefillResults[i];
+        if (!inserted || !prefilled) continue;
 
-      const cardText = formatConfirmationCard(
-        inserted,
-        prefilled.category,
-        conn.display_name,
-        isLarge,
-      );
+        // Skip cards for old transactions — stored in DB but no card sent
+        if (inserted.date !== today) continue;
 
-      const result = await withChatContext(
-        group.telegram_group_id,
-        conn.panel_message_thread_id,
-        () =>
-          sendMessage(cardText, {
-            reply_markup: {
-              inline_keyboard: [
-                [
-                  { text: '✅ Принять', callback_data: `bank_confirm:${inserted.id}` },
-                  { text: '✏️ Исправить', callback_data: `bank_edit:${inserted.id}` },
+        // Skip cards for transactions from excluded accounts
+        if (inserted.account_id) {
+          const accounts = database.bankAccounts.findByConnectionId(connectionId);
+          const account = accounts.find((a) => a.account_id === inserted.account_id);
+          if (account?.is_excluded === 1) continue;
+        }
+
+        // Large transaction: compare EUR equivalent to threshold
+        const amountInEur = convertAnyToEUR(inserted.amount, inserted.currency);
+        const isLarge = amountInEur >= env.LARGE_TX_THRESHOLD_EUR;
+
+        const cardText = formatConfirmationCard(
+          inserted,
+          prefilled.category,
+          conn.display_name,
+          isLarge,
+        );
+
+        const result = await withChatContext(
+          group.telegram_group_id,
+          conn.panel_message_thread_id,
+          () =>
+            sendMessage(cardText, {
+              reply_markup: {
+                inline_keyboard: [
+                  [
+                    { text: '✅ Принять', callback_data: `bank_confirm:${inserted.id}` },
+                    { text: '✏️ Исправить', callback_data: `bank_edit:${inserted.id}` },
+                  ],
                 ],
-              ],
-            },
-          }),
-      );
+              },
+            }),
+        );
 
-      if (result) {
-        database.bankTransactions.setTelegramMessageId(inserted.id, result.message_id);
+        if (result) {
+          database.bankTransactions.setTelegramMessageId(inserted.id, result.message_id);
+        }
       }
-    }
 
-    // Notify about old (non-today) transactions that were inserted this cycle
-    const oldTxsWithPrefill = newPendingTxs
-      .map((tx, i) => ({ tx, category: prefillResults[i]?.category ?? tx.prefill_category ?? '—' }))
-      .filter(({ tx }) => tx.date !== today);
-    if (oldTxsWithPrefill.length > 0) {
-      await notifyOldTransactions(oldTxsWithPrefill, conn, group);
+      // Notify about old (non-today) transactions that were inserted this cycle
+      const oldTxsWithPrefill = newPendingTxs
+        .map((tx, i) => ({
+          tx,
+          category: prefillResults[i]?.category ?? tx.prefill_category ?? '—',
+        }))
+        .filter(({ tx }) => tx.date !== today);
+      if (oldTxsWithPrefill.length > 0) {
+        await notifyOldTransactions(oldTxsWithPrefill, conn, group);
+      }
+    } else if (newPendingTxs.length > 0) {
+      logger.info(
+        { connectionId, groupId: group.id, pending: newPendingTxs.length },
+        'Bank cards disabled for group — stored transactions without sending cards',
+      );
     }
 
     // Success: reset failures

--- a/src/services/budget-manager.test.ts
+++ b/src/services/budget-manager.test.ts
@@ -24,6 +24,7 @@ const mockFindGroupById = mock((): Group | null => ({
   active_topic_id: null,
   oauth_client: 'legacy' as const,
   bank_panel_summary_message_id: null,
+  bank_cards_enabled: 1,
   created_at: '',
   updated_at: '',
 }));
@@ -103,6 +104,7 @@ function resetAll() {
     active_topic_id: null,
     oauth_client: 'legacy' as const,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     created_at: '',
     updated_at: '',
   });
@@ -197,6 +199,7 @@ describe('BudgetManager.set', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });
@@ -274,6 +277,7 @@ describe('BudgetManager.set', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });
@@ -329,6 +333,7 @@ describe('BudgetManager.delete', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });
@@ -358,6 +363,7 @@ describe('BudgetManager.delete', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });

--- a/src/services/feedback.test.ts
+++ b/src/services/feedback.test.ts
@@ -72,6 +72,7 @@ describe('sendFeedback', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });
@@ -113,6 +114,7 @@ describe('sendFeedback', () => {
       active_topic_id: null,
       oauth_client: 'legacy' as const,
       bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
       created_at: '',
       updated_at: '',
     });

--- a/src/web/miniapp-api.test.ts
+++ b/src/web/miniapp-api.test.ts
@@ -69,6 +69,7 @@ function stubGroup(overrides?: Partial<Group>): Group {
     custom_prompt: null,
     active_topic_id: null,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     oauth_client: 'current',
     created_at: '2024-01-01',
     updated_at: '2024-01-01',

--- a/src/web/oauth-callback.test.ts
+++ b/src/web/oauth-callback.test.ts
@@ -31,6 +31,7 @@ function stubGroup(overrides: Partial<Group> & { id: number }): Group {
     custom_prompt: null,
     active_topic_id: null,
     bank_panel_summary_message_id: null,
+    bank_cards_enabled: 1,
     oauth_client: 'current',
     created_at: '2024-01-01',
     updated_at: '2024-01-01',


### PR DESCRIPTION
## Что

Автоматические карточки подтверждения банк-синка теперь **выключены по умолчанию** с per-group тумблером для включения. Когда выключено — синк работает в режиме «только балансы/история»: транзакции пишутся в БД, но непрошеные карточки не шлются и AI-prefill не тратится.

## Изменения

- **Миграция 050**: `groups.bank_cards_enabled INTEGER NOT NULL DEFAULT 0` (идемпотентная, существующие миграции не тронуты).
- **`Group` тип + репозиторий**: чтение и запись `bank_cards_enabled`.
- **`sync-service.ts`**: три автоматических пути отправки обёрнуты в `if (group.bank_cards_enabled)`:
  1. Phase 2 — `preFillTransactions` (трата на Anthropic) — скипается целиком
  2. Phase 3 — per-tx карточки за сегодня
  3. `notifyOldTransactions` — сводка по старым транзакциям («Показать для подтверждения?»)

  Phase 1 (вставка транзакций) и все операционные/user-initiated пути (OTP, ack, алерт о 3 ошибках, обновление панели, колбэки `bank_show_old`/`confirm`/`edit`) остаются живыми.
- **`/settings`**: тумблер «Карточки банковских транзакций: вкл/выкл» с ре-рендером на месте через `ctx.editText`; колбэк `settings:bankcards` (18 байт).

## Решённые дефолты

Off по умолчанию, per-group, prefill скипается при off, все три пути загейчены, без ретроактивного флуда (`notifyOldTransactions` шлёт только то, что вставлено в текущем цикле).

## Тесты

TDD: off-путь (транзакции вставлены, prefill НЕ вызван, карточки НЕ отправлены, notifyOldTransactions НЕ вызван) + on-путь (поведение как было) + миграция/репозиторий + тумблер в settings.

Полный сьют: 3417/3417 зелёные, tsc чисто.

## Вне скоупа

Тумблер виден только в `/settings` — в панели `/bank` и `/help` не упомянут (по решению, можно добавить отдельно).

🤖 Generated with [Claude Code](https://claude.com/claude-code)