### PR TITLE
bank cards follow-ups: /bank panel hint + runSyncCycle refactor

### DIFF
--- a/src/bot/commands/bank.ts
+++ b/src/bot/commands/bank.ts
@@ -297,7 +297,11 @@ async function showBanksPanel(
   // Send one combined message for all banks
   const accounts = database.bankAccounts.findByGroupId(group.id);
   const totalEur = accounts.reduce((sum, a) => sum + convertAnyToEUR(a.balance, a.currency), 0);
-  const text = buildCombinedBankStatusText(connections, totalEur);
+  const text = buildCombinedBankStatusText(
+    connections,
+    totalEur,
+    Boolean(group.bank_cards_enabled),
+  );
   const keyboard = buildCombinedBankKeyboard(connections);
 
   const sent = await sendMessage(text, {
@@ -332,7 +336,7 @@ async function showBankStatus(
       // already gone
     }
   }
-  const text = buildBankStatusText(conn);
+  const text = buildBankStatusText(conn, Boolean(group.bank_cards_enabled));
   const sent = await sendMessage(text, {
     reply_markup: {
       inline_keyboard: buildBankManageKeyboard(conn, explicit),

--- a/src/bot/commands/bank.ts
+++ b/src/bot/commands/bank.ts
@@ -297,11 +297,7 @@ async function showBanksPanel(
   // Send one combined message for all banks
   const accounts = database.bankAccounts.findByGroupId(group.id);
   const totalEur = accounts.reduce((sum, a) => sum + convertAnyToEUR(a.balance, a.currency), 0);
-  const text = buildCombinedBankStatusText(
-    connections,
-    totalEur,
-    Boolean(group.bank_cards_enabled),
-  );
+  const text = buildCombinedBankStatusText(connections, totalEur);
   const keyboard = buildCombinedBankKeyboard(connections);
 
   const sent = await sendMessage(text, {
@@ -336,7 +332,7 @@ async function showBankStatus(
       // already gone
     }
   }
-  const text = buildBankStatusText(conn, Boolean(group.bank_cards_enabled));
+  const text = buildBankStatusText(conn);
   const sent = await sendMessage(text, {
     reply_markup: {
       inline_keyboard: buildBankManageKeyboard(conn, explicit),

--- a/src/services/bank/panel-builder.test.ts
+++ b/src/services/bank/panel-builder.test.ts
@@ -424,6 +424,34 @@ describe('buildCombinedBankStatusText', () => {
   });
 });
 
+describe('bank cards off hint', () => {
+  test('buildBankStatusText appends the hint when cards are off', () => {
+    const text = buildBankStatusText(baseConn, false);
+    expect(text).toContain('выключены');
+    expect(text).toContain('/settings');
+  });
+
+  test('buildBankStatusText omits the hint when cards are on', () => {
+    expect(buildBankStatusText(baseConn, true)).not.toContain('/settings');
+  });
+
+  test('buildBankStatusText omits the hint by default', () => {
+    expect(buildBankStatusText(baseConn)).not.toContain('/settings');
+  });
+
+  test('buildCombinedBankStatusText shows the hint exactly once across multiple banks', () => {
+    const c1 = { ...baseConn, id: 1, display_name: 'A' };
+    const c2 = { ...baseConn, id: 2, display_name: 'B' };
+    const text = buildCombinedBankStatusText([c1, c2], 1234, false);
+    expect(text).toContain('выключены');
+    expect(text.match(/\/settings/g)?.length).toBe(1);
+  });
+
+  test('buildCombinedBankStatusText omits the hint when cards are on', () => {
+    expect(buildCombinedBankStatusText([baseConn], 0, true)).not.toContain('/settings');
+  });
+});
+
 describe('buildCombinedBankKeyboard', () => {
   test('per-bank: sync button present when active + synced + no failures', () => {
     const conn = {

--- a/src/services/bank/panel-builder.test.ts
+++ b/src/services/bank/panel-builder.test.ts
@@ -1,6 +1,6 @@
 // Tests for panel-builder — status text, keyboard generation, and timeSince helper.
 
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import type { BankAccount, BankTransaction } from '../../database/types';
 import { makeBankTransaction } from '../../test-utils/fixtures';
 import { mockDatabase } from '../../test-utils/mocks/database';
@@ -12,9 +12,15 @@ const mockAccounts: { findByConnectionId: (id: number) => BankAccount[] } = {
 const mockTxs: { findPendingByConnectionId: (id: number) => BankTransaction[] } = {
   findPendingByConnectionId: () => [],
 };
+// buildBankStatusText resolves the cards-off hint from the owning group. Default
+// to cards-on (no hint) so unrelated panel tests are unaffected; hint tests override.
+const mockGroups: { findById: (id: number) => { bank_cards_enabled: number } | null } = {
+  findById: () => ({ bank_cards_enabled: 1 }),
+};
 
 mock.module('../../database', () => ({
   database: mockDatabase({
+    groups: { findById: mock((id: number) => mockGroups.findById(id)) },
     bankAccounts: { findByConnectionId: mock((id: number) => mockAccounts.findByConnectionId(id)) },
     bankTransactions: {
       findPendingByConnectionId: mock((id: number) => mockTxs.findPendingByConnectionId(id)),
@@ -425,30 +431,41 @@ describe('buildCombinedBankStatusText', () => {
 });
 
 describe('bank cards off hint', () => {
-  test('buildBankStatusText appends the hint when cards are off', () => {
-    const text = buildBankStatusText(baseConn, false);
+  afterEach(() => {
+    mockGroups.findById = () => ({ bank_cards_enabled: 1 });
+  });
+
+  test('buildBankStatusText appends the hint when the group has cards off', () => {
+    mockGroups.findById = () => ({ bank_cards_enabled: 0 });
+    const text = buildBankStatusText(baseConn);
     expect(text).toContain('выключены');
     expect(text).toContain('/settings');
   });
 
   test('buildBankStatusText omits the hint when cards are on', () => {
-    expect(buildBankStatusText(baseConn, true)).not.toContain('/settings');
-  });
-
-  test('buildBankStatusText omits the hint by default', () => {
+    mockGroups.findById = () => ({ bank_cards_enabled: 1 });
     expect(buildBankStatusText(baseConn)).not.toContain('/settings');
   });
 
+  test('buildBankStatusText omits the hint when the group is missing', () => {
+    mockGroups.findById = () => null;
+    // No group resolved → cardsEnabled false → hint shown (fail-visible, not hidden)
+    expect(buildBankStatusText(baseConn)).toContain('/settings');
+  });
+
   test('buildCombinedBankStatusText shows the hint exactly once across multiple banks', () => {
+    mockGroups.findById = () => ({ bank_cards_enabled: 0 });
     const c1 = { ...baseConn, id: 1, display_name: 'A' };
     const c2 = { ...baseConn, id: 2, display_name: 'B' };
-    const text = buildCombinedBankStatusText([c1, c2], 1234, false);
+    const text = buildCombinedBankStatusText([c1, c2], 1234);
     expect(text).toContain('выключены');
     expect(text.match(/\/settings/g)?.length).toBe(1);
+    expect(text.match(/выключены/g)?.length).toBe(1);
   });
 
   test('buildCombinedBankStatusText omits the hint when cards are on', () => {
-    expect(buildCombinedBankStatusText([baseConn], 0, true)).not.toContain('/settings');
+    mockGroups.findById = () => ({ bank_cards_enabled: 1 });
+    expect(buildCombinedBankStatusText([baseConn], 0)).not.toContain('/settings');
   });
 });
 

--- a/src/services/bank/panel-builder.ts
+++ b/src/services/bank/panel-builder.ts
@@ -11,13 +11,11 @@ export interface PanelButton {
  * Reminder appended to the /bank panel when chat cards are off, so transactions
  * that sync silently into the DB aren't a mystery and the user knows how to enable them.
  */
-function bankCardsOffHint(cardsEnabled: boolean | undefined): string {
-  return cardsEnabled === false
-    ? '\n\n🔕 Карточки транзакций в чате выключены — включить в /settings'
-    : '';
+function bankCardsOffHint(cardsEnabled: boolean): string {
+  return cardsEnabled ? '' : '\n\n🔕 Карточки транзакций в чате выключены — включить в /settings';
 }
 
-export function buildBankStatusText(conn: BankConnection, cardsEnabled?: boolean): string {
+export function buildBankStatusText(conn: BankConnection, cardsEnabled = true): string {
   const accounts = database.bankAccounts.findByConnectionId(conn.id);
 
   const syncLine = conn.last_sync_at
@@ -97,9 +95,9 @@ export function timeSince(isoDate: string): string {
 export function buildCombinedBankStatusText(
   connections: BankConnection[],
   totalEur: number,
-  cardsEnabled?: boolean,
+  cardsEnabled = true,
 ): string {
-  // Per-section text omits the hint (cardsEnabled not forwarded) so it appears once below the total.
+  // Sections use the default cardsEnabled=true (no hint) so the hint appears once below the total.
   const sections = connections.map((conn) => buildBankStatusText(conn)).join('\n\n');
   return `${sections}\n\nИтого: ~${totalEur.toFixed(0)} EUR${bankCardsOffHint(cardsEnabled)}`;
 }

--- a/src/services/bank/panel-builder.ts
+++ b/src/services/bank/panel-builder.ts
@@ -7,7 +7,17 @@ export interface PanelButton {
   callback_data: string;
 }
 
-export function buildBankStatusText(conn: BankConnection): string {
+/**
+ * Reminder appended to the /bank panel when chat cards are off, so transactions
+ * that sync silently into the DB aren't a mystery and the user knows how to enable them.
+ */
+function bankCardsOffHint(cardsEnabled: boolean | undefined): string {
+  return cardsEnabled === false
+    ? '\n\n🔕 Карточки транзакций в чате выключены — включить в /settings'
+    : '';
+}
+
+export function buildBankStatusText(conn: BankConnection, cardsEnabled?: boolean): string {
   const accounts = database.bankAccounts.findByConnectionId(conn.id);
 
   const syncLine = conn.last_sync_at
@@ -40,7 +50,7 @@ export function buildBankStatusText(conn: BankConnection): string {
       ? `\n⚠️ Ошибка синхронизации: ${conn.last_error}`
       : '';
 
-  return `🏦 ${conn.display_name} · ${syncLine} · ${statusEmoji}\nБаланс: ${balanceLine}${txLines}${errorLine}`;
+  return `🏦 ${conn.display_name} · ${syncLine} · ${statusEmoji}\nБаланс: ${balanceLine}${txLines}${errorLine}${bankCardsOffHint(cardsEnabled)}`;
 }
 
 /**
@@ -87,9 +97,11 @@ export function timeSince(isoDate: string): string {
 export function buildCombinedBankStatusText(
   connections: BankConnection[],
   totalEur: number,
+  cardsEnabled?: boolean,
 ): string {
+  // Per-section text omits the hint (cardsEnabled not forwarded) so it appears once below the total.
   const sections = connections.map((conn) => buildBankStatusText(conn)).join('\n\n');
-  return `${sections}\n\nИтого: ~${totalEur.toFixed(0)} EUR`;
+  return `${sections}\n\nИтого: ~${totalEur.toFixed(0)} EUR${bankCardsOffHint(cardsEnabled)}`;
 }
 
 /**

--- a/src/services/bank/panel-builder.ts
+++ b/src/services/bank/panel-builder.ts
@@ -15,7 +15,17 @@ function bankCardsOffHint(cardsEnabled: boolean): string {
   return cardsEnabled ? '' : '\n\n🔕 Карточки транзакций в чате выключены — включить в /settings';
 }
 
-export function buildBankStatusText(conn: BankConnection, cardsEnabled = true): string {
+/** Whether the group that owns this connection currently has chat cards enabled. */
+function cardsEnabledForConnection(conn: BankConnection): boolean {
+  return Boolean(database.groups.findById(conn.group_id)?.bank_cards_enabled);
+}
+
+/**
+ * Per-connection status section (balance, recent operations, errors).
+ * Does NOT include the cards-off hint — that is panel-level and added once by the
+ * public builders, so the combined multi-bank panel never repeats it per section.
+ */
+function renderBankSection(conn: BankConnection): string {
   const accounts = database.bankAccounts.findByConnectionId(conn.id);
 
   const syncLine = conn.last_sync_at
@@ -48,7 +58,16 @@ export function buildBankStatusText(conn: BankConnection, cardsEnabled = true): 
       ? `\n⚠️ Ошибка синхронизации: ${conn.last_error}`
       : '';
 
-  return `🏦 ${conn.display_name} · ${syncLine} · ${statusEmoji}\nБаланс: ${balanceLine}${txLines}${errorLine}${bankCardsOffHint(cardsEnabled)}`;
+  return `🏦 ${conn.display_name} · ${syncLine} · ${statusEmoji}\nБаланс: ${balanceLine}${txLines}${errorLine}`;
+}
+
+/**
+ * Single-connection panel text. The cards-off hint is resolved from the owning
+ * group here, so it persists across every render of the panel — the initial
+ * /bank view, sync-service status edits, and panel navigation alike.
+ */
+export function buildBankStatusText(conn: BankConnection): string {
+  return `${renderBankSection(conn)}${bankCardsOffHint(cardsEnabledForConnection(conn))}`;
 }
 
 /**
@@ -95,10 +114,12 @@ export function timeSince(isoDate: string): string {
 export function buildCombinedBankStatusText(
   connections: BankConnection[],
   totalEur: number,
-  cardsEnabled = true,
 ): string {
-  // Sections use the default cardsEnabled=true (no hint) so the hint appears once below the total.
-  const sections = connections.map((conn) => buildBankStatusText(conn)).join('\n\n');
+  // Sections render without the hint; it is appended once below the total. All
+  // connections in a panel belong to the same group, so the first one decides it.
+  const sections = connections.map(renderBankSection).join('\n\n');
+  const first = connections[0];
+  const cardsEnabled = first ? cardsEnabledForConnection(first) : true;
   return `${sections}\n\nИтого: ~${totalEur.toFixed(0)} EUR${bankCardsOffHint(cardsEnabled)}`;
 }
 

--- a/src/services/bank/sync-service.ts
+++ b/src/services/bank/sync-service.ts
@@ -380,7 +380,7 @@ async function runSyncCycle(connectionId: number, allowOtp = false): Promise<voi
     // When off, sync is balance/history-only: transactions stay in the DB as
     // pending, but no AI prefill is spent and no unsolicited cards are sent.
     if (group.bank_cards_enabled) {
-      await pushAutomaticCards(newPendingTxs, conn, group, connectionId, today);
+      await pushAutomaticCards(newPendingTxs, conn, group, today);
     } else if (newPendingTxs.length > 0) {
       logger.info(
         { connectionId, groupId: group.id, pending: newPendingTxs.length },
@@ -628,15 +628,15 @@ function extractTime(dateStr: string): string | null {
 }
 
 /**
- * Phase 2+3 of a sync cycle: AI-prefill the new pending transactions, push a
- * confirmation card for each of today's, and send an old-tx summary for the rest.
- * Called only when the group has bank cards enabled (the gate lives in runSyncCycle).
+ * Runs the chat-card steps of a sync cycle: AI-prefill the new pending
+ * transactions, push a confirmation card for each of today's, and send an
+ * old-tx summary for the rest. Called only when the group has bank cards
+ * enabled (the gate lives in runSyncCycle).
  */
 async function pushAutomaticCards(
   newPendingTxs: BankTransaction[],
   conn: BankConnection,
   group: Group,
-  connectionId: number,
   today: string,
 ): Promise<void> {
   // Phase 2: batch AI pre-fill for all new pending transactions
@@ -660,7 +660,7 @@ async function pushAutomaticCards(
 
     // Skip cards for transactions from excluded accounts
     if (inserted.account_id) {
-      const accounts = database.bankAccounts.findByConnectionId(connectionId);
+      const accounts = database.bankAccounts.findByConnectionId(conn.id);
       const account = accounts.find((a) => a.account_id === inserted.account_id);
       if (account?.is_excluded === 1) continue;
     }

--- a/src/services/bank/sync-service.ts
+++ b/src/services/bank/sync-service.ts
@@ -380,74 +380,7 @@ async function runSyncCycle(connectionId: number, allowOtp = false): Promise<voi
     // When off, sync is balance/history-only: transactions stay in the DB as
     // pending, but no AI prefill is spent and no unsolicited cards are sent.
     if (group.bank_cards_enabled) {
-      // Phase 2: batch AI pre-fill for all new pending transactions
-      const prefillResults = await preFillTransactions(newPendingTxs, group.id);
-      for (let i = 0; i < newPendingTxs.length; i++) {
-        const tx = newPendingTxs[i];
-        const prefilled = prefillResults[i];
-        if (tx && prefilled) {
-          database.bankTransactions.setPrefill(tx.id, prefilled.category, '');
-        }
-      }
-
-      // Phase 3: send confirmation cards — only for today's transactions
-      for (let i = 0; i < newPendingTxs.length; i++) {
-        const inserted = newPendingTxs[i];
-        const prefilled = prefillResults[i];
-        if (!inserted || !prefilled) continue;
-
-        // Skip cards for old transactions — stored in DB but no card sent
-        if (inserted.date !== today) continue;
-
-        // Skip cards for transactions from excluded accounts
-        if (inserted.account_id) {
-          const accounts = database.bankAccounts.findByConnectionId(connectionId);
-          const account = accounts.find((a) => a.account_id === inserted.account_id);
-          if (account?.is_excluded === 1) continue;
-        }
-
-        // Large transaction: compare EUR equivalent to threshold
-        const amountInEur = convertAnyToEUR(inserted.amount, inserted.currency);
-        const isLarge = amountInEur >= env.LARGE_TX_THRESHOLD_EUR;
-
-        const cardText = formatConfirmationCard(
-          inserted,
-          prefilled.category,
-          conn.display_name,
-          isLarge,
-        );
-
-        const result = await withChatContext(
-          group.telegram_group_id,
-          conn.panel_message_thread_id,
-          () =>
-            sendMessage(cardText, {
-              reply_markup: {
-                inline_keyboard: [
-                  [
-                    { text: '✅ Принять', callback_data: `bank_confirm:${inserted.id}` },
-                    { text: '✏️ Исправить', callback_data: `bank_edit:${inserted.id}` },
-                  ],
-                ],
-              },
-            }),
-        );
-
-        if (result) {
-          database.bankTransactions.setTelegramMessageId(inserted.id, result.message_id);
-        }
-      }
-
-      // Notify about old (non-today) transactions that were inserted this cycle
-      const oldTxsWithPrefill = newPendingTxs
-        .map((tx, i) => ({
-          tx,
-          category: prefillResults[i]?.category ?? tx.prefill_category ?? '—',
-        }))
-        .filter(({ tx }) => tx.date !== today);
-      if (oldTxsWithPrefill.length > 0) {
-        await notifyOldTransactions(oldTxsWithPrefill, conn, group);
-      }
+      await pushAutomaticCards(newPendingTxs, conn, group, connectionId, today);
     } else if (newPendingTxs.length > 0) {
       logger.info(
         { connectionId, groupId: group.id, pending: newPendingTxs.length },
@@ -692,6 +625,88 @@ function extractTime(dateStr: string): string | null {
   // Strip timezone offset and seconds — keep HH:MM
   const hhmm = timePart.slice(0, 5);
   return /^\d{2}:\d{2}$/.test(hhmm) ? hhmm : null;
+}
+
+/**
+ * Phase 2+3 of a sync cycle: AI-prefill the new pending transactions, push a
+ * confirmation card for each of today's, and send an old-tx summary for the rest.
+ * Called only when the group has bank cards enabled (the gate lives in runSyncCycle).
+ */
+async function pushAutomaticCards(
+  newPendingTxs: BankTransaction[],
+  conn: BankConnection,
+  group: Group,
+  connectionId: number,
+  today: string,
+): Promise<void> {
+  // Phase 2: batch AI pre-fill for all new pending transactions
+  const prefillResults = await preFillTransactions(newPendingTxs, group.id);
+  for (let i = 0; i < newPendingTxs.length; i++) {
+    const tx = newPendingTxs[i];
+    const prefilled = prefillResults[i];
+    if (tx && prefilled) {
+      database.bankTransactions.setPrefill(tx.id, prefilled.category, '');
+    }
+  }
+
+  // Phase 3: send confirmation cards — only for today's transactions
+  for (let i = 0; i < newPendingTxs.length; i++) {
+    const inserted = newPendingTxs[i];
+    const prefilled = prefillResults[i];
+    if (!inserted || !prefilled) continue;
+
+    // Skip cards for old transactions — stored in DB but no card sent
+    if (inserted.date !== today) continue;
+
+    // Skip cards for transactions from excluded accounts
+    if (inserted.account_id) {
+      const accounts = database.bankAccounts.findByConnectionId(connectionId);
+      const account = accounts.find((a) => a.account_id === inserted.account_id);
+      if (account?.is_excluded === 1) continue;
+    }
+
+    // Large transaction: compare EUR equivalent to threshold
+    const amountInEur = convertAnyToEUR(inserted.amount, inserted.currency);
+    const isLarge = amountInEur >= env.LARGE_TX_THRESHOLD_EUR;
+
+    const cardText = formatConfirmationCard(
+      inserted,
+      prefilled.category,
+      conn.display_name,
+      isLarge,
+    );
+
+    const result = await withChatContext(
+      group.telegram_group_id,
+      conn.panel_message_thread_id,
+      () =>
+        sendMessage(cardText, {
+          reply_markup: {
+            inline_keyboard: [
+              [
+                { text: '✅ Принять', callback_data: `bank_confirm:${inserted.id}` },
+                { text: '✏️ Исправить', callback_data: `bank_edit:${inserted.id}` },
+              ],
+            ],
+          },
+        }),
+    );
+
+    if (result) {
+      database.bankTransactions.setTelegramMessageId(inserted.id, result.message_id);
+    }
+  }
+
+  // Notify about old (non-today) transactions that were inserted this cycle
+  const oldTxsWithPrefill = newPendingTxs
+    .map((tx, i) => ({
+      tx,
+      category: prefillResults[i]?.category ?? tx.prefill_category ?? '—',
+    }))
+    .filter(({ tx }) => tx.date !== today);
+  if (oldTxsWithPrefill.length > 0) {
+    await notifyOldTransactions(oldTxsWithPrefill, conn, group);
+  }
 }
 
 function formatConfirmationCard(


### PR DESCRIPTION
Follow-ups to #97 (opt-in bank confirmation cards, default OFF), requested after merge.

- **feat(bank): hint in /bank panel when chat cards are off** — with cards off by default, transactions sync silently into the DB and the panel gave no clue. Append a one-line "🔕 Карточки транзакций в чате выключены — включить в /settings" reminder, shown once per panel. Addresses the discoverability half of #99.
- **refactor(bank): extract pushAutomaticCards from runSyncCycle** — flattens the extra nesting the cards gate introduced. Pure refactor; behavior + comments + the both-branch coverage in sync-service.test.ts unchanged. Closes #100.

Tests: full suite 3425 pass / 0 fail (+5 new hint tests). typecheck + lint clean. knip adds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)