### PR TITLE
feat(settings): group settings registry — AI can change any setting + editable /settings menu

### DIFF
--- a/docs/specs/2026-06-28-group-settings-registry.md
+++ b/docs/specs/2026-06-28-group-settings-registry.md
@@ -52,9 +52,29 @@ The five registered settings:
 |-----|------|-------|
 | `default_currency` | currency | restricted to `SUPPORTED_CURRENCIES` (they have reliable EUR rates); `apply` also keeps the new code in `enabled_currencies`. |
 | `enabled_currencies` | currency_multi | accepts any valid ISO-format code (onboarding parity with custom currencies); always keeps the default currency in the set; dedupes. |
-| `custom_prompt` | text | free text; `clear`/`сброс`/empty → `null`. |
-| `active_topic_id` | topic | integer, or `clear`/`сброс`/empty → `null`. |
+| `custom_prompt` | text | full-rewrite text, or `clear`/`сброс`/empty → `null`. **Adding/remembering a note uses `set_custom_prompt` (append), NOT this** — see the dual-writer contract below. |
+| `active_topic_id` | topic | **CLEAR-ONLY**: `clear`/`сброс`/empty → `null`; any numeric id is rejected with a Russian message telling the user to bind via `/topic`. |
 | `bank_cards_enabled` | toggle | `on/off`, `1/0`, `true/false`, `вкл/выкл`, … |
+
+`apply()` returns whether the write actually persisted (false if the group row vanished);
+`runSetting` turns a non-persisting write into a Russian "не удалось сохранить" error instead
+of a false "saved".
+
+#### `active_topic_id` is clear-only (anti-brick)
+
+If the AI or the menu could set `active_topic_id` to an arbitrary integer, the group could be
+pointed at a non-existent thread and silently stop responding. So the registry path only
+*clears* the binding; *binding* must go through the `/topic` command run INSIDE the target
+topic, where Telegram guarantees the thread exists. `/topic` writes the column directly and is
+unaffected.
+
+#### `custom_prompt` dual-writer contract
+
+Two tools write `custom_prompt`: `set_custom_prompt` (append — accumulates group notes) and
+`update_group_setting custom_prompt` (full overwrite/clear). To avoid the model wiping
+accumulated notes on "учти что …", the tool description, the `aiValueHint`, and the system
+prompt all state: **remembering/adding a note → `set_custom_prompt` (append); a full
+rewrite/clear on explicit request ("перепиши промпт"/"очисти промпт") → `update_group_setting`.**
 
 ### Enforcement — adding a column can't bypass the registry
 
@@ -89,20 +109,27 @@ setting and must never deflect to `/settings`.
 
 ### Editable `/settings` menu
 
-`buildSettingsView` renders one line per registry setting plus a read-only spreadsheet
-line. The keyboard exposes an action per setting; `handleSettingsCallback` routes
-`settings:*` callbacks (`edit`, `medit`, `set`, `mtog`, `back`, legacy `bankcards`) through
-**the same** `applyGroupSetting` path the AI uses. `callback_data` uses short latin registry
-keys + currency codes only (never raw Cyrillic labels), staying within Telegram's 64-byte
-limit.
+`buildSettingsView` renders one line per registry setting plus a read-only spreadsheet line.
+The keyboard is **generated from `GROUP_SETTINGS`, dispatched by `def.kind`** (toggle → in-place
+flip; currency → picker; currency_multi → multi-select; topic → topic sub-view; text → text
+sub-view) — so a newly-registered setting automatically gets a reachable button, with a `never`
+exhaustiveness guard forcing any new `kind` to be handled. A menu-side test asserts every
+`Object.keys(GROUP_SETTINGS)` produces a button — the menu analogue of the registry guard.
+
+`handleSettingsCallback` routes `settings:*` callbacks (`edit`, `medit`, `tedit`, `xedit`,
+`set`, `mtog`, `back`, legacy `bankcards`) through **the same** `applyGroupSetting` path the AI
+uses. `callback_data` uses short latin registry keys + currency codes only (never raw Cyrillic
+labels), staying within Telegram's 64-byte limit. User-controlled values (`custom_prompt`) are
+HTML-escaped before composing the menu text, since `/settings` sends `parse_mode: 'HTML'`.
 
 ## Decisions / limitations
 
 - `default_currency` is intentionally restricted to `SUPPORTED_CURRENCIES`; a default
   without a built-in EUR rate would break aggregate display (`convertCurrency`). EGP was
   added to `SUPPORTED_CURRENCIES` to satisfy the headline use case.
-- Free-text entry (`custom_prompt`) and topic selection (`active_topic_id`) are set by the
-  AI tool or existing flows (`/topic`); the menu offers only a "clear/reset" action for them.
+- Free-text entry (`custom_prompt`) is set in chat / by the AI; topic binding goes through
+  `/topic`. In the menu both expose a sub-view that shows the current value and a clear/reset
+  action only.
 - The multi-currency picker sources custom currencies from the enabled set, mirroring the
   onboarding picker (`createCurrencyKeyboard`): unchecking a custom code removes its button.
   Re-adding one is done via `update_group_setting` or `/connect`. A stateful in-menu

--- a/docs/specs/2026-06-28-group-settings-registry.md
+++ b/docs/specs/2026-06-28-group-settings-registry.md
@@ -1,0 +1,109 @@
+# Group Settings Registry
+
+Date: 2026-06-28
+Branch: `feat/group-settings-registry`
+
+## Problem
+
+A user asked the AI bot to "change the group's default currency to Egyptian pounds" and the
+bot replied it could not — there was no tool for changing group settings. Separately, the
+`/settings` command was read-only: it displayed the config and offered a single bank-cards
+toggle, nothing else was editable.
+
+The owner's requirement:
+
+1. The AI must be able to change **any** group setting.
+2. It must be **architecturally impossible** to add a group setting that the AI (and the
+   `/settings` menu) cannot change.
+3. `/settings` must become a real editable menu.
+
+All of this must be built around **one** settings registry that is the source of truth for
+both the AI tool and the `/settings` UI, so the two can never drift.
+
+## Design
+
+### The registry — `src/services/settings/group-settings-registry.ts`
+
+A `GroupSettingDef` describes one user-configurable group setting:
+
+- `key` — the `UpdateGroupData` column it writes.
+- `emoji`, `labelRu` — display metadata.
+- `kind` — discriminator: `'currency' | 'currency_multi' | 'toggle' | 'topic' | 'text'`.
+- `aiValueHint` — tells the AI what value string to pass.
+- `formatValue(group)` — renders the current stored value for display.
+- `parse(raw, group)` — robustly parses an LLM/user-supplied string into the typed value, or
+  returns a Russian error.
+- `apply(group, value)` — persists via `database.groups.update`, plus any side effects.
+
+`GroupSettingDef` is a **discriminated union** of one concrete interface per `kind`, each
+pinning `parse`/`apply` to a specific value type (`CurrencyCode`, `CurrencyCode[]`,
+`number`, `number | null`, `string | null`). The single shared mutation entry point is:
+
+```ts
+applyGroupSetting(def, group, raw): Promise<{ ok: true } | { ok: false; error: string }>
+```
+
+It `switch`es on `def.kind`, which narrows `def` to a concrete variant so `parse` and
+`apply` stay correlated on the same value type `V` — no `any`, no `as unknown as`.
+
+The five registered settings:
+
+| key | kind | notes |
+|-----|------|-------|
+| `default_currency` | currency | restricted to `SUPPORTED_CURRENCIES` (they have reliable EUR rates); `apply` also keeps the new code in `enabled_currencies`. |
+| `enabled_currencies` | currency_multi | accepts any valid ISO-format code (onboarding parity with custom currencies); always keeps the default currency in the set; dedupes. |
+| `custom_prompt` | text | free text; `clear`/`сброс`/empty → `null`. |
+| `active_topic_id` | topic | integer, or `clear`/`сброс`/empty → `null`. |
+| `bank_cards_enabled` | toggle | `on/off`, `1/0`, `true/false`, `вкл/выкл`, … |
+
+### Enforcement — adding a column can't bypass the registry
+
+Three layers make it a compile error (and a CI runtime error) to add a group setting that
+isn't reachable by the AI and the menu:
+
+1. `ALL_UPDATE_KEYS satisfies Record<keyof UpdateGroupData, true>` — an exhaustive map of
+   every `UpdateGroupData` key. Adding a column to `UpdateGroupData` without listing it here
+   fails to compile.
+2. `EditableGroupSettingKey = Exclude<keyof UpdateGroupData, SYSTEM_GROUP_FIELDS[number]>` —
+   every update key is either a system field or an editable setting.
+3. `GROUP_SETTINGS: { [K in EditableGroupSettingKey]: <def with key K> }` — every editable
+   key must have a matching, correctly-typed definition, or it fails to compile.
+
+A runtime test (`group-settings-registry.test.ts`) re-asserts
+`Object.keys(GROUP_SETTINGS)` equals `keys(ALL_UPDATE_KEYS)` minus `SYSTEM_GROUP_FIELDS`,
+so even a type-system workaround turns CI red. **The guard test fails the moment a new
+`UpdateGroupData` column is added without classifying it as either a system field or a
+registry-backed setting.**
+
+System fields (`SYSTEM_GROUP_FIELDS`): `title`, `invite_link`, `google_refresh_token`,
+`spreadsheet_id`, `bank_panel_summary_message_id`, `oauth_client`.
+
+### AI tool — `update_group_setting`
+
+`tools.ts` defines a single generic tool whose `setting` enum and per-setting value hints
+are generated from `GROUP_SETTINGS` (so they never drift). `tool-executor.ts`
+`executeUpdateGroupSetting` looks up the registry entry, runs `applyGroupSetting`, and
+returns a Russian success/error summary. `executeGetGroupSettings` renders every registry
+setting via `formatValue`. The agent system prompt states the AI can change any group
+setting and must never deflect to `/settings`.
+
+### Editable `/settings` menu
+
+`buildSettingsView` renders one line per registry setting plus a read-only spreadsheet
+line. The keyboard exposes an action per setting; `handleSettingsCallback` routes
+`settings:*` callbacks (`edit`, `medit`, `set`, `mtog`, `back`, legacy `bankcards`) through
+**the same** `applyGroupSetting` path the AI uses. `callback_data` uses short latin registry
+keys + currency codes only (never raw Cyrillic labels), staying within Telegram's 64-byte
+limit.
+
+## Decisions / limitations
+
+- `default_currency` is intentionally restricted to `SUPPORTED_CURRENCIES`; a default
+  without a built-in EUR rate would break aggregate display (`convertCurrency`). EGP was
+  added to `SUPPORTED_CURRENCIES` to satisfy the headline use case.
+- Free-text entry (`custom_prompt`) and topic selection (`active_topic_id`) are set by the
+  AI tool or existing flows (`/topic`); the menu offers only a "clear/reset" action for them.
+- The multi-currency picker sources custom currencies from the enabled set, mirroring the
+  onboarding picker (`createCurrencyKeyboard`): unchecking a custom code removes its button.
+  Re-adding one is done via `update_group_setting` or `/connect`. A stateful in-menu
+  custom-code entry flow was left out of scope.

--- a/src/bot/commands/settings.test.ts
+++ b/src/bot/commands/settings.test.ts
@@ -46,6 +46,7 @@ mock.module('../../database', () => ({
 const { handleSettingsCommand, handleSettingsCallback, buildSettingsView } = await import(
   './settings'
 );
+const { GROUP_SETTINGS } = await import('../../services/settings/group-settings-registry');
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -86,7 +87,8 @@ function fakeCallbackCtx(): Ctx['CallbackQuery'] {
 beforeEach(() => {
   sendMessageMock.mockReset().mockResolvedValue(null);
   groupsFindByTelegramGroupIdMock.mockReset().mockReturnValue(null);
-  groupsUpdateMock.mockReset().mockReturnValue(null);
+  // Default: update persists (returns the row). Tests for failed writes override this.
+  groupsUpdateMock.mockReset().mockReturnValue(fakeGroup());
   logMock.error.mockReset();
   logMock.warn.mockReset();
 });
@@ -123,36 +125,54 @@ describe('/settings rendering', () => {
     expect(logMock.error).not.toHaveBeenCalled();
   });
 
-  test('main keyboard exposes an action per setting', () => {
-    const view = buildSettingsView(fakeGroup({ bank_cards_enabled: 0 }));
-    const json = JSON.stringify(view.keyboard);
-    expect(json).toContain('Сменить валюту по умолчанию');
-    expect(json).toContain('settings:edit:default_currency');
-    expect(json).toContain('Изменить набор валют');
-    expect(json).toContain('settings:medit:enabled_currencies');
-    expect(json).toContain('Включить карточки банка');
-    expect(json).toContain('settings:set:bank_cards_enabled:on');
+  // Menu-side analogue of the registry enforcement test: EVERY registry setting must
+  // produce a reachable button. A new GROUP_SETTINGS entry that gets no button fails here.
+  test('every GROUP_SETTINGS key produces a reachable menu button', () => {
+    const json = JSON.stringify(buildSettingsView(fakeGroup()).keyboard);
+    for (const key of Object.keys(GROUP_SETTINGS)) {
+      expect(json).toContain(key);
+    }
+  });
+
+  test('main keyboard dispatches the right sub-action per kind', () => {
+    const json = JSON.stringify(buildSettingsView(fakeGroup({ bank_cards_enabled: 0 })).keyboard);
+    expect(json).toContain('settings:edit:default_currency'); // currency
+    expect(json).toContain('settings:medit:enabled_currencies'); // currency_multi
+    expect(json).toContain('settings:set:bank_cards_enabled:on'); // toggle (off → "on")
+    expect(json).toContain('settings:tedit:active_topic_id'); // topic
+    expect(json).toContain('settings:xedit:custom_prompt'); // text
   });
 
   test('bank-cards button reflects current state and clarifies off = balance only', () => {
     const off = buildSettingsView(fakeGroup({ bank_cards_enabled: 0 }));
     expect(off.text).toContain('Карточки банковских транзакций: выкл (только баланс)');
-    expect(JSON.stringify(off.keyboard)).toContain('Включить карточки банка');
+    expect(JSON.stringify(off.keyboard)).toContain('settings:set:bank_cards_enabled:on');
 
     const on = buildSettingsView(fakeGroup({ bank_cards_enabled: 1 }));
     expect(on.text).toContain('Карточки банковских транзакций: вкл');
-    expect(JSON.stringify(on.keyboard)).toContain('Выключить карточки банка');
+    expect(JSON.stringify(on.keyboard)).toContain('settings:set:bank_cards_enabled:off');
   });
 
-  test('clear buttons appear only when custom_prompt / topic are set', () => {
-    const empty = buildSettingsView(fakeGroup({ custom_prompt: null, active_topic_id: null }));
-    expect(JSON.stringify(empty.keyboard)).not.toContain('Очистить AI-промпт');
-    expect(JSON.stringify(empty.keyboard)).not.toContain('Сбросить топик');
+  // The global sanitizeOutgoingMessages hook re-decodes &lt;…&gt; and restores whitelisted
+  // tags, so entity-escaping would be undone. We neutralize tag chars with guillemets so a
+  // user's custom_prompt can never render as active formatting / a link in the menu.
+  test('neutralizes angle brackets in user-controlled values (no injection survives sanitizer)', () => {
+    const view = buildSettingsView(fakeGroup({ custom_prompt: '<b>x</b> <a href="z">l</a>' }));
+    expect(view.text).not.toContain('<b>');
+    expect(view.text).not.toContain('<a ');
+    expect(view.text).not.toContain('</');
+    // Look-alike guillemets are not tag characters; the sanitizer leaves them untouched.
+    expect(view.text).toContain('‹b›x‹/b›');
+  });
 
-    const set = buildSettingsView(fakeGroup({ custom_prompt: 'Be brief', active_topic_id: 42 }));
-    const json = JSON.stringify(set.keyboard);
-    expect(json).toContain('settings:set:custom_prompt:clear');
-    expect(json).toContain('settings:set:active_topic_id:clear');
+  test('neutralizes PRE-ENCODED tag delimiters too (sanitizer would decode &lt;…&gt;)', () => {
+    const view = buildSettingsView(
+      fakeGroup({ custom_prompt: '&lt;a href="https://x"&gt;click&lt;/a&gt;' }),
+    );
+    // No &lt;/&gt; left for the outgoing HTML sanitizer to decode back into a real tag.
+    expect(view.text).not.toContain('&lt;');
+    expect(view.text).not.toContain('&gt;');
+    expect(view.text).toContain('‹a href=');
   });
 
   test('sends friendly error message and logs when sender throws', async () => {
@@ -181,6 +201,8 @@ describe('/settings callbacks', () => {
     expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 1 });
     const editText = ctx.editText as ReturnType<typeof mock>;
     expect(editText).toHaveBeenCalled();
+    // Re-render must use HTML parse mode to match sendMessage, so escapeHtml is consistent.
+    expect(editText.mock.calls[0]?.[1]).toMatchObject({ parse_mode: 'HTML' });
     expect(logMock.error).not.toHaveBeenCalled();
     expect(logMock.warn).not.toHaveBeenCalled();
   });
@@ -301,6 +323,118 @@ describe('/settings callbacks', () => {
     const editText = ctx.editText as ReturnType<typeof mock>;
     const kbJson = JSON.stringify(editText.mock.calls[0]?.[1]);
     expect(kbJson).toContain('settings:mtog:enabled_currencies:GEL');
+  });
+
+  test('set bank_cards_enabled:off writes 0', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 1 }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'bank_cards_enabled', 'off']);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 0 });
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+
+  test('set custom_prompt:clear writes null', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ custom_prompt: 'old note' }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'custom_prompt', 'clear']);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { custom_prompt: null });
+  });
+
+  test('set active_topic_id:clear writes null', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ active_topic_id: 99 }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'active_topic_id', 'clear']);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { active_topic_id: null });
+  });
+
+  test('menu cannot set active_topic_id to a number (clear-only)', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup());
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'active_topic_id', '42']);
+
+    expect(groupsUpdateMock).not.toHaveBeenCalled();
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect((answer.mock.calls[0]?.[0] as { text: string }).text).toContain('/topic');
+  });
+
+  test('tedit opens the topic sub-view with a reset + back keyboard', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ active_topic_id: 5 }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['tedit', 'active_topic_id']);
+
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    expect(editText.mock.calls[0]?.[0] as string).toContain('/topic');
+    const kbJson = JSON.stringify(editText.mock.calls[0]?.[1]);
+    expect(kbJson).toContain('settings:set:active_topic_id:clear');
+    expect(kbJson).toContain('settings:back');
+  });
+
+  test('xedit opens the text sub-view with a clear + back keyboard', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ custom_prompt: 'note' }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['xedit', 'custom_prompt']);
+
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const kbJson = JSON.stringify(editText.mock.calls[0]?.[1]);
+    expect(kbJson).toContain('settings:set:custom_prompt:clear');
+    expect(kbJson).toContain('settings:back');
+  });
+
+  test('set with an unknown setting key answers "Неверные данные"', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup());
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'spreadsheet_id', 'x']);
+
+    expect(groupsUpdateMock).not.toHaveBeenCalled();
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect(answer.mock.calls[0]?.[0]).toMatchObject({ text: 'Неверные данные' });
+  });
+
+  test('unknown sub-action answers "Неизвестное действие"', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup());
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['garbage']);
+
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect(answer.mock.calls[0]?.[0]).toMatchObject({ text: 'Неизвестное действие' });
+  });
+
+  test('edit/medit with a wrong-kind key answer "Неверные данные"', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup());
+
+    const editCtx = fakeCallbackCtx();
+    await handleSettingsCallback(editCtx, ['edit', 'enabled_currencies']); // not a 'currency' kind
+    expect(
+      (editCtx.answerCallbackQuery as ReturnType<typeof mock>).mock.calls[0]?.[0],
+    ).toMatchObject({ text: 'Неверные данные' });
+
+    const meditCtx = fakeCallbackCtx();
+    await handleSettingsCallback(meditCtx, ['medit', 'default_currency']); // not 'currency_multi'
+    expect(
+      (meditCtx.answerCallbackQuery as ReturnType<typeof mock>).mock.calls[0]?.[0],
+    ).toMatchObject({ text: 'Неверные данные' });
+  });
+
+  test('reports failure when the update does not persist', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 0 }));
+    groupsUpdateMock.mockReturnValue(null); // write fails
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'bank_cards_enabled', 'on']);
+
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect((answer.mock.calls[0]?.[0] as { text: string }).text).toContain('Не удалось');
   });
 
   test('answers "Группа не настроена" when the group is missing', async () => {

--- a/src/bot/commands/settings.test.ts
+++ b/src/bot/commands/settings.test.ts
@@ -1,4 +1,4 @@
-// Tests for /settings — renders current group config, handles errors
+// Tests for /settings — registry-driven editable menu: rendering, currency edit, toggles.
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { CurrencyCode } from '../../config/constants';
@@ -28,7 +28,7 @@ mock.module('../../services/bank/telegram-sender', () => ({
   deleteMessage: mock(() => Promise.resolve()),
 }));
 
-// ── Database ──────────────────────────────────────────────────────────────
+// ── Database (shared by settings.ts AND the registry it calls) ─────────────
 
 const groupsFindByTelegramGroupIdMock = mock((_id: number): Group | null => null);
 const groupsUpdateMock = mock((_id: number, _data: Partial<Group>): Group | null => null);
@@ -43,7 +43,7 @@ mock.module('../../database', () => ({
 
 // ── Import after mocks ────────────────────────────────────────────────────
 
-const { handleSettingsCommand, handleSettingsBankCardsToggle, buildSettingsView } = await import(
+const { handleSettingsCommand, handleSettingsCallback, buildSettingsView } = await import(
   './settings'
 );
 
@@ -71,7 +71,7 @@ function fakeGroup(overrides: Partial<Group> = {}): Group {
     created_at: '',
     updated_at: '',
     ...overrides,
-  } as Group;
+  };
 }
 
 function fakeCallbackCtx(): Ctx['CallbackQuery'] {
@@ -91,10 +91,10 @@ beforeEach(() => {
   logMock.warn.mockReset();
 });
 
-// ── Tests ─────────────────────────────────────────────────────────────────
+// ── Rendering ─────────────────────────────────────────────────────────────
 
-describe('/settings', () => {
-  test('renders default currency, enabled currencies, and spreadsheet status (connected)', async () => {
+describe('/settings rendering', () => {
+  test('renders every registry setting plus the spreadsheet status', async () => {
     await handleSettingsCommand(
       fakeCtx(),
       fakeGroup({
@@ -109,6 +109,8 @@ describe('/settings', () => {
     expect(msg).toContain('Настройки группы');
     expect(msg).toContain('Валюта по умолчанию: EUR');
     expect(msg).toContain('EUR, USD, RSD');
+    expect(msg).toContain('AI-промпт: не задан');
+    expect(msg).toContain('Топик: не задан');
     expect(msg).toContain('Таблица: настроена');
     expect(logMock.error).not.toHaveBeenCalled();
   });
@@ -121,29 +123,36 @@ describe('/settings', () => {
     expect(logMock.error).not.toHaveBeenCalled();
   });
 
-  test('shows non-EUR default currency correctly', async () => {
-    await handleSettingsCommand(
-      fakeCtx(),
-      fakeGroup({
-        default_currency: 'RSD' as CurrencyCode,
-        enabled_currencies: ['RSD'] as CurrencyCode[],
-      }),
-    );
-
-    const msg = sendMessageMock.mock.calls[0]?.[0] as string;
-    expect(msg).toContain('Валюта по умолчанию: RSD');
-    expect(msg).toContain('Включенные валюты: RSD');
+  test('main keyboard exposes an action per setting', () => {
+    const view = buildSettingsView(fakeGroup({ bank_cards_enabled: 0 }));
+    const json = JSON.stringify(view.keyboard);
+    expect(json).toContain('Сменить валюту по умолчанию');
+    expect(json).toContain('settings:edit:default_currency');
+    expect(json).toContain('Изменить набор валют');
+    expect(json).toContain('settings:medit:enabled_currencies');
+    expect(json).toContain('Включить карточки банка');
+    expect(json).toContain('settings:set:bank_cards_enabled:on');
   });
 
-  test('single enabled currency renders without extra commas', async () => {
-    await handleSettingsCommand(
-      fakeCtx(),
-      fakeGroup({ enabled_currencies: ['USD'] as CurrencyCode[] }),
-    );
+  test('bank-cards button reflects current state and clarifies off = balance only', () => {
+    const off = buildSettingsView(fakeGroup({ bank_cards_enabled: 0 }));
+    expect(off.text).toContain('Карточки банковских транзакций: выкл (только баланс)');
+    expect(JSON.stringify(off.keyboard)).toContain('Включить карточки банка');
 
-    const msg = sendMessageMock.mock.calls[0]?.[0] as string;
-    expect(msg).toContain('Включенные валюты: USD\n');
-    expect(msg).not.toContain('USD,');
+    const on = buildSettingsView(fakeGroup({ bank_cards_enabled: 1 }));
+    expect(on.text).toContain('Карточки банковских транзакций: вкл');
+    expect(JSON.stringify(on.keyboard)).toContain('Выключить карточки банка');
+  });
+
+  test('clear buttons appear only when custom_prompt / topic are set', () => {
+    const empty = buildSettingsView(fakeGroup({ custom_prompt: null, active_topic_id: null }));
+    expect(JSON.stringify(empty.keyboard)).not.toContain('Очистить AI-промпт');
+    expect(JSON.stringify(empty.keyboard)).not.toContain('Сбросить топик');
+
+    const set = buildSettingsView(fakeGroup({ custom_prompt: 'Be brief', active_topic_id: 42 }));
+    const json = JSON.stringify(set.keyboard);
+    expect(json).toContain('settings:set:custom_prompt:clear');
+    expect(json).toContain('settings:set:active_topic_id:clear');
   });
 
   test('sends friendly error message and logs when sender throws', async () => {
@@ -153,72 +162,155 @@ describe('/settings', () => {
 
     await handleSettingsCommand(fakeCtx(), fakeGroup());
 
-    // First call threw; catch block should call sendMessage again
     expect(sendMessageMock).toHaveBeenCalledTimes(2);
     expect(logMock.error).toHaveBeenCalled();
-
     const errMsg = sendMessageMock.mock.calls[1]?.[0] as string;
     expect(errMsg).toContain('непредвиденная');
   });
-
-  test('renders bank-cards state and a toggle button reflecting it', async () => {
-    await handleSettingsCommand(fakeCtx(), fakeGroup({ bank_cards_enabled: 0 }));
-
-    const msg = sendMessageMock.mock.calls[0]?.[0] as string;
-    expect(msg).toContain('Карточки банковских транзакций: выкл');
-    // Off state must clarify that only the balance keeps syncing.
-    expect(msg).toContain('только баланс');
-
-    const opts = sendMessageMock.mock.calls[0]?.[1] as { reply_markup?: unknown } | undefined;
-    expect(opts?.reply_markup).toBeDefined();
-    const view = buildSettingsView(fakeGroup({ bank_cards_enabled: 0 }));
-    expect(view.text).toContain('выкл');
-    expect(JSON.stringify(view.keyboard)).toContain('Включить карточки банка');
-
-    const onView = buildSettingsView(fakeGroup({ bank_cards_enabled: 1 }));
-    expect(onView.text).toContain('Карточки банковских транзакций: вкл');
-    expect(JSON.stringify(onView.keyboard)).toContain('Выключить карточки банка');
-  });
 });
 
-describe('/settings bank-cards toggle', () => {
-  test('flips bank_cards_enabled from 0 to 1 and re-renders', async () => {
+// ── Callback flow ───────────────────────────────────────────────────────────
+
+describe('/settings callbacks', () => {
+  test('set bank_cards_enabled:on writes 1 and re-renders in place', async () => {
     groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 0 }));
-    groupsUpdateMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 1 }));
 
     const ctx = fakeCallbackCtx();
-    await handleSettingsBankCardsToggle(ctx);
+    await handleSettingsCallback(ctx, ['set', 'bank_cards_enabled', 'on']);
 
     expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 1 });
     const editText = ctx.editText as ReturnType<typeof mock>;
-    const editedText = editText.mock.calls[0]?.[0] as string;
-    expect(editedText).toContain('Карточки банковских транзакций: вкл');
+    expect(editText).toHaveBeenCalled();
     expect(logMock.error).not.toHaveBeenCalled();
+    expect(logMock.warn).not.toHaveBeenCalled();
   });
 
-  test('flips bank_cards_enabled from 1 to 0 and re-renders', async () => {
+  test('legacy bankcards sub-action flips the current state', async () => {
     groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 1 }));
-    groupsUpdateMock.mockReturnValue(fakeGroup({ bank_cards_enabled: 0 }));
 
     const ctx = fakeCallbackCtx();
-    await handleSettingsBankCardsToggle(ctx);
+    await handleSettingsCallback(ctx, ['bankcards']);
 
     expect(groupsUpdateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 0 });
-    const editText = ctx.editText as ReturnType<typeof mock>;
-    const editedText = editText.mock.calls[0]?.[0] as string;
-    expect(editedText).toContain('Карточки банковских транзакций: выкл');
     expect(logMock.error).not.toHaveBeenCalled();
   });
 
-  test('answers with error and does not update when group is missing', async () => {
+  test('set default_currency changes it and keeps it enabled', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(
+      fakeGroup({ default_currency: 'EUR', enabled_currencies: ['EUR', 'USD'] }),
+    );
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'default_currency', 'rsd']);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, {
+      default_currency: 'RSD',
+      enabled_currencies: ['EUR', 'USD', 'RSD'],
+    });
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect(answer.mock.calls[0]?.[0]).toMatchObject({ text: '✅ Сохранено' });
+  });
+
+  test('invalid currency shows a Russian error and writes nothing', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup());
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['set', 'default_currency', 'zzz']);
+
+    expect(groupsUpdateMock).not.toHaveBeenCalled();
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    const text = (answer.mock.calls[0]?.[0] as { text: string }).text;
+    expect(text).toContain('ZZZ');
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+
+  test('edit opens the default-currency picker sub-view', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup({ default_currency: 'EUR' }));
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['edit', 'default_currency']);
+
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const kbJson = JSON.stringify(editText.mock.calls[0]?.[1]);
+    expect(kbJson).toContain('settings:set:default_currency:RSD');
+    expect(kbJson).toContain('settings:back');
+    expect(logMock.error).not.toHaveBeenCalled();
+  });
+
+  test('medit opens the multi-currency picker sub-view', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(
+      fakeGroup({ enabled_currencies: ['EUR', 'USD'] }),
+    );
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['medit', 'enabled_currencies']);
+
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const kbJson = JSON.stringify(editText.mock.calls[0]?.[1]);
+    expect(kbJson).toContain('settings:mtog:enabled_currencies:RSD');
+    expect(kbJson).toContain('settings:back');
+  });
+
+  test('mtog adds a currency to the enabled set', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(
+      fakeGroup({ default_currency: 'EUR', enabled_currencies: ['EUR', 'USD'] }),
+    );
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['mtog', 'enabled_currencies', 'RSD']);
+
+    expect(groupsUpdateMock).toHaveBeenCalledWith(-100, {
+      enabled_currencies: ['EUR', 'USD', 'RSD'],
+    });
+  });
+
+  test('mtog refuses to remove the default currency', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(
+      fakeGroup({ default_currency: 'EUR', enabled_currencies: ['EUR', 'USD'] }),
+    );
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['mtog', 'enabled_currencies', 'EUR']);
+
+    expect(groupsUpdateMock).not.toHaveBeenCalled();
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect((answer.mock.calls[0]?.[0] as { text: string }).text).toContain('по умолчанию');
+  });
+
+  test('back answers the callback and re-renders the main view', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(fakeGroup());
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['back']);
+
+    const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
+    expect(answer).toHaveBeenCalled();
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const renderedText = editText.mock.calls[0]?.[0] as string;
+    expect(renderedText).toContain('Настройки группы');
+  });
+
+  test('multi-select keeps custom (non-built-in) currencies editable', async () => {
+    groupsFindByTelegramGroupIdMock.mockReturnValue(
+      fakeGroup({ default_currency: 'EUR', enabled_currencies: ['EUR', 'GEL'] as CurrencyCode[] }),
+    );
+
+    const ctx = fakeCallbackCtx();
+    await handleSettingsCallback(ctx, ['medit', 'enabled_currencies']);
+
+    const editText = ctx.editText as ReturnType<typeof mock>;
+    const kbJson = JSON.stringify(editText.mock.calls[0]?.[1]);
+    expect(kbJson).toContain('settings:mtog:enabled_currencies:GEL');
+  });
+
+  test('answers "Группа не настроена" when the group is missing', async () => {
     groupsFindByTelegramGroupIdMock.mockReturnValue(null);
 
     const ctx = fakeCallbackCtx();
-    await handleSettingsBankCardsToggle(ctx);
+    await handleSettingsCallback(ctx, ['edit', 'default_currency']);
 
     expect(groupsUpdateMock).not.toHaveBeenCalled();
     const answer = ctx.answerCallbackQuery as ReturnType<typeof mock>;
     expect(answer.mock.calls[0]?.[0]).toMatchObject({ text: 'Группа не настроена' });
-    expect(logMock.error).not.toHaveBeenCalled();
   });
 });

--- a/src/bot/commands/settings.ts
+++ b/src/bot/commands/settings.ts
@@ -1,36 +1,62 @@
-/** /settings command — shows current group config and a per-group bank-cards toggle */
+/** /settings command — editable group settings menu driven by the settings registry. */
 import { InlineKeyboard } from 'gramio';
 import { database } from '../../database';
 import type { Group } from '../../database/types';
 import { sendMessage } from '../../services/bank/telegram-sender';
+import {
+  applyGroupSetting,
+  GROUP_SETTINGS,
+  isEditableGroupSettingKey,
+} from '../../services/settings/group-settings-registry';
 import { createLogger } from '../../utils/logger.ts';
 import { formatErrorForUser } from '../bot-error-formatter';
+import {
+  createSettingsCurrencyPickKeyboard,
+  createSettingsMultiCurrencyKeyboard,
+} from '../keyboards';
 import type { Ctx } from '../types';
 
 const logger = createLogger('cmd-settings');
 
-/** Callback data for the bank-cards toggle button (kept short for the 64-byte limit) */
-const SETTINGS_BANK_CARDS_CALLBACK = 'settings:bankcards';
-
 /**
- * Build the settings message text and keyboard for a group.
- * Shared by the /settings command and its toggle callback so both render identically.
+ * Build the settings message text and main keyboard for a group.
+ * Every registry-backed setting renders as a line; the keyboard exposes an action per setting.
  */
 export function buildSettingsView(group: Group): { text: string; keyboard: InlineKeyboard } {
-  const cardsOn = !!group.bank_cards_enabled;
-
   let text = '⚙️ Настройки группы:\n\n';
-  text += `💱 Валюта по умолчанию: ${group.default_currency}\n`;
-  text += `💵 Включенные валюты: ${group.enabled_currencies.join(', ')}\n`;
+  for (const def of Object.values(GROUP_SETTINGS)) {
+    text += `${def.emoji} ${def.labelRu}: ${def.formatValue(group)}\n`;
+  }
+  // spreadsheet_id is a system field — show it as read-only info, no button.
   text += `📊 Таблица: ${group.spreadsheet_id ? 'настроена' : 'не настроена'}\n`;
-  text += `🔔 Карточки банковских транзакций: ${cardsOn ? 'вкл' : 'выкл (только баланс)'}\n`;
 
-  const keyboard = new InlineKeyboard().text(
-    cardsOn ? '🔕 Выключить карточки банка' : '🔔 Включить карточки банка',
-    SETTINGS_BANK_CARDS_CALLBACK,
-  );
+  return { text, keyboard: buildSettingsKeyboard(group) };
+}
 
-  return { text, keyboard };
+/** Main settings keyboard: one action per editable setting. */
+function buildSettingsKeyboard(group: Group): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+
+  keyboard.text('💱 Сменить валюту по умолчанию', 'settings:edit:default_currency').row();
+  keyboard.text('💵 Изменить набор валют', 'settings:medit:enabled_currencies').row();
+
+  const cardsOn = !!group.bank_cards_enabled;
+  keyboard
+    .text(
+      cardsOn ? '🔕 Выключить карточки банка' : '🔔 Включить карточки банка',
+      `settings:set:bank_cards_enabled:${cardsOn ? 'off' : 'on'}`,
+    )
+    .row();
+
+  // Free-text / topic settings: offer an in-place "clear" only when a value is set.
+  if (group.custom_prompt) {
+    keyboard.text('📝 Очистить AI-промпт', 'settings:set:custom_prompt:clear').row();
+  }
+  if (group.active_topic_id != null) {
+    keyboard.text('📍 Сбросить топик', 'settings:set:active_topic_id:clear').row();
+  }
+
+  return keyboard;
 }
 
 /**
@@ -48,38 +74,177 @@ export async function handleSettingsCommand(ctx: Ctx['Command'], group: Group): 
 }
 
 /**
- * Toggle the per-group bank_cards_enabled setting from the /settings keyboard,
- * then re-render the settings view in place.
+ * Route every `settings:*` callback. Sub-actions share the registry's parse/apply path, so
+ * the menu and the AI tool mutate group settings through identical code.
  */
-export async function handleSettingsBankCardsToggle(ctx: Ctx['CallbackQuery']): Promise<void> {
+export async function handleSettingsCallback(
+  ctx: Ctx['CallbackQuery'],
+  params: string[],
+): Promise<void> {
+  const chatId = ctx.message?.chat?.id;
+  const group = chatId ? database.groups.findByTelegramGroupId(chatId) : null;
+  if (!chatId || !group) {
+    await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
+    return;
+  }
+
+  const [sub, key, value] = params;
   try {
-    const chatId = ctx.message?.chat?.id;
-    if (!chatId) {
-      await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
-      return;
+    switch (sub) {
+      case 'edit':
+        await openCurrencyPicker(ctx, group, key);
+        break;
+      case 'medit':
+        await openMultiCurrencyPicker(ctx, group, key);
+        break;
+      case 'set':
+        await applySetting(ctx, chatId, key, value);
+        break;
+      case 'mtog':
+        await toggleEnabledCurrency(ctx, group, value);
+        break;
+      case 'back':
+        await ctx.answerCallbackQuery();
+        await renderMain(ctx, chatId);
+        break;
+      case 'bankcards':
+        // Back-compat: legacy bank-cards toggle button from messages sent before this menu.
+        await applySetting(
+          ctx,
+          chatId,
+          'bank_cards_enabled',
+          group.bank_cards_enabled ? 'off' : 'on',
+        );
+        break;
+      default:
+        await ctx.answerCallbackQuery({ text: 'Неизвестное действие' });
     }
+  } catch (error) {
+    logger.error({ err: error }, '[CMD] Error in /settings callback');
+    await ctx.answerCallbackQuery({ text: 'Ошибка' });
+  }
+}
 
-    const group = database.groups.findByTelegramGroupId(chatId);
-    if (!group) {
-      await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
-      return;
-    }
+/** Parse + apply a raw value for `key` through the registry, then re-render the main view. */
+async function applySetting(
+  ctx: Ctx['CallbackQuery'],
+  chatId: number,
+  key: string | undefined,
+  value: string | undefined,
+): Promise<void> {
+  if (!key || value === undefined || !isEditableGroupSettingKey(key)) {
+    await ctx.answerCallbackQuery({ text: 'Неверные данные' });
+    return;
+  }
 
-    const next = group.bank_cards_enabled ? 0 : 1;
-    const updated = database.groups.update(group.telegram_group_id, { bank_cards_enabled: next });
-    if (!updated) {
-      await ctx.answerCallbackQuery({ text: 'Не удалось сохранить' });
-      return;
-    }
+  const group = database.groups.findByTelegramGroupId(chatId);
+  if (!group) {
+    await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
+    return;
+  }
 
-    await ctx.answerCallbackQuery({
-      text: next ? '🔔 Карточки банка включены' : '🔕 Карточки банка выключены',
-    });
+  const result = await applyGroupSetting(GROUP_SETTINGS[key], group, value);
+  if (!result.ok) {
+    await ctx.answerCallbackQuery({ text: result.error.slice(0, 200) });
+    return;
+  }
 
-    const { text, keyboard } = buildSettingsView(updated);
+  await ctx.answerCallbackQuery({ text: '✅ Сохранено' });
+  await renderMain(ctx, chatId);
+}
+
+/** Toggle one currency in the enabled set (the default currency can never be removed). */
+async function toggleEnabledCurrency(
+  ctx: Ctx['CallbackQuery'],
+  group: Group,
+  code: string | undefined,
+): Promise<void> {
+  if (!code) {
+    await ctx.answerCallbackQuery({ text: 'Неверные данные' });
+    return;
+  }
+  if (code === group.default_currency) {
+    await ctx.answerCallbackQuery({ text: 'Это валюта по умолчанию, её нельзя убрать' });
+    return;
+  }
+
+  const next = new Set<string>(group.enabled_currencies);
+  if (next.has(code)) next.delete(code);
+  else next.add(code);
+
+  const result = await applyGroupSetting(
+    GROUP_SETTINGS.enabled_currencies,
+    group,
+    [...next].join(','),
+  );
+  if (!result.ok) {
+    await ctx.answerCallbackQuery({ text: result.error.slice(0, 200) });
+    return;
+  }
+
+  await ctx.answerCallbackQuery();
+  const updated = database.groups.findByTelegramGroupId(group.telegram_group_id);
+  if (updated) await renderMultiCurrency(ctx, updated);
+}
+
+async function openCurrencyPicker(
+  ctx: Ctx['CallbackQuery'],
+  group: Group,
+  key: string | undefined,
+): Promise<void> {
+  if (key !== 'default_currency') {
+    await ctx.answerCallbackQuery({ text: 'Неверные данные' });
+    return;
+  }
+  await ctx.answerCallbackQuery();
+  await editView(
+    ctx,
+    '💱 Выбери валюту по умолчанию:',
+    createSettingsCurrencyPickKeyboard(group.default_currency),
+  );
+}
+
+async function openMultiCurrencyPicker(
+  ctx: Ctx['CallbackQuery'],
+  group: Group,
+  key: string | undefined,
+): Promise<void> {
+  if (key !== 'enabled_currencies') {
+    await ctx.answerCallbackQuery({ text: 'Неверные данные' });
+    return;
+  }
+  await ctx.answerCallbackQuery();
+  await renderMultiCurrency(ctx, group);
+}
+
+async function renderMultiCurrency(ctx: Ctx['CallbackQuery'], group: Group): Promise<void> {
+  const text = `💵 Отметь включённые валюты:\nСейчас: ${group.enabled_currencies.join(', ')}`;
+  await editView(
+    ctx,
+    text,
+    createSettingsMultiCurrencyKeyboard(group.enabled_currencies, group.default_currency),
+  );
+}
+
+async function renderMain(ctx: Ctx['CallbackQuery'], chatId: number): Promise<void> {
+  const group = database.groups.findByTelegramGroupId(chatId);
+  if (!group) {
+    await ctx.answerCallbackQuery({ text: 'Группа не настроена' });
+    return;
+  }
+  const { text, keyboard } = buildSettingsView(group);
+  await editView(ctx, text, keyboard);
+}
+
+/** Edit the settings message in place, tolerating Telegram "message not modified" errors. */
+async function editView(
+  ctx: Ctx['CallbackQuery'],
+  text: string,
+  keyboard: InlineKeyboard,
+): Promise<void> {
+  try {
     await ctx.editText(text, { reply_markup: keyboard });
   } catch (error) {
-    logger.error({ err: error }, '[CMD] Error toggling bank cards in /settings');
-    await ctx.answerCallbackQuery({ text: 'Ошибка' });
+    logger.warn({ err: error }, '[CMD] /settings editText failed');
   }
 }

--- a/src/bot/commands/settings.ts
+++ b/src/bot/commands/settings.ts
@@ -1,4 +1,4 @@
-/** /settings command — editable group settings menu driven by the settings registry. */
+/** /settings command — editable group settings menu generated entirely from the registry. */
 import { InlineKeyboard } from 'gramio';
 import { database } from '../../database';
 import type { Group } from '../../database/types';
@@ -6,6 +6,7 @@ import { sendMessage } from '../../services/bank/telegram-sender';
 import {
   applyGroupSetting,
   GROUP_SETTINGS,
+  type GroupSettingDef,
   isEditableGroupSettingKey,
 } from '../../services/settings/group-settings-registry';
 import { createLogger } from '../../utils/logger.ts';
@@ -19,13 +20,30 @@ import type { Ctx } from '../types';
 const logger = createLogger('cmd-settings');
 
 /**
+ * Neutralize tag delimiters in user-controlled values (custom_prompt) before they go into a
+ * menu message. Entity-escaping would NOT work here: every outgoing HTML message passes through
+ * the global `sanitizeOutgoingMessages` hook, which decodes `&lt;`/`&gt;`/`&amp;` and restores
+ * whitelisted tags — so an escaped `<b>`/`<a href>` would come back as active formatting/a link.
+ *
+ * We replace BOTH raw `<`/`>` AND the literal `&lt;`/`&gt;` substrings with look-alike
+ * guillemets (‹ ›) so nothing the sanitizer decodes can form a tag (covers a prompt that
+ * already contains pre-encoded delimiters). Numeric entities (`&#60;`) are safe: the sanitizer
+ * doesn't decode them. Bare `&` needs no handling — the HTML sanitizer escapes it consistently.
+ */
+function neutralizeForMenu(text: string): string {
+  return text.replace(/&lt;/gi, '‹').replace(/&gt;/gi, '›').replace(/</g, '‹').replace(/>/g, '›');
+}
+
+/**
  * Build the settings message text and main keyboard for a group.
- * Every registry-backed setting renders as a line; the keyboard exposes an action per setting.
+ * Both are generated from GROUP_SETTINGS, so a newly-registered setting automatically gets a
+ * line and a reachable button — the menu-side analogue of the registry enforcement guarantee.
  */
 export function buildSettingsView(group: Group): { text: string; keyboard: InlineKeyboard } {
   let text = '⚙️ Настройки группы:\n\n';
   for (const def of Object.values(GROUP_SETTINGS)) {
-    text += `${def.emoji} ${def.labelRu}: ${def.formatValue(group)}\n`;
+    // formatValue may contain user-controlled text (custom_prompt) — neutralize tag chars.
+    text += `${def.emoji} ${def.labelRu}: ${neutralizeForMenu(def.formatValue(group))}\n`;
   }
   // spreadsheet_id is a system field — show it as read-only info, no button.
   text += `📊 Таблица: ${group.spreadsheet_id ? 'настроена' : 'не настроена'}\n`;
@@ -33,30 +51,44 @@ export function buildSettingsView(group: Group): { text: string; keyboard: Inlin
   return { text, keyboard: buildSettingsKeyboard(group) };
 }
 
-/** Main settings keyboard: one action per editable setting. */
+/** Main keyboard: exactly one action button per registry setting, dispatched by def.kind. */
 function buildSettingsKeyboard(group: Group): InlineKeyboard {
   const keyboard = new InlineKeyboard();
-
-  keyboard.text('💱 Сменить валюту по умолчанию', 'settings:edit:default_currency').row();
-  keyboard.text('💵 Изменить набор валют', 'settings:medit:enabled_currencies').row();
-
-  const cardsOn = !!group.bank_cards_enabled;
-  keyboard
-    .text(
-      cardsOn ? '🔕 Выключить карточки банка' : '🔔 Включить карточки банка',
-      `settings:set:bank_cards_enabled:${cardsOn ? 'off' : 'on'}`,
-    )
-    .row();
-
-  // Free-text / topic settings: offer an in-place "clear" only when a value is set.
-  if (group.custom_prompt) {
-    keyboard.text('📝 Очистить AI-промпт', 'settings:set:custom_prompt:clear').row();
+  for (const def of Object.values(GROUP_SETTINGS)) {
+    addSettingButton(keyboard, def, group);
+    keyboard.row();
   }
-  if (group.active_topic_id != null) {
-    keyboard.text('📍 Сбросить топик', 'settings:set:active_topic_id:clear').row();
-  }
-
   return keyboard;
+}
+
+function addSettingButton(keyboard: InlineKeyboard, def: GroupSettingDef, group: Group): void {
+  switch (def.kind) {
+    case 'toggle': {
+      const on = def.current(group) === 1;
+      keyboard.text(
+        `${def.emoji} ${def.labelRu}: ${on ? 'выключить' : 'включить'}`,
+        `settings:set:${def.key}:${on ? 'off' : 'on'}`,
+      );
+      return;
+    }
+    case 'currency':
+      keyboard.text(`${def.emoji} ${def.labelRu}`, `settings:edit:${def.key}`);
+      return;
+    case 'currency_multi':
+      keyboard.text(`${def.emoji} ${def.labelRu}`, `settings:medit:${def.key}`);
+      return;
+    case 'topic':
+      keyboard.text(`${def.emoji} ${def.labelRu}`, `settings:tedit:${def.key}`);
+      return;
+    case 'text':
+      keyboard.text(`${def.emoji} ${def.labelRu}`, `settings:xedit:${def.key}`);
+      return;
+    default: {
+      // A new kind must be handled above or this fails to compile.
+      const exhaustive: never = def;
+      throw new Error(`Unhandled setting kind: ${String(exhaustive)}`);
+    }
+  }
 }
 
 /**
@@ -90,38 +122,51 @@ export async function handleSettingsCallback(
 
   const [sub, key, value] = params;
   try {
-    switch (sub) {
-      case 'edit':
-        await openCurrencyPicker(ctx, group, key);
-        break;
-      case 'medit':
-        await openMultiCurrencyPicker(ctx, group, key);
-        break;
-      case 'set':
-        await applySetting(ctx, chatId, key, value);
-        break;
-      case 'mtog':
-        await toggleEnabledCurrency(ctx, group, value);
-        break;
-      case 'back':
-        await ctx.answerCallbackQuery();
-        await renderMain(ctx, chatId);
-        break;
-      case 'bankcards':
-        // Back-compat: legacy bank-cards toggle button from messages sent before this menu.
-        await applySetting(
-          ctx,
-          chatId,
-          'bank_cards_enabled',
-          group.bank_cards_enabled ? 'off' : 'on',
-        );
-        break;
-      default:
-        await ctx.answerCallbackQuery({ text: 'Неизвестное действие' });
-    }
+    await dispatchSettingsAction(ctx, { chatId, group, sub, key, value });
   } catch (error) {
     logger.error({ err: error }, '[CMD] Error in /settings callback');
     await ctx.answerCallbackQuery({ text: 'Ошибка' });
+  }
+}
+
+interface SettingsAction {
+  chatId: number;
+  group: Group;
+  sub: string | undefined;
+  key: string | undefined;
+  value: string | undefined;
+}
+
+async function dispatchSettingsAction(
+  ctx: Ctx['CallbackQuery'],
+  { chatId, group, sub, key, value }: SettingsAction,
+): Promise<void> {
+  switch (sub) {
+    case 'edit':
+      return openCurrencyPicker(ctx, group, key);
+    case 'medit':
+      return openMultiCurrencyPicker(ctx, group, key);
+    case 'tedit':
+      return openTopicEditor(ctx, group, key);
+    case 'xedit':
+      return openTextEditor(ctx, group, key);
+    case 'set':
+      return applySetting(ctx, chatId, key, value);
+    case 'mtog':
+      return toggleEnabledCurrency(ctx, group, key, value);
+    case 'back':
+      await ctx.answerCallbackQuery();
+      return renderMain(ctx, chatId);
+    case 'bankcards':
+      // Back-compat: legacy bank-cards toggle button from messages predating this menu.
+      return applySetting(
+        ctx,
+        chatId,
+        'bank_cards_enabled',
+        group.bank_cards_enabled ? 'off' : 'on',
+      );
+    default:
+      await ctx.answerCallbackQuery({ text: 'Неизвестное действие' });
   }
 }
 
@@ -157,9 +202,11 @@ async function applySetting(
 async function toggleEnabledCurrency(
   ctx: Ctx['CallbackQuery'],
   group: Group,
+  key: string | undefined,
   code: string | undefined,
 ): Promise<void> {
-  if (!code) {
+  const def = key && isEditableGroupSettingKey(key) ? GROUP_SETTINGS[key] : null;
+  if (!def || def.kind !== 'currency_multi' || !code) {
     await ctx.answerCallbackQuery({ text: 'Неверные данные' });
     return;
   }
@@ -172,11 +219,7 @@ async function toggleEnabledCurrency(
   if (next.has(code)) next.delete(code);
   else next.add(code);
 
-  const result = await applyGroupSetting(
-    GROUP_SETTINGS.enabled_currencies,
-    group,
-    [...next].join(','),
-  );
+  const result = await applyGroupSetting(def, group, [...next].join(','));
   if (!result.ok) {
     await ctx.answerCallbackQuery({ text: result.error.slice(0, 200) });
     return;
@@ -184,7 +227,7 @@ async function toggleEnabledCurrency(
 
   await ctx.answerCallbackQuery();
   const updated = database.groups.findByTelegramGroupId(group.telegram_group_id);
-  if (updated) await renderMultiCurrency(ctx, updated);
+  if (updated) await renderMultiCurrency(ctx, updated, def.key);
 }
 
 async function openCurrencyPicker(
@@ -192,15 +235,16 @@ async function openCurrencyPicker(
   group: Group,
   key: string | undefined,
 ): Promise<void> {
-  if (key !== 'default_currency') {
+  const def = key && isEditableGroupSettingKey(key) ? GROUP_SETTINGS[key] : null;
+  if (!def || def.kind !== 'currency') {
     await ctx.answerCallbackQuery({ text: 'Неверные данные' });
     return;
   }
   await ctx.answerCallbackQuery();
   await editView(
     ctx,
-    '💱 Выбери валюту по умолчанию:',
-    createSettingsCurrencyPickKeyboard(group.default_currency),
+    `${def.emoji} Выбери валюту по умолчанию:`,
+    createSettingsCurrencyPickKeyboard(def.key, group.default_currency),
   );
 }
 
@@ -209,20 +253,69 @@ async function openMultiCurrencyPicker(
   group: Group,
   key: string | undefined,
 ): Promise<void> {
-  if (key !== 'enabled_currencies') {
+  const def = key && isEditableGroupSettingKey(key) ? GROUP_SETTINGS[key] : null;
+  if (!def || def.kind !== 'currency_multi') {
     await ctx.answerCallbackQuery({ text: 'Неверные данные' });
     return;
   }
   await ctx.answerCallbackQuery();
-  await renderMultiCurrency(ctx, group);
+  await renderMultiCurrency(ctx, group, def.key);
 }
 
-async function renderMultiCurrency(ctx: Ctx['CallbackQuery'], group: Group): Promise<void> {
-  const text = `💵 Отметь включённые валюты:\nСейчас: ${group.enabled_currencies.join(', ')}`;
+/** Topic sub-view: binding goes through /topic; the menu can only clear. */
+async function openTopicEditor(
+  ctx: Ctx['CallbackQuery'],
+  group: Group,
+  key: string | undefined,
+): Promise<void> {
+  const def = key && isEditableGroupSettingKey(key) ? GROUP_SETTINGS[key] : null;
+  if (!def || def.kind !== 'topic') {
+    await ctx.answerCallbackQuery({ text: 'Неверные данные' });
+    return;
+  }
+  await ctx.answerCallbackQuery();
+  const text =
+    `${def.emoji} ${def.labelRu}: ${neutralizeForMenu(def.formatValue(group))}\n\n` +
+    'Чтобы привязать бота к топику — зайди в нужный топик и отправь там /topic. Здесь можно только сбросить привязку.';
+  const keyboard = new InlineKeyboard()
+    .text('📍 Сбросить топик', `settings:set:${def.key}:clear`)
+    .row()
+    .text('⬅️ Назад', 'settings:back');
+  await editView(ctx, text, keyboard);
+}
+
+/** Text sub-view (custom_prompt): set via chat/AI; the menu shows the value and can clear. */
+async function openTextEditor(
+  ctx: Ctx['CallbackQuery'],
+  group: Group,
+  key: string | undefined,
+): Promise<void> {
+  const def = key && isEditableGroupSettingKey(key) ? GROUP_SETTINGS[key] : null;
+  if (!def || def.kind !== 'text') {
+    await ctx.answerCallbackQuery({ text: 'Неверные данные' });
+    return;
+  }
+  await ctx.answerCallbackQuery();
+  const text =
+    `${def.emoji} ${def.labelRu}: ${neutralizeForMenu(def.formatValue(group))}\n\n` +
+    'Промпт задаётся в чате: напиши боту «перепиши промпт: …» (заменить целиком) или «запомни, что …» (добавить заметку). Здесь можно очистить.';
+  const keyboard = new InlineKeyboard()
+    .text('🗑 Очистить промпт', `settings:set:${def.key}:clear`)
+    .row()
+    .text('⬅️ Назад', 'settings:back');
+  await editView(ctx, text, keyboard);
+}
+
+async function renderMultiCurrency(
+  ctx: Ctx['CallbackQuery'],
+  group: Group,
+  key: string,
+): Promise<void> {
+  const text = `💵 Отметь включённые валюты:\nСейчас: ${neutralizeForMenu(group.enabled_currencies.join(', '))}`;
   await editView(
     ctx,
     text,
-    createSettingsMultiCurrencyKeyboard(group.enabled_currencies, group.default_currency),
+    createSettingsMultiCurrencyKeyboard(key, group.enabled_currencies, group.default_currency),
   );
 }
 
@@ -236,15 +329,25 @@ async function renderMain(ctx: Ctx['CallbackQuery'], chatId: number): Promise<vo
   await editView(ctx, text, keyboard);
 }
 
-/** Edit the settings message in place, tolerating Telegram "message not modified" errors. */
+/**
+ * Edit the settings message in place. Uses HTML parse mode to match the command-path
+ * `sendMessage` (also HTML), so the menu text (with user values already neutralized by
+ * neutralizeForMenu) renders identically on both the initial send and every re-render.
+ *
+ * A "message is not modified" 400 (re-render with identical content) is benign and
+ * swallowed; every other error propagates so the caller logs it and tells the user,
+ * instead of silently looking like nothing happened.
+ */
 async function editView(
   ctx: Ctx['CallbackQuery'],
   text: string,
   keyboard: InlineKeyboard,
 ): Promise<void> {
   try {
-    await ctx.editText(text, { reply_markup: keyboard });
+    await ctx.editText(text, { reply_markup: keyboard, parse_mode: 'HTML' });
   } catch (error) {
-    logger.warn({ err: error }, '[CMD] /settings editText failed');
+    const message = error instanceof Error ? error.message : String(error);
+    if (/message is not modified/i.test(message)) return;
+    throw error;
   }
 }

--- a/src/bot/handlers/callback.handler.test.ts
+++ b/src/bot/handlers/callback.handler.test.ts
@@ -135,7 +135,7 @@ mock.module('../commands/feedback', () => ({
 }));
 
 const settingsMocks = {
-  handleSettingsBankCardsToggle: mock(() => Promise.resolve()),
+  handleSettingsCallback: mock(() => Promise.resolve()),
 };
 mock.module('../commands/settings', () => settingsMocks);
 
@@ -322,19 +322,20 @@ describe('handleCallbackQuery — routing table', () => {
   });
 
   describe('settings routing', () => {
-    test('routes "settings:bankcards" → handleSettingsBankCardsToggle', async () => {
-      const ctx = fakeCallbackCtx('settings:bankcards');
+    test('routes "settings:edit:default_currency" → handleSettingsCallback with params', async () => {
+      const ctx = fakeCallbackCtx('settings:edit:default_currency');
       await handleCallbackQuery(ctx as never, fakeBot() as never);
-      expect(settingsMocks.handleSettingsBankCardsToggle).toHaveBeenCalledTimes(1);
+      expect(settingsMocks.handleSettingsCallback).toHaveBeenCalledTimes(1);
+      expect(settingsMocks.handleSettingsCallback).toHaveBeenCalledWith(ctx, [
+        'edit',
+        'default_currency',
+      ]);
     });
 
-    test('routes unknown "settings:garbage" → Invalid parameters answer', async () => {
-      const ctx = fakeCallbackCtx('settings:garbage');
+    test('routes legacy "settings:bankcards" → handleSettingsCallback', async () => {
+      const ctx = fakeCallbackCtx('settings:bankcards');
       await handleCallbackQuery(ctx as never, fakeBot() as never);
-      expect(settingsMocks.handleSettingsBankCardsToggle).not.toHaveBeenCalled();
-      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith(
-        expect.objectContaining({ text: 'Invalid parameters' }),
-      );
+      expect(settingsMocks.handleSettingsCallback).toHaveBeenCalledWith(ctx, ['bankcards']);
     });
   });
 

--- a/src/bot/handlers/callback.handler.ts
+++ b/src/bot/handlers/callback.handler.ts
@@ -42,7 +42,7 @@ import {
 import { handleDevCallback } from '../commands/dev';
 import { handleDisconnectCancel, handleDisconnectConfirm } from '../commands/disconnect';
 import { cancelPendingFeedback } from '../commands/feedback';
-import { handleSettingsBankCardsToggle } from '../commands/settings';
+import { handleSettingsCallback } from '../commands/settings';
 import { createBudgetPromptKeyboard, createCategoriesListKeyboard } from '../keyboards';
 import { saveExpenseToSheet, saveReceiptExpenses } from '../services/expense-saver';
 import { getSheetErrorMessage } from '../services/sheet-errors';
@@ -108,14 +108,9 @@ export async function handleCallbackQuery(
         break;
       }
 
-      case 'settings': {
-        if (params[0] === 'bankcards') {
-          await handleSettingsBankCardsToggle(ctx);
-        } else {
-          await ctx.answerCallbackQuery({ text: 'Invalid parameters' });
-        }
+      case 'settings':
+        await handleSettingsCallback(ctx, params);
         break;
-      }
 
       case 'setup': {
         const setupAction = params.join(':');

--- a/src/bot/keyboards.test.ts
+++ b/src/bot/keyboards.test.ts
@@ -58,7 +58,7 @@ describe('createCurrencyKeyboard', () => {
     }
   });
 
-  it('shows all 12 supported currencies as buttons', () => {
+  it('shows all supported currencies as buttons', () => {
     const kb = createCurrencyKeyboard([]);
     const texts = allButtons(kb).map((b) => b.text);
     // All currencies appear as buttons (not selected, so just the code)

--- a/src/bot/keyboards.ts
+++ b/src/bot/keyboards.ts
@@ -51,6 +51,63 @@ export function createCurrencyKeyboard(selectedCurrencies: string[] = []): Inlin
 }
 
 /**
+ * Build the /settings default-currency picker: every supported currency as a button,
+ * the current default marked, plus a Back button. Callback data uses latin codes only.
+ */
+export function createSettingsCurrencyPickKeyboard(currentDefault: string): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+
+  for (let i = 0; i < SUPPORTED_CURRENCIES.length; i += 3) {
+    for (const code of SUPPORTED_CURRENCIES.slice(i, i + 3)) {
+      const label = code === currentDefault ? `✅ ${code}` : code;
+      keyboard.text(label, `settings:set:default_currency:${code}`);
+    }
+    keyboard.row();
+  }
+
+  keyboard.text('⬅️ Назад', 'settings:back');
+  return keyboard;
+}
+
+/**
+ * Build the /settings enabled-currencies multi-select: every supported currency with a
+ * checkbox; the default currency is locked (it can never be removed). A Done button
+ * returns to the main settings view.
+ */
+export function createSettingsMultiCurrencyKeyboard(
+  enabledCurrencies: string[],
+  defaultCurrency: string,
+): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const enabledSet = new Set(enabledCurrencies);
+  const supportedSet = new Set<string>(SUPPORTED_CURRENCIES);
+
+  const addButton = (code: string): void => {
+    const checkbox = enabledSet.has(code) ? '✅' : '▫️';
+    const lock = code === defaultCurrency ? '🔒' : '';
+    keyboard.text(`${checkbox}${lock} ${code}`, `settings:mtog:enabled_currencies:${code}`);
+  };
+
+  for (let i = 0; i < SUPPORTED_CURRENCIES.length; i += 3) {
+    for (const code of SUPPORTED_CURRENCIES.slice(i, i + 3)) addButton(code);
+    keyboard.row();
+  }
+
+  // Custom (non-built-in) currencies the group enabled during onboarding stay editable here.
+  // Like the onboarding picker (createCurrencyKeyboard), the list is sourced from the enabled
+  // set: unchecking a custom code removes its button. Re-adding one is done via the AI tool
+  // (update_group_setting enabled_currencies) or /connect, which both accept arbitrary codes.
+  const custom = enabledCurrencies.filter((c) => !supportedSet.has(c));
+  for (let i = 0; i < custom.length; i += 3) {
+    for (const code of custom.slice(i, i + 3)) addButton(code);
+    keyboard.row();
+  }
+
+  keyboard.text(KEYBOARD_TEXTS.done, 'settings:back');
+  return keyboard;
+}
+
+/**
  * Create default currency selection keyboard (Step 2)
  */
 export function createDefaultCurrencyKeyboard(enabledCurrencies: string[]): InlineKeyboard {

--- a/src/bot/keyboards.ts
+++ b/src/bot/keyboards.ts
@@ -52,15 +52,19 @@ export function createCurrencyKeyboard(selectedCurrencies: string[] = []): Inlin
 
 /**
  * Build the /settings default-currency picker: every supported currency as a button,
- * the current default marked, plus a Back button. Callback data uses latin codes only.
+ * the current default marked, plus a Back button. Callback data uses the registry key +
+ * latin currency codes only (never raw labels) to stay within the 64-byte limit.
  */
-export function createSettingsCurrencyPickKeyboard(currentDefault: string): InlineKeyboard {
+export function createSettingsCurrencyPickKeyboard(
+  settingKey: string,
+  currentDefault: string,
+): InlineKeyboard {
   const keyboard = new InlineKeyboard();
 
   for (let i = 0; i < SUPPORTED_CURRENCIES.length; i += 3) {
     for (const code of SUPPORTED_CURRENCIES.slice(i, i + 3)) {
       const label = code === currentDefault ? `✅ ${code}` : code;
-      keyboard.text(label, `settings:set:default_currency:${code}`);
+      keyboard.text(label, `settings:set:${settingKey}:${code}`);
     }
     keyboard.row();
   }
@@ -75,6 +79,7 @@ export function createSettingsCurrencyPickKeyboard(currentDefault: string): Inli
  * returns to the main settings view.
  */
 export function createSettingsMultiCurrencyKeyboard(
+  settingKey: string,
   enabledCurrencies: string[],
   defaultCurrency: string,
 ): InlineKeyboard {
@@ -85,7 +90,7 @@ export function createSettingsMultiCurrencyKeyboard(
   const addButton = (code: string): void => {
     const checkbox = enabledSet.has(code) ? '✅' : '▫️';
     const lock = code === defaultCurrency ? '🔒' : '';
-    keyboard.text(`${checkbox}${lock} ${code}`, `settings:mtog:enabled_currencies:${code}`);
+    keyboard.text(`${checkbox}${lock} ${code}`, `settings:mtog:${settingKey}:${code}`);
   };
 
   for (let i = 0; i < SUPPORTED_CURRENCIES.length; i += 3) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -545,6 +545,10 @@ export const CURRENCY_ALIASES: Record<string, string> = {
   дирхам: 'AED',
   дирхама: 'AED',
   дирхамов: 'AED',
+
+  // Egyptian Pound
+  egp: 'EGP',
+  егп: 'EGP',
 };
 
 /**
@@ -563,6 +567,7 @@ export const SUPPORTED_CURRENCIES = [
   'INR',
   'LKR',
   'AED',
+  'EGP',
 ] as const;
 
 export type CurrencyCode = (typeof SUPPORTED_CURRENCIES)[number];

--- a/src/services/ai/agent.test.ts
+++ b/src/services/ai/agent.test.ts
@@ -366,6 +366,17 @@ describe('ExpenseBotAgent', () => {
       expect(systemContent).toContain('set_custom_prompt');
       expect(systemContent).toContain('NEVER say "got it"');
     });
+
+    it('system prompt tells the AI it can change any group setting', async () => {
+      mockStreamReturn();
+
+      await agent.run('test', [], mockBot as unknown as import('gramio').Bot);
+
+      const opts = getLastCallOpts();
+      const systemContent = opts.messages[0]?.content as string;
+      expect(systemContent).toContain('update_group_setting');
+      expect(systemContent).toContain('never tell the user to open /settings');
+    });
   });
 
   // -- run() -- error handling (throws AgentError after retries) -------------

--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -423,6 +423,7 @@ If an expense has no comment in the tool result, show nothing — do NOT invent 
 11. Missing/unmatched bank expenses → call find_missing_expenses.
 12. User asks you to remember, note, or save ANYTHING — a fact about a person, an account, a rule, a preference, any context — → call set_custom_prompt with mode="append". NEVER say "got it", "noted", "запомнил", or "remembered" without calling the tool first. This includes phrases like "запомни что", "note that", "keep in mind", "учти что".
 13. Recurring patterns → call get_recurring_patterns. To manage (pause/resume/dismiss/delete) → call manage_recurring_pattern.
+14. Changing a group setting (default currency, enabled currencies, AI prompt, bank-transaction cards, topic) → call update_group_setting with setting=<key> and value=<string>. You CAN change ANY group setting now — never reply that you can't, and never tell the user to open /settings instead. Call get_group_settings first if you need the current values, then apply the change and confirm the new value to the user.
 
 ## FORMATTING
 Use ONLY these HTML tags (no Markdown, no ** or *):
@@ -448,6 +449,7 @@ This bot tracks expenses and budgets. It can:
 - Connect bank accounts (/bank) to auto-import transactions with AI categorization
 - View real-time bank account balances (get_bank_balances tool)
 - Find bank transactions not yet recorded as expenses (find_missing_expenses tool)
+- Change any group setting (default currency, enabled currencies, AI prompt, bank-transaction cards, topic) via update_group_setting
 
 IMPORTANT: /connect is for Google Sheets integration only. /bank is for bank account integration (TBC, Kaspi, etc.).
 
@@ -473,6 +475,7 @@ When a user asks "что ты умеешь?", "what can you do?", or similar —
 - Конвертировать валюты и считать любые выражения
 - Отслеживать повторяющиеся расходы (аренда, подписки и т.д.)
 - Давать финансовые советы и отвечать на вопросы о тратах
+- Менять настройки группы: валюту по умолчанию, набор валют, AI-промпт, карточки банковских транзакций, топик
 - Запоминать заметки и правила для группы
 - Отправлять фидбек и баг-репорты администратору
 

--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -423,7 +423,10 @@ If an expense has no comment in the tool result, show nothing — do NOT invent 
 11. Missing/unmatched bank expenses → call find_missing_expenses.
 12. User asks you to remember, note, or save ANYTHING — a fact about a person, an account, a rule, a preference, any context — → call set_custom_prompt with mode="append". NEVER say "got it", "noted", "запомнил", or "remembered" without calling the tool first. This includes phrases like "запомни что", "note that", "keep in mind", "учти что".
 13. Recurring patterns → call get_recurring_patterns. To manage (pause/resume/dismiss/delete) → call manage_recurring_pattern.
-14. Changing a group setting (default currency, enabled currencies, AI prompt, bank-transaction cards, topic) → call update_group_setting with setting=<key> and value=<string>. You CAN change ANY group setting now — never reply that you can't, and never tell the user to open /settings instead. Call get_group_settings first if you need the current values, then apply the change and confirm the new value to the user.
+14. Changing a group setting (default currency, enabled currencies, bank-transaction cards) → call update_group_setting with setting=<key> and value=<string>. You CAN change these — never reply that you can't, and never tell the user to open /settings instead. Call get_group_settings first if you need current values, then apply and confirm the new value.
+   - default_currency accepts ONLY the built-in supported codes (USD, EUR, RUB, RSD, GBP, BYN, CHF, JPY, CNY, INR, LKR, AED, EGP).
+   - TOPIC: to BIND the bot to a topic the user must run /topic INSIDE that topic — update_group_setting active_topic_id can only CLEAR the binding ("сброс"), never set an id. Tell the user to use /topic for binding.
+   - custom_prompt via update_group_setting OVERWRITES the entire prompt — use it ONLY for an explicit full rewrite or clear ("перепиши промпт", "очисти промпт"). To remember/add a note WITHOUT wiping existing notes, use set_custom_prompt (append) per rule 12.
 
 ## FORMATTING
 Use ONLY these HTML tags (no Markdown, no ** or *):

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -1293,12 +1293,15 @@ describe('executeGetExchangeRates', () => {
 describe('executeGetGroupSettings', () => {
   beforeEach(resetAllMocks);
 
-  test('returns group config', async () => {
+  test('returns group config rendered from the settings registry', async () => {
     const result = await executeTool('get_group_settings', {}, ctx);
     expect(result.success).toBe(true);
-    expect(result.output).toContain('Default currency: EUR');
+    expect(result.output).toContain('default_currency): EUR');
     expect(result.output).toContain('EUR, USD');
     expect(result.output).toContain('not connected');
+    // Every registry setting must be visible, including the bank-cards toggle and topic.
+    expect(result.output).toContain('bank_cards_enabled)');
+    expect(result.output).toContain('active_topic_id)');
   });
 
   test('returns error when group not found', async () => {
@@ -1330,7 +1333,100 @@ describe('executeGetGroupSettings', () => {
 
     const result = await executeTool('get_group_settings', {}, ctx);
     expect(result.success).toBe(true);
-    expect(result.output).toContain('Custom prompt text: Be brief and speak in Russian');
+    expect(result.output).toContain('Custom prompt full text: Be brief and speak in Russian');
+  });
+});
+
+describe('update_group_setting', () => {
+  beforeEach(resetAllMocks);
+
+  test('changes default currency and persists, keeping it in enabled set', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'default_currency', value: 'egp' },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(mockGroups.update).toHaveBeenCalledWith(456, {
+      default_currency: 'EGP',
+      enabled_currencies: ['EUR', 'USD', 'EGP'],
+    });
+  });
+
+  test('toggles bank cards off', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'bank_cards_enabled', value: 'off' },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(mockGroups.update).toHaveBeenCalledWith(456, { bank_cards_enabled: 0 });
+  });
+
+  test('sets a custom prompt', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'custom_prompt', value: 'Speak English' },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(mockGroups.update).toHaveBeenCalledWith(456, { custom_prompt: 'Speak English' });
+  });
+
+  test('clears the active topic', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'active_topic_id', value: 'clear' },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(mockGroups.update).toHaveBeenCalledWith(456, { active_topic_id: null });
+  });
+
+  test('replaces the enabled currency set', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'enabled_currencies', value: 'usd, rsd' },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    // Default currency (EUR) is always kept in the set.
+    expect(mockGroups.update).toHaveBeenCalledWith(456, {
+      enabled_currencies: ['USD', 'RSD', 'EUR'],
+    });
+  });
+
+  test('returns a Russian error on an invalid currency and writes nothing', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'default_currency', value: 'zzz' },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('ZZZ');
+    expect(mockGroups.update).not.toHaveBeenCalled();
+  });
+
+  test('rejects a system field as an unknown setting', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'spreadsheet_id', value: 'x' },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('spreadsheet_id');
+    expect(mockGroups.update).not.toHaveBeenCalled();
+  });
+
+  test('returns an error when the group is missing', async () => {
+    mockGroups.findById.mockReturnValue(null);
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'default_currency', value: 'usd' },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(mockGroups.update).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/ai/tool-executor.test.ts
+++ b/src/services/ai/tool-executor.test.ts
@@ -1312,7 +1312,7 @@ describe('executeGetGroupSettings', () => {
     expect(result.error).toContain('Group not found');
   });
 
-  test('shows custom prompt when set', async () => {
+  test('shows a short custom prompt once (preview only, no duplicate full-text line)', async () => {
     mockGroups.findById.mockReturnValue({
       id: 1,
       telegram_group_id: 456,
@@ -1333,7 +1333,33 @@ describe('executeGetGroupSettings', () => {
 
     const result = await executeTool('get_group_settings', {}, ctx);
     expect(result.success).toBe(true);
-    expect(result.output).toContain('Custom prompt full text: Be brief and speak in Russian');
+    // The preview line carries the full short prompt; no separate "full text" line.
+    expect(result.output).toContain('custom_prompt): Be brief and speak in Russian');
+    expect(result.output).not.toContain('Custom prompt full text:');
+  });
+
+  test('appends the full text only when the prompt is long enough to be truncated', async () => {
+    const longPrompt = `Always reply in Russian. ${'x'.repeat(80)}`;
+    mockGroups.findById.mockReturnValue({
+      id: 1,
+      telegram_group_id: 456,
+      title: null,
+      invite_link: null,
+      google_refresh_token: null,
+      spreadsheet_id: null,
+      default_currency: 'EUR',
+      enabled_currencies: ['EUR'],
+      custom_prompt: longPrompt,
+      active_topic_id: null,
+      oauth_client: 'legacy' as const,
+      bank_panel_summary_message_id: null,
+      bank_cards_enabled: 1,
+      created_at: '',
+      updated_at: '',
+    });
+
+    const result = await executeTool('get_group_settings', {}, ctx);
+    expect(result.output).toContain(`Custom prompt full text: ${longPrompt}`);
   });
 });
 
@@ -1426,6 +1452,35 @@ describe('update_group_setting', () => {
       ctx,
     );
     expect(result.success).toBe(false);
+    expect(mockGroups.update).not.toHaveBeenCalled();
+  });
+
+  test('rejects a missing setting key (Russian error)', async () => {
+    const result = await executeTool('update_group_setting', { value: 'usd' }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('настройку');
+    expect(mockGroups.update).not.toHaveBeenCalled();
+  });
+
+  test('rejects a non-string value (Russian error)', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'default_currency', value: 123 },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('строкой');
+    expect(mockGroups.update).not.toHaveBeenCalled();
+  });
+
+  test('active_topic_id is clear-only: a numeric value is rejected and nothing persists', async () => {
+    const result = await executeTool(
+      'update_group_setting',
+      { setting: 'active_topic_id', value: '42' },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('/topic');
     expect(mockGroups.update).not.toHaveBeenCalled();
   });
 });

--- a/src/services/ai/tool-executor.ts
+++ b/src/services/ai/tool-executor.ts
@@ -20,6 +20,11 @@ import { evaluateCurrencyExpression } from '../currency/calculator';
 import { convertCurrency, formatAmount, formatExchangeRatesForAI } from '../currency/converter';
 import { googleConn } from '../google/sheets';
 import { renderTableToPng } from '../render/table-renderer.ts';
+import {
+  applyGroupSetting,
+  GROUP_SETTINGS,
+  isEditableGroupSettingKey,
+} from '../settings/group-settings-registry';
 import { executeBatchItems, isBatchInput } from './batch';
 import {
   computeExpenseStats,
@@ -80,6 +85,8 @@ export async function executeTool(
         return await executeSyncBudgets(ctx);
       case 'set_custom_prompt':
         return executeSetCustomPrompt(input, ctx);
+      case 'update_group_setting':
+        return await executeUpdateGroupSetting(input, ctx);
       case 'manage_category':
         return await executeManageCategory(input, ctx);
       case 'calculate':
@@ -475,18 +482,64 @@ function executeGetGroupSettings(ctx: AgentContext): ToolResult {
     return { success: false, error: 'Group not found' };
   }
 
-  const lines = [
-    `Default currency: ${group.default_currency}`,
-    `Enabled currencies: ${group.enabled_currencies.join(', ')}`,
-    `Spreadsheet: ${group.spreadsheet_id ? 'connected' : 'not connected'}`,
-    `Custom prompt: ${group.custom_prompt ? 'set' : 'not set'}`,
-  ];
+  // Render every registry-backed setting so all of them stay visible to the AI,
+  // including bank_cards_enabled and active_topic_id.
+  const lines = Object.values(GROUP_SETTINGS).map(
+    (def) => `${def.labelRu} (${def.key}): ${def.formatValue(group)}`,
+  );
+  lines.push(
+    `Spreadsheet (spreadsheet_id): ${group.spreadsheet_id ? 'connected' : 'not connected'}`,
+  );
 
+  // The custom_prompt line above is a short preview; include the full text so the
+  // AI can actually follow the stored instructions.
   if (group.custom_prompt) {
-    lines.push(`Custom prompt text: ${group.custom_prompt}`);
+    lines.push(`Custom prompt full text: ${group.custom_prompt}`);
   }
 
   return { success: true, output: lines.join('\n') };
+}
+
+/**
+ * Generic group-setting writer. Looks up the registry entry, parses + applies the value
+ * through the shared registry path, and returns a Russian success/error summary.
+ */
+async function executeUpdateGroupSetting(
+  input: Record<string, unknown>,
+  ctx: AgentContext,
+): Promise<ToolResult> {
+  const settingKey = input['setting'];
+  const rawValue = input['value'];
+
+  if (typeof settingKey !== 'string' || !settingKey) {
+    return { success: false, error: 'setting is required' };
+  }
+  if (typeof rawValue !== 'string') {
+    return { success: false, error: 'value must be a string' };
+  }
+  if (!isEditableGroupSettingKey(settingKey)) {
+    return {
+      success: false,
+      error: `Неизвестная настройка "${settingKey}". Доступны: ${Object.keys(GROUP_SETTINGS).join(', ')}.`,
+    };
+  }
+
+  const group = database.groups.findById(ctx.groupId);
+  if (!group) {
+    return { success: false, error: 'Group not found' };
+  }
+
+  const def = GROUP_SETTINGS[settingKey];
+  const result = await applyGroupSetting(def, group, rawValue);
+  if (!result.ok) {
+    return { success: false, error: result.error };
+  }
+
+  const updated = database.groups.findById(ctx.groupId) ?? group;
+  return {
+    success: true,
+    output: `Готово, поменял для тебя. ${def.emoji} ${def.labelRu}: ${def.formatValue(updated)}`,
+  };
 }
 
 function executeGetExchangeRates(): ToolResult {

--- a/src/services/ai/tool-executor.ts
+++ b/src/services/ai/tool-executor.ts
@@ -491,10 +491,14 @@ function executeGetGroupSettings(ctx: AgentContext): ToolResult {
     `Spreadsheet (spreadsheet_id): ${group.spreadsheet_id ? 'connected' : 'not connected'}`,
   );
 
-  // The custom_prompt line above is a short preview; include the full text so the
-  // AI can actually follow the stored instructions.
+  // The custom_prompt line above is a preview. Only append the full text when the preview
+  // actually truncated it (>60 flattened chars) — otherwise it just duplicates the line and
+  // wastes tokens in every AI context.
   if (group.custom_prompt) {
-    lines.push(`Custom prompt full text: ${group.custom_prompt}`);
+    const flattened = group.custom_prompt.replace(/\s+/g, ' ').trim();
+    if (flattened.length > 60) {
+      lines.push(`Custom prompt full text: ${group.custom_prompt}`);
+    }
   }
 
   return { success: true, output: lines.join('\n') };
@@ -512,10 +516,10 @@ async function executeUpdateGroupSetting(
   const rawValue = input['value'];
 
   if (typeof settingKey !== 'string' || !settingKey) {
-    return { success: false, error: 'setting is required' };
+    return { success: false, error: 'Не указано, какую настройку менять.' };
   }
   if (typeof rawValue !== 'string') {
-    return { success: false, error: 'value must be a string' };
+    return { success: false, error: 'Значение настройки должно быть строкой.' };
   }
   if (!isEditableGroupSettingKey(settingKey)) {
     return {
@@ -526,7 +530,7 @@ async function executeUpdateGroupSetting(
 
   const group = database.groups.findById(ctx.groupId);
   if (!group) {
-    return { success: false, error: 'Group not found' };
+    return { success: false, error: 'Группа не найдена.' };
   }
 
   const def = GROUP_SETTINGS[settingKey];

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -1,5 +1,6 @@
 /** OpenAI-format tool definitions for the expense bot agent */
 import type OpenAI from 'openai';
+import { GROUP_SETTINGS } from '../settings/group-settings-registry';
 
 /** Shorthand: wraps name+description+parameters into OpenAI tool shape */
 function tool(
@@ -8,6 +9,22 @@ function tool(
   parameters: Record<string, unknown>,
 ): OpenAI.ChatCompletionTool {
   return { type: 'function', function: { name, description, parameters } };
+}
+
+/**
+ * Build the update_group_setting description from the settings registry so the per-setting
+ * value hints stay in sync with the registry and never drift.
+ */
+function buildUpdateGroupSettingDescription(): string {
+  const settingLines = Object.values(GROUP_SETTINGS).map(
+    (def) => `- "${def.key}" (${def.labelRu}): ${def.aiValueHint}`,
+  );
+  return [
+    'Change a group setting immediately when the user asks. You CAN and SHOULD change any of these — never say you cannot, and never deflect the user to /settings.',
+    'Pass setting=<key> and value=<string>. The value is parsed and validated; on bad input you get a Russian error message to relay to the user.',
+    'Settings:',
+    ...settingLines,
+  ].join('\n');
 }
 
 /** Convert legacy Anthropic-format tool defs to OpenAI format (input_schema → parameters) */
@@ -347,6 +364,26 @@ export const TOOL_DEFINITIONS: OpenAI.ChatCompletionTool[] = fromAnthropicFormat
       required: ['action', 'name'],
     },
   },
+  {
+    name: 'update_group_setting',
+    description: buildUpdateGroupSettingDescription(),
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        setting: {
+          type: 'string',
+          enum: Object.keys(GROUP_SETTINGS),
+          description: 'Which group setting to change (see per-setting hints in the description).',
+        },
+        value: {
+          type: 'string',
+          description:
+            'New value as a string. The exact format depends on the chosen setting — see its hint in the tool description.',
+        },
+      },
+      required: ['setting', 'value'],
+    },
+  },
 
   // === Bank tools ===
   {
@@ -532,6 +569,7 @@ export const TOOL_LABELS: Record<string, string> = {
   sync_budgets: 'Синхронизирую бюджеты',
   calculate: 'Считаю',
   set_custom_prompt: 'Обновляю промпт',
+  update_group_setting: 'Меняю настройку группы',
   manage_category: 'Управляю категориями',
   get_bank_transactions: 'Загружаю банковские транзакции',
   get_bank_balances: 'Проверяю балансы счетов',

--- a/src/services/currency/converter.test.ts
+++ b/src/services/currency/converter.test.ts
@@ -84,6 +84,11 @@ describe('convertToEUR', () => {
     expect(convertToEUR(100, 'AED')).toBe(25);
   });
 
+  it('converts EGP to EUR (small rate)', () => {
+    // 1 EGP = 0.018 EUR → 1000 EGP = 18 EUR
+    expect(convertToEUR(1000, 'EGP')).toBe(18);
+  });
+
   it('converts RUB to EUR', () => {
     // 1 RUB = 0.0093 EUR
     expect(convertToEUR(1000, 'RUB')).toBe(9.3);
@@ -102,6 +107,7 @@ describe('convertToEUR', () => {
     'INR',
     'LKR',
     'AED',
+    'EGP',
   ] as const;
   for (const currency of currencies) {
     it(`converts ${currency} to EUR (result is positive for positive input)`, () => {
@@ -352,9 +358,9 @@ describe('formatAmount (aiContext=true)', () => {
 });
 
 describe('getAllExchangeRates', () => {
-  it('returns object with all 12 currencies', () => {
+  it('returns object with all 13 currencies', () => {
     const rates = getAllExchangeRates();
-    expect(Object.keys(rates)).toHaveLength(12);
+    expect(Object.keys(rates)).toHaveLength(13);
   });
 
   it('EUR rate is 1.0', () => {
@@ -393,6 +399,7 @@ describe('getAllExchangeRates', () => {
     expect(keys).toContain('INR');
     expect(keys).toContain('LKR');
     expect(keys).toContain('AED');
+    expect(keys).toContain('EGP');
   });
 });
 

--- a/src/services/currency/converter.ts
+++ b/src/services/currency/converter.ts
@@ -27,6 +27,7 @@ const FALLBACK_RATES_STR: Record<CurrencyCode, string> = {
   INR: '0.011', // 1 INR = 0.011 EUR (approx 90 INR = 1 EUR)
   LKR: '0.0028', // 1 LKR = 0.0028 EUR (approx 360 LKR = 1 EUR)
   AED: '0.25', // 1 AED = 0.25 EUR (approx 4 AED = 1 EUR)
+  EGP: '0.018', // 1 EGP = 0.018 EUR (approx 55.5 EGP = 1 EUR)
 };
 
 const FALLBACK_RATES: Record<CurrencyCode, number> = Object.fromEntries(
@@ -122,6 +123,7 @@ async function fetchExchangeRates(): Promise<Record<CurrencyCode, number> | null
       INR: 1 / (data.rates['INR'] || 1),
       LKR: 1 / (data.rates['LKR'] || 1),
       AED: 1 / (data.rates['AED'] || 1),
+      EGP: 1 / (data.rates['EGP'] || 1),
     };
 
     // Build string-precision rates for Big.js arithmetic.
@@ -142,6 +144,7 @@ async function fetchExchangeRates(): Promise<Record<CurrencyCode, number> | null
       INR: toRateStr('INR'),
       LKR: toRateStr('LKR'),
       AED: toRateStr('AED'),
+      EGP: toRateStr('EGP'),
     };
 
     // Store rates for known currencies only — populated lazily as new currencies are encountered.
@@ -167,6 +170,7 @@ async function fetchExchangeRates(): Promise<Record<CurrencyCode, number> | null
     logger.info(`  /1 INR = €${(1 / rates.INR).toFixed(6)}`);
     logger.info(`  /1 LKR = €${(1 / rates.LKR).toFixed(6)}`);
     logger.info(`  /1 AED = €${(1 / rates.AED).toFixed(4)}`);
+    logger.info(`  /1 EGP = €${(1 / rates.EGP).toFixed(6)}`);
 
     return rates;
   } catch (error) {

--- a/src/services/currency/parser.test.ts
+++ b/src/services/currency/parser.test.ts
@@ -56,6 +56,20 @@ describe('parseExpenseMessage', () => {
       expect(result?.category).toBe('Транспорт');
     });
 
+    test('should parse amount with currency code (EGP)', () => {
+      const result = parseExpenseMessage('250 EGP сувениры', 'USD');
+      expect(result).not.toBeNull();
+      expect(result?.amount).toBe(250);
+      expect(result?.currency).toBe('EGP');
+      expect(result?.category).toBe('Сувениры');
+    });
+
+    test('should parse amount with lowercase egp alias', () => {
+      const result = parseExpenseMessage('250 egp сувениры', 'USD');
+      expect(result).not.toBeNull();
+      expect(result?.currency).toBe('EGP');
+    });
+
     test('should parse amount with spaces in number (1 900)', () => {
       const result = parseExpenseMessage('1 900 RSD транспорт', 'USD');
       expect(result).not.toBeNull();

--- a/src/services/settings/group-settings-registry.test.ts
+++ b/src/services/settings/group-settings-registry.test.ts
@@ -139,10 +139,16 @@ describe('enabled_currencies setting', () => {
     expect(result).toEqual({ ok: true, value: ['EUR', 'USD'] });
   });
 
-  test('parse rejects when any code is unsupported', () => {
-    const result = def.parse('usd, zzz', fakeGroup());
+  test('parse rejects malformed (non 3-letter) codes', () => {
+    const result = def.parse('usd, ab', fakeGroup());
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toContain('ZZZ');
+    if (!result.ok) expect(result.error).toContain('AB');
+  });
+
+  test('parse accepts custom ISO codes for onboarding parity (e.g. GEL)', () => {
+    const result = def.parse('usd, gel', fakeGroup({ default_currency: 'USD' }));
+    // GEL is a valid ISO code but outside the built-in set — onboarding allows it, so does this.
+    expect(result).toEqual({ ok: true, value: ['USD', 'GEL'] as CurrencyCode[] });
   });
 
   test('parse rejects an empty list', () => {

--- a/src/services/settings/group-settings-registry.test.ts
+++ b/src/services/settings/group-settings-registry.test.ts
@@ -1,0 +1,263 @@
+// Tests for the group settings registry: enforcement guard, parse, formatValue, apply.
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { CurrencyCode } from '../../config/constants';
+import type { Group, UpdateGroupData } from '../../database/types';
+
+// ── Database mock (registry writes via database.groups.update) ──────────────
+
+const updateMock = mock((_id: number, _data: UpdateGroupData): Group | null => null);
+mock.module('../../database', () => ({
+  database: { groups: { update: updateMock } },
+}));
+
+const {
+  GROUP_SETTINGS,
+  SYSTEM_GROUP_FIELDS,
+  ALL_UPDATE_KEYS,
+  applyGroupSetting,
+  isEditableGroupSettingKey,
+} = await import('./group-settings-registry');
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function fakeGroup(overrides: Partial<Group> = {}): Group {
+  return {
+    id: 1,
+    telegram_group_id: -100,
+    title: null,
+    invite_link: null,
+    google_refresh_token: null,
+    spreadsheet_id: null,
+    default_currency: 'USD' as CurrencyCode,
+    enabled_currencies: ['USD', 'EUR'] as CurrencyCode[],
+    custom_prompt: null,
+    active_topic_id: null,
+    bank_panel_summary_message_id: null,
+    bank_cards_enabled: 0,
+    oauth_client: 'current',
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  updateMock.mockReset().mockReturnValue(null);
+});
+
+// ── Enforcement guard ─────────────────────────────────────────────────────────
+
+describe('registry enforcement', () => {
+  test('GROUP_SETTINGS covers exactly every editable (non-system) UpdateGroupData key', () => {
+    const systemSet = new Set<string>(SYSTEM_GROUP_FIELDS);
+    const expectedEditable = Object.keys(ALL_UPDATE_KEYS).filter((k) => !systemSet.has(k));
+
+    expect(new Set(Object.keys(GROUP_SETTINGS))).toEqual(new Set(expectedEditable));
+  });
+
+  test('every registry entry declares a key matching its map slot', () => {
+    for (const [key, def] of Object.entries(GROUP_SETTINGS)) {
+      expect<string>(def.key).toBe(key);
+    }
+  });
+
+  test('system fields and editable settings are disjoint', () => {
+    const systemSet = new Set<string>(SYSTEM_GROUP_FIELDS);
+    for (const key of Object.keys(GROUP_SETTINGS)) {
+      expect(systemSet.has(key)).toBe(false);
+    }
+  });
+
+  test('isEditableGroupSettingKey accepts registry keys and rejects system / unknown keys', () => {
+    expect(isEditableGroupSettingKey('default_currency')).toBe(true);
+    expect(isEditableGroupSettingKey('bank_cards_enabled')).toBe(true);
+    expect(isEditableGroupSettingKey('spreadsheet_id')).toBe(false);
+    expect(isEditableGroupSettingKey('nonsense')).toBe(false);
+  });
+});
+
+// ── default_currency ──────────────────────────────────────────────────────────
+
+describe('default_currency setting', () => {
+  const def = GROUP_SETTINGS.default_currency;
+
+  test('parse uppercases and accepts a supported code', () => {
+    expect(def.parse('egp', fakeGroup())).toEqual({ ok: true, value: 'EGP' });
+  });
+
+  test('parse rejects an unsupported code with a Russian error naming supported codes', () => {
+    const result = def.parse('xyz', fakeGroup());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('XYZ');
+      expect(result.error).toContain('USD');
+    }
+  });
+
+  test('formatValue returns the current default code', () => {
+    expect(def.formatValue(fakeGroup({ default_currency: 'RSD' as CurrencyCode }))).toBe('RSD');
+  });
+
+  test('apply adds the new default to enabled_currencies when missing', async () => {
+    const result = await applyGroupSetting(def, fakeGroup(), 'egp');
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(-100, {
+      default_currency: 'EGP',
+      enabled_currencies: ['USD', 'EUR', 'EGP'],
+    });
+  });
+
+  test('apply keeps enabled set unchanged when default already present', async () => {
+    const result = await applyGroupSetting(def, fakeGroup({ default_currency: 'USD' }), 'eur');
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(-100, {
+      default_currency: 'EUR',
+      enabled_currencies: ['USD', 'EUR'],
+    });
+  });
+
+  test('apply does not write on invalid input', async () => {
+    const result = await applyGroupSetting(def, fakeGroup(), 'nope');
+    expect(result.ok).toBe(false);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── enabled_currencies ────────────────────────────────────────────────────────
+
+describe('enabled_currencies setting', () => {
+  const def = GROUP_SETTINGS.enabled_currencies;
+
+  test('parse splits on commas/spaces, uppercases, dedupes', () => {
+    const result = def.parse('usd, eur usd', fakeGroup({ default_currency: 'USD' }));
+    expect(result).toEqual({ ok: true, value: ['USD', 'EUR'] });
+  });
+
+  test('parse always keeps the default currency in the set', () => {
+    const result = def.parse('eur', fakeGroup({ default_currency: 'USD' }));
+    expect(result).toEqual({ ok: true, value: ['EUR', 'USD'] });
+  });
+
+  test('parse rejects when any code is unsupported', () => {
+    const result = def.parse('usd, zzz', fakeGroup());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('ZZZ');
+  });
+
+  test('parse rejects an empty list', () => {
+    const result = def.parse('   ', fakeGroup());
+    expect(result.ok).toBe(false);
+  });
+
+  test('formatValue joins codes with commas', () => {
+    expect(
+      def.formatValue(fakeGroup({ enabled_currencies: ['USD', 'EUR', 'EGP'] as CurrencyCode[] })),
+    ).toBe('USD, EUR, EGP');
+  });
+
+  test('apply writes the parsed currency list', async () => {
+    const result = await applyGroupSetting(
+      def,
+      fakeGroup({ default_currency: 'USD' }),
+      'usd eur egp',
+    );
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(-100, { enabled_currencies: ['USD', 'EUR', 'EGP'] });
+  });
+});
+
+// ── bank_cards_enabled (toggle) ────────────────────────────────────────────────
+
+describe('bank_cards_enabled setting', () => {
+  const def = GROUP_SETTINGS.bank_cards_enabled;
+
+  test('parse accepts on/off synonyms', () => {
+    expect(def.parse('on', fakeGroup())).toEqual({ ok: true, value: 1 });
+    expect(def.parse('ВКЛ', fakeGroup())).toEqual({ ok: true, value: 1 });
+    expect(def.parse('true', fakeGroup())).toEqual({ ok: true, value: 1 });
+    expect(def.parse('off', fakeGroup())).toEqual({ ok: true, value: 0 });
+    expect(def.parse('выкл', fakeGroup())).toEqual({ ok: true, value: 0 });
+    expect(def.parse('0', fakeGroup())).toEqual({ ok: true, value: 0 });
+  });
+
+  test('parse rejects gibberish', () => {
+    const result = def.parse('maybe', fakeGroup());
+    expect(result.ok).toBe(false);
+  });
+
+  test('formatValue clarifies the off state still syncs balance', () => {
+    expect(def.formatValue(fakeGroup({ bank_cards_enabled: 1 }))).toBe('вкл');
+    expect(def.formatValue(fakeGroup({ bank_cards_enabled: 0 }))).toContain('только баланс');
+  });
+
+  test('apply writes 0/1', async () => {
+    await applyGroupSetting(def, fakeGroup(), 'on');
+    expect(updateMock).toHaveBeenCalledWith(-100, { bank_cards_enabled: 1 });
+  });
+});
+
+// ── active_topic_id (topic) ────────────────────────────────────────────────────
+
+describe('active_topic_id setting', () => {
+  const def = GROUP_SETTINGS.active_topic_id;
+
+  test('parse accepts an integer', () => {
+    expect(def.parse('55', fakeGroup())).toEqual({ ok: true, value: 55 });
+  });
+
+  test('parse treats clear words and empty as null', () => {
+    expect(def.parse('clear', fakeGroup())).toEqual({ ok: true, value: null });
+    expect(def.parse('сброс', fakeGroup())).toEqual({ ok: true, value: null });
+    expect(def.parse('', fakeGroup())).toEqual({ ok: true, value: null });
+  });
+
+  test('parse rejects non-integer text', () => {
+    const result = def.parse('abc', fakeGroup());
+    expect(result.ok).toBe(false);
+  });
+
+  test('formatValue shows the id or "не задан"', () => {
+    expect(def.formatValue(fakeGroup({ active_topic_id: 7 }))).toBe('#7');
+    expect(def.formatValue(fakeGroup({ active_topic_id: null }))).toBe('не задан');
+  });
+
+  test('apply writes the id and clears to null', async () => {
+    await applyGroupSetting(def, fakeGroup(), '7');
+    expect(updateMock).toHaveBeenCalledWith(-100, { active_topic_id: 7 });
+    updateMock.mockReset();
+    await applyGroupSetting(def, fakeGroup(), 'clear');
+    expect(updateMock).toHaveBeenCalledWith(-100, { active_topic_id: null });
+  });
+});
+
+// ── custom_prompt (text) ───────────────────────────────────────────────────────
+
+describe('custom_prompt setting', () => {
+  const def = GROUP_SETTINGS.custom_prompt;
+
+  test('parse keeps trimmed text', () => {
+    expect(def.parse('  speak in English  ', fakeGroup())).toEqual({
+      ok: true,
+      value: 'speak in English',
+    });
+  });
+
+  test('parse clears on clear words and empty', () => {
+    expect(def.parse('clear', fakeGroup())).toEqual({ ok: true, value: null });
+    expect(def.parse('', fakeGroup())).toEqual({ ok: true, value: null });
+  });
+
+  test('formatValue previews the prompt or "не задан"', () => {
+    expect(def.formatValue(fakeGroup({ custom_prompt: null }))).toBe('не задан');
+    expect(def.formatValue(fakeGroup({ custom_prompt: 'Be brief' }))).toBe('Be brief');
+  });
+
+  test('apply writes the prompt and clears it', async () => {
+    await applyGroupSetting(def, fakeGroup(), 'Be brief');
+    expect(updateMock).toHaveBeenCalledWith(-100, { custom_prompt: 'Be brief' });
+    updateMock.mockReset();
+    await applyGroupSetting(def, fakeGroup(), 'clear');
+    expect(updateMock).toHaveBeenCalledWith(-100, { custom_prompt: null });
+  });
+});

--- a/src/services/settings/group-settings-registry.test.ts
+++ b/src/services/settings/group-settings-registry.test.ts
@@ -43,7 +43,8 @@ function fakeGroup(overrides: Partial<Group> = {}): Group {
 }
 
 beforeEach(() => {
-  updateMock.mockReset().mockReturnValue(null);
+  // Default: update succeeds (returns the row). Tests that need a failed write override this.
+  updateMock.mockReset().mockReturnValue(fakeGroup());
 });
 
 // ── Enforcement guard ─────────────────────────────────────────────────────────
@@ -208,14 +209,18 @@ describe('bank_cards_enabled setting', () => {
 describe('active_topic_id setting', () => {
   const def = GROUP_SETTINGS.active_topic_id;
 
-  test('parse accepts an integer', () => {
-    expect(def.parse('55', fakeGroup())).toEqual({ ok: true, value: 55 });
-  });
-
   test('parse treats clear words and empty as null', () => {
     expect(def.parse('clear', fakeGroup())).toEqual({ ok: true, value: null });
     expect(def.parse('сброс', fakeGroup())).toEqual({ ok: true, value: null });
     expect(def.parse('', fakeGroup())).toEqual({ ok: true, value: null });
+  });
+
+  test('parse is CLEAR-ONLY: any numeric id is rejected with a /topic instruction', () => {
+    for (const raw of ['7', '0', '-5', '99999999999999999999']) {
+      const result = def.parse(raw, fakeGroup());
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('/topic');
+    }
   });
 
   test('parse rejects non-integer text', () => {
@@ -228,12 +233,15 @@ describe('active_topic_id setting', () => {
     expect(def.formatValue(fakeGroup({ active_topic_id: null }))).toBe('не задан');
   });
 
-  test('apply writes the id and clears to null', async () => {
-    await applyGroupSetting(def, fakeGroup(), '7');
-    expect(updateMock).toHaveBeenCalledWith(-100, { active_topic_id: 7 });
-    updateMock.mockReset();
-    await applyGroupSetting(def, fakeGroup(), 'clear');
+  test('apply clears to null; a numeric id never persists', async () => {
+    const cleared = await applyGroupSetting(def, fakeGroup({ active_topic_id: 7 }), 'сброс');
+    expect(cleared.ok).toBe(true);
     expect(updateMock).toHaveBeenCalledWith(-100, { active_topic_id: null });
+
+    updateMock.mockReset().mockReturnValue(fakeGroup());
+    const numeric = await applyGroupSetting(def, fakeGroup(), '7');
+    expect(numeric.ok).toBe(false);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });
 
@@ -259,11 +267,55 @@ describe('custom_prompt setting', () => {
     expect(def.formatValue(fakeGroup({ custom_prompt: 'Be brief' }))).toBe('Be brief');
   });
 
+  test('formatValue (previewPrompt) keeps an exactly-60-char prompt verbatim', () => {
+    const exactly60 = 'a'.repeat(60);
+    expect(def.formatValue(fakeGroup({ custom_prompt: exactly60 }))).toBe(exactly60);
+  });
+
+  test('formatValue (previewPrompt) truncates a >60-char prompt with an ellipsis', () => {
+    const preview = def.formatValue(fakeGroup({ custom_prompt: 'b'.repeat(61) }));
+    expect(preview.endsWith('…')).toBe(true);
+    expect(preview).toBe(`${'b'.repeat(57)}…`);
+  });
+
+  test('formatValue (previewPrompt) flattens multiline whitespace to single spaces', () => {
+    expect(def.formatValue(fakeGroup({ custom_prompt: 'line one\n\n  line two' }))).toBe(
+      'line one line two',
+    );
+  });
+
   test('apply writes the prompt and clears it', async () => {
     await applyGroupSetting(def, fakeGroup(), 'Be brief');
     expect(updateMock).toHaveBeenCalledWith(-100, { custom_prompt: 'Be brief' });
-    updateMock.mockReset();
+    updateMock.mockReset().mockReturnValue(fakeGroup());
     await applyGroupSetting(def, fakeGroup(), 'clear');
     expect(updateMock).toHaveBeenCalledWith(-100, { custom_prompt: null });
+  });
+
+  test('apply reports failure when the group update does not persist', async () => {
+    updateMock.mockReset().mockReturnValue(null);
+    const result = await applyGroupSetting(def, fakeGroup(), 'Be brief');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('Не удалось');
+  });
+});
+
+// ── aiValueHint contracts (fed verbatim into the AI tool description) ────────────
+
+describe('aiValueHint contracts', () => {
+  test('custom_prompt routes notes to set_custom_prompt and warns it overwrites', () => {
+    const hint = GROUP_SETTINGS.custom_prompt.aiValueHint;
+    expect(hint).toContain('set_custom_prompt');
+    expect(hint.toUpperCase()).toContain('REPLACE');
+  });
+
+  test('active_topic_id is clear-only and points the user to /topic', () => {
+    const hint = GROUP_SETTINGS.active_topic_id.aiValueHint;
+    expect(hint).toContain('/topic');
+    expect(hint.toLowerCase()).toContain('clear');
+  });
+
+  test('default_currency notes the restricted built-in set', () => {
+    expect(GROUP_SETTINGS.default_currency.aiValueHint).toContain('built-in');
   });
 });

--- a/src/services/settings/group-settings-registry.ts
+++ b/src/services/settings/group-settings-registry.ts
@@ -1,0 +1,369 @@
+/**
+ * Group settings registry — the single source of truth for every user-configurable
+ * group setting. Both the AI `update_group_setting` tool and the /settings menu mutate
+ * groups EXCLUSIVELY through these definitions, so a setting can never be changeable in
+ * one surface but not the other.
+ *
+ * Enforcement (compile-time): every key of `UpdateGroupData` must be classified as either
+ * a system field (`SYSTEM_GROUP_FIELDS`) or an editable setting with a `GROUP_SETTINGS`
+ * entry. `ALL_UPDATE_KEYS satisfies Record<keyof UpdateGroupData, true>` fails to compile
+ * if a new column is added to `UpdateGroupData` without listing it here; `GROUP_SETTINGS`
+ * being keyed by `EditableGroupSettingKey` then forces an entry for every editable key.
+ * `group-settings-registry.test.ts` re-checks the same invariant at runtime.
+ */
+import { type CurrencyCode, SUPPORTED_CURRENCIES } from '../../config/constants';
+import { database } from '../../database';
+import type { Group, UpdateGroupData } from '../../database/types';
+
+// ── Enforcement: classify every UpdateGroupData key ───────────────────────────
+
+/** Fields that are internal plumbing, never exposed as user settings. */
+export const SYSTEM_GROUP_FIELDS = [
+  'title',
+  'invite_link',
+  'google_refresh_token',
+  'spreadsheet_id',
+  'bank_panel_summary_message_id',
+  'oauth_client',
+] as const;
+
+/**
+ * Exhaustive map of every `UpdateGroupData` key. The `satisfies` clause makes TypeScript
+ * fail to compile if a field is added to `UpdateGroupData` without being listed here —
+ * forcing a deliberate system-vs-setting classification.
+ */
+export const ALL_UPDATE_KEYS = {
+  title: true,
+  invite_link: true,
+  google_refresh_token: true,
+  spreadsheet_id: true,
+  default_currency: true,
+  enabled_currencies: true,
+  custom_prompt: true,
+  active_topic_id: true,
+  bank_panel_summary_message_id: true,
+  bank_cards_enabled: true,
+  oauth_client: true,
+} satisfies Record<keyof UpdateGroupData, true>;
+
+/** Every editable setting key = all update keys minus the system fields. */
+export type EditableGroupSettingKey = Exclude<
+  keyof UpdateGroupData,
+  (typeof SYSTEM_GROUP_FIELDS)[number]
+>;
+
+// ── Setting definition shape ──────────────────────────────────────────────────
+
+export type GroupSettingKind = 'currency' | 'currency_multi' | 'toggle' | 'topic' | 'text';
+
+export type SettingParseResult<V> = { ok: true; value: V } | { ok: false; error: string };
+
+interface BaseSettingDef {
+  readonly emoji: string;
+  readonly labelRu: string;
+  /** Tells the AI exactly what value string to pass to `update_group_setting`. */
+  readonly aiValueHint: string;
+  /** Render the current stored value for display (menu lines, AI context, summaries). */
+  formatValue(group: Group): string;
+}
+
+interface CurrencySettingDef extends BaseSettingDef {
+  readonly key: 'default_currency';
+  readonly kind: 'currency';
+  parse(raw: string, group: Group): SettingParseResult<CurrencyCode>;
+  apply(group: Group, value: CurrencyCode): Promise<void>;
+}
+
+interface CurrencyMultiSettingDef extends BaseSettingDef {
+  readonly key: 'enabled_currencies';
+  readonly kind: 'currency_multi';
+  parse(raw: string, group: Group): SettingParseResult<CurrencyCode[]>;
+  apply(group: Group, value: CurrencyCode[]): Promise<void>;
+}
+
+interface ToggleSettingDef extends BaseSettingDef {
+  readonly key: 'bank_cards_enabled';
+  readonly kind: 'toggle';
+  parse(raw: string, group: Group): SettingParseResult<number>;
+  apply(group: Group, value: number): Promise<void>;
+}
+
+interface TopicSettingDef extends BaseSettingDef {
+  readonly key: 'active_topic_id';
+  readonly kind: 'topic';
+  parse(raw: string, group: Group): SettingParseResult<number | null>;
+  apply(group: Group, value: number | null): Promise<void>;
+}
+
+interface TextSettingDef extends BaseSettingDef {
+  readonly key: 'custom_prompt';
+  readonly kind: 'text';
+  parse(raw: string, group: Group): SettingParseResult<string | null>;
+  apply(group: Group, value: string | null): Promise<void>;
+}
+
+export type GroupSettingDef =
+  | CurrencySettingDef
+  | CurrencyMultiSettingDef
+  | ToggleSettingDef
+  | TopicSettingDef
+  | TextSettingDef;
+
+// ── Parsing helpers ────────────────────────────────────────────────────────────
+
+/** Words that clear an optional setting (topic / custom prompt). */
+const CLEAR_WORDS = new Set([
+  'clear',
+  'none',
+  'reset',
+  'unset',
+  'сброс',
+  'сбросить',
+  'очистить',
+  'убрать',
+]);
+
+const TOGGLE_ON = new Set([
+  'on',
+  '1',
+  'true',
+  'yes',
+  'enable',
+  'enabled',
+  'вкл',
+  'включить',
+  'включено',
+  'да',
+]);
+const TOGGLE_OFF = new Set([
+  'off',
+  '0',
+  'false',
+  'no',
+  'disable',
+  'disabled',
+  'выкл',
+  'выключить',
+  'выключено',
+  'нет',
+]);
+
+function isSupportedCurrency(code: string): code is CurrencyCode {
+  return SUPPORTED_CURRENCIES.some((c) => c === code);
+}
+
+function supportedCurrencyList(): string {
+  return SUPPORTED_CURRENCIES.join(', ');
+}
+
+function parseCurrency(raw: string): SettingParseResult<CurrencyCode> {
+  const code = raw.trim().toUpperCase();
+  if (!code) {
+    return { ok: false, error: 'Укажи код валюты, например EGP или USD.' };
+  }
+  if (isSupportedCurrency(code)) {
+    return { ok: true, value: code };
+  }
+  return {
+    ok: false,
+    error: `Неизвестная валюта "${code}". Поддерживаются: ${supportedCurrencyList()}.`,
+  };
+}
+
+function parseCurrencyMulti(raw: string, group: Group): SettingParseResult<CurrencyCode[]> {
+  const tokens = raw
+    .split(/[\s,]+/)
+    .map((t) => t.trim().toUpperCase())
+    .filter(Boolean);
+
+  if (tokens.length === 0) {
+    return { ok: false, error: 'Перечисли хотя бы одну валюту, например "USD, EUR".' };
+  }
+
+  const invalid = tokens.filter((t) => !isSupportedCurrency(t));
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      error: `Неизвестные валюты: ${invalid.join(', ')}. Поддерживаются: ${supportedCurrencyList()}.`,
+    };
+  }
+
+  const valid = tokens.filter(isSupportedCurrency);
+  // The default currency must always stay enabled — a default outside the set is a bug.
+  const withDefault = valid.includes(group.default_currency)
+    ? valid
+    : [...valid, group.default_currency];
+  return { ok: true, value: [...new Set(withDefault)] };
+}
+
+function parseToggle(raw: string): SettingParseResult<number> {
+  const value = raw.trim().toLowerCase();
+  if (TOGGLE_ON.has(value)) return { ok: true, value: 1 };
+  if (TOGGLE_OFF.has(value)) return { ok: true, value: 0 };
+  return { ok: false, error: `Не понял "${raw}". Напиши "вкл" или "выкл".` };
+}
+
+function parseTopic(raw: string): SettingParseResult<number | null> {
+  const value = raw.trim().toLowerCase();
+  if (value === '' || CLEAR_WORDS.has(value)) {
+    return { ok: true, value: null };
+  }
+  if (!/^-?\d+$/.test(value)) {
+    return { ok: false, error: `Топик должен быть числом или "сброс". Получено: "${raw}".` };
+  }
+  return { ok: true, value: Number.parseInt(value, 10) };
+}
+
+function parseText(raw: string): SettingParseResult<string | null> {
+  const trimmed = raw.trim();
+  if (trimmed === '' || CLEAR_WORDS.has(trimmed.toLowerCase())) {
+    return { ok: true, value: null };
+  }
+  return { ok: true, value: trimmed };
+}
+
+function previewPrompt(prompt: string | null): string {
+  if (!prompt) return 'не задан';
+  const oneLine = prompt.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 60 ? `${oneLine.slice(0, 57)}…` : oneLine;
+}
+
+// ── Setting definitions ──────────────────────────────────────────────────────
+
+const defaultCurrencySetting: CurrencySettingDef = {
+  key: 'default_currency',
+  kind: 'currency',
+  emoji: '💱',
+  labelRu: 'Валюта по умолчанию',
+  aiValueHint: 'ISO currency code, e.g. "EGP", "USD", "RSD"',
+  formatValue: (group) => group.default_currency,
+  parse: (raw) => parseCurrency(raw),
+  async apply(group, value) {
+    const enabled = group.enabled_currencies.includes(value)
+      ? group.enabled_currencies
+      : [...group.enabled_currencies, value];
+    database.groups.update(group.telegram_group_id, {
+      default_currency: value,
+      enabled_currencies: enabled,
+    });
+  },
+};
+
+const enabledCurrenciesSetting: CurrencyMultiSettingDef = {
+  key: 'enabled_currencies',
+  kind: 'currency_multi',
+  emoji: '💵',
+  labelRu: 'Включённые валюты',
+  aiValueHint:
+    'comma- or space-separated ISO codes, e.g. "USD, EUR, EGP"; the default currency is always kept',
+  formatValue: (group) => group.enabled_currencies.join(', ') || '—',
+  parse: (raw, group) => parseCurrencyMulti(raw, group),
+  async apply(group, value) {
+    database.groups.update(group.telegram_group_id, { enabled_currencies: value });
+  },
+};
+
+const bankCardsSetting: ToggleSettingDef = {
+  key: 'bank_cards_enabled',
+  kind: 'toggle',
+  emoji: '🔔',
+  labelRu: 'Карточки банковских транзакций',
+  aiValueHint: 'on / off (also accepts 1/0, true/false, вкл/выкл)',
+  formatValue: (group) => (group.bank_cards_enabled ? 'вкл' : 'выкл (только баланс)'),
+  parse: (raw) => parseToggle(raw),
+  async apply(group, value) {
+    database.groups.update(group.telegram_group_id, { bank_cards_enabled: value });
+  },
+};
+
+const activeTopicSetting: TopicSettingDef = {
+  key: 'active_topic_id',
+  kind: 'topic',
+  emoji: '📍',
+  labelRu: 'Топик',
+  aiValueHint: 'integer topic id, or "clear"/"сброс" to unset',
+  formatValue: (group) =>
+    group.active_topic_id != null ? `#${group.active_topic_id}` : 'не задан',
+  parse: (raw) => parseTopic(raw),
+  async apply(group, value) {
+    database.groups.update(group.telegram_group_id, { active_topic_id: value });
+  },
+};
+
+const customPromptSetting: TextSettingDef = {
+  key: 'custom_prompt',
+  kind: 'text',
+  emoji: '📝',
+  labelRu: 'AI-промпт',
+  aiValueHint: 'free text, or "clear"/"сброс" to remove',
+  formatValue: (group) => previewPrompt(group.custom_prompt),
+  parse: (raw) => parseText(raw),
+  async apply(group, value) {
+    database.groups.update(group.telegram_group_id, { custom_prompt: value });
+  },
+};
+
+/**
+ * The registry. Keyed by `EditableGroupSettingKey` with each slot pinned to the definition
+ * whose `key` matches, so adding an editable column without a matching, correctly-typed
+ * definition fails to compile.
+ */
+export const GROUP_SETTINGS: {
+  [K in EditableGroupSettingKey]: Extract<GroupSettingDef, { key: K }>;
+} = {
+  default_currency: defaultCurrencySetting,
+  enabled_currencies: enabledCurrenciesSetting,
+  bank_cards_enabled: bankCardsSetting,
+  active_topic_id: activeTopicSetting,
+  custom_prompt: customPromptSetting,
+};
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/** Type guard: is `key` a registry-backed editable setting? */
+export function isEditableGroupSettingKey(key: string): key is EditableGroupSettingKey {
+  return Object.hasOwn(GROUP_SETTINGS, key);
+}
+
+export type ApplyGroupSettingResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Parse a raw (LLM- or user-supplied) string for a setting and persist it.
+ * This is the ONE mutation path shared by the AI tool and the /settings menu.
+ */
+export async function applyGroupSetting(
+  def: GroupSettingDef,
+  group: Group,
+  raw: string,
+): Promise<ApplyGroupSettingResult> {
+  // The switch narrows `def` to a concrete variant so `parse`/`apply` stay correlated
+  // on the same value type V — no casts needed.
+  switch (def.kind) {
+    case 'currency':
+      return runSetting(def, group, raw);
+    case 'currency_multi':
+      return runSetting(def, group, raw);
+    case 'toggle':
+      return runSetting(def, group, raw);
+    case 'topic':
+      return runSetting(def, group, raw);
+    case 'text':
+      return runSetting(def, group, raw);
+  }
+}
+
+async function runSetting<V>(
+  def: {
+    parse(raw: string, group: Group): SettingParseResult<V>;
+    apply(group: Group, value: V): Promise<void>;
+  },
+  group: Group,
+  raw: string,
+): Promise<ApplyGroupSettingResult> {
+  const parsed = def.parse(raw, group);
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+  await def.apply(group, parsed.value);
+  return { ok: true };
+}

--- a/src/services/settings/group-settings-registry.ts
+++ b/src/services/settings/group-settings-registry.ts
@@ -69,39 +69,42 @@ interface BaseSettingDef {
   formatValue(group: Group): string;
 }
 
+/** apply() returns whether the write actually persisted (false if the group vanished). */
 interface CurrencySettingDef extends BaseSettingDef {
   readonly key: 'default_currency';
   readonly kind: 'currency';
   parse(raw: string, group: Group): SettingParseResult<CurrencyCode>;
-  apply(group: Group, value: CurrencyCode): Promise<void>;
+  apply(group: Group, value: CurrencyCode): Promise<boolean>;
 }
 
 interface CurrencyMultiSettingDef extends BaseSettingDef {
   readonly key: 'enabled_currencies';
   readonly kind: 'currency_multi';
   parse(raw: string, group: Group): SettingParseResult<CurrencyCode[]>;
-  apply(group: Group, value: CurrencyCode[]): Promise<void>;
+  apply(group: Group, value: CurrencyCode[]): Promise<boolean>;
 }
 
 interface ToggleSettingDef extends BaseSettingDef {
   readonly key: 'bank_cards_enabled';
   readonly kind: 'toggle';
   parse(raw: string, group: Group): SettingParseResult<number>;
-  apply(group: Group, value: number): Promise<void>;
+  apply(group: Group, value: number): Promise<boolean>;
+  /** Current on/off state (1/0) — used by the menu to label the in-place toggle button. */
+  current(group: Group): number;
 }
 
 interface TopicSettingDef extends BaseSettingDef {
   readonly key: 'active_topic_id';
   readonly kind: 'topic';
   parse(raw: string, group: Group): SettingParseResult<number | null>;
-  apply(group: Group, value: number | null): Promise<void>;
+  apply(group: Group, value: number | null): Promise<boolean>;
 }
 
 interface TextSettingDef extends BaseSettingDef {
   readonly key: 'custom_prompt';
   readonly kind: 'text';
   parse(raw: string, group: Group): SettingParseResult<string | null>;
-  apply(group: Group, value: string | null): Promise<void>;
+  apply(group: Group, value: string | null): Promise<boolean>;
 }
 
 export type GroupSettingDef =
@@ -214,15 +217,21 @@ function parseToggle(raw: string): SettingParseResult<number> {
   return { ok: false, error: `Не понял "${raw}". Напиши "вкл" или "выкл".` };
 }
 
+/**
+ * Topic binding is CLEAR-ONLY through the registry (AI tool + menu). Accepting a free-form
+ * id would let the AI/menu point the group at a non-existent thread and silently brick it
+ * (the bot would stop responding). Binding must go through /topic run INSIDE the target
+ * topic, where Telegram guarantees the thread exists.
+ */
+const TOPIC_BIND_HINT =
+  'Привязать топик отсюда нельзя — зайди в нужный топик и отправь там /topic, тогда Telegram гарантирует, что топик существует. Здесь можно только сбросить привязку (напиши "сброс").';
+
 function parseTopic(raw: string): SettingParseResult<number | null> {
   const value = raw.trim().toLowerCase();
   if (value === '' || CLEAR_WORDS.has(value)) {
     return { ok: true, value: null };
   }
-  if (!/^-?\d+$/.test(value)) {
-    return { ok: false, error: `Топик должен быть числом или "сброс". Получено: "${raw}".` };
-  }
-  return { ok: true, value: Number.parseInt(value, 10) };
+  return { ok: false, error: TOPIC_BIND_HINT };
 }
 
 function parseText(raw: string): SettingParseResult<string | null> {
@@ -241,22 +250,27 @@ function previewPrompt(prompt: string | null): string {
 
 // ── Setting definitions ──────────────────────────────────────────────────────
 
+/** Persist a partial group update; returns false if the group no longer exists. */
+function persist(telegramGroupId: number, data: UpdateGroupData): boolean {
+  return database.groups.update(telegramGroupId, data) !== null;
+}
+
 const defaultCurrencySetting: CurrencySettingDef = {
   key: 'default_currency',
   kind: 'currency',
   emoji: '💱',
   labelRu: 'Валюта по умолчанию',
-  aiValueHint: 'ISO currency code, e.g. "EGP", "USD", "RSD"',
+  aiValueHint:
+    'one of the built-in supported ISO codes (USD, EUR, RUB, RSD, GBP, BYN, CHF, JPY, CNY, INR, LKR, AED, EGP), e.g. "EGP"',
   formatValue: (group) => group.default_currency,
   parse: (raw) => parseCurrency(raw),
-  async apply(group, value) {
+  apply(group, value) {
     const enabled = group.enabled_currencies.includes(value)
       ? group.enabled_currencies
       : [...group.enabled_currencies, value];
-    database.groups.update(group.telegram_group_id, {
-      default_currency: value,
-      enabled_currencies: enabled,
-    });
+    return Promise.resolve(
+      persist(group.telegram_group_id, { default_currency: value, enabled_currencies: enabled }),
+    );
   },
 };
 
@@ -269,8 +283,8 @@ const enabledCurrenciesSetting: CurrencyMultiSettingDef = {
     'comma- or space-separated ISO codes, e.g. "USD, EUR, EGP"; the default currency is always kept',
   formatValue: (group) => group.enabled_currencies.join(', ') || '—',
   parse: (raw, group) => parseCurrencyMulti(raw, group),
-  async apply(group, value) {
-    database.groups.update(group.telegram_group_id, { enabled_currencies: value });
+  apply(group, value) {
+    return Promise.resolve(persist(group.telegram_group_id, { enabled_currencies: value }));
   },
 };
 
@@ -281,9 +295,10 @@ const bankCardsSetting: ToggleSettingDef = {
   labelRu: 'Карточки банковских транзакций',
   aiValueHint: 'on / off (also accepts 1/0, true/false, вкл/выкл)',
   formatValue: (group) => (group.bank_cards_enabled ? 'вкл' : 'выкл (только баланс)'),
+  current: (group) => (group.bank_cards_enabled ? 1 : 0),
   parse: (raw) => parseToggle(raw),
-  async apply(group, value) {
-    database.groups.update(group.telegram_group_id, { bank_cards_enabled: value });
+  apply(group, value) {
+    return Promise.resolve(persist(group.telegram_group_id, { bank_cards_enabled: value }));
   },
 };
 
@@ -292,12 +307,13 @@ const activeTopicSetting: TopicSettingDef = {
   kind: 'topic',
   emoji: '📍',
   labelRu: 'Топик',
-  aiValueHint: 'integer topic id, or "clear"/"сброс" to unset',
+  aiValueHint:
+    'only "clear"/"сброс" to unbind the topic. To BIND a topic the user must run /topic inside that topic — the AI/menu cannot set a topic id.',
   formatValue: (group) =>
     group.active_topic_id != null ? `#${group.active_topic_id}` : 'не задан',
   parse: (raw) => parseTopic(raw),
-  async apply(group, value) {
-    database.groups.update(group.telegram_group_id, { active_topic_id: value });
+  apply(group, value) {
+    return Promise.resolve(persist(group.telegram_group_id, { active_topic_id: value }));
   },
 };
 
@@ -306,11 +322,12 @@ const customPromptSetting: TextSettingDef = {
   kind: 'text',
   emoji: '📝',
   labelRu: 'AI-промпт',
-  aiValueHint: 'free text, or "clear"/"сброс" to remove',
+  aiValueHint:
+    'full prompt text to OVERWRITE, or "clear"/"сброс" to remove. To ADD/remember a note without wiping existing notes, use set_custom_prompt (append) instead — this REPLACES the whole prompt.',
   formatValue: (group) => previewPrompt(group.custom_prompt),
   parse: (raw) => parseText(raw),
-  async apply(group, value) {
-    database.groups.update(group.telegram_group_id, { custom_prompt: value });
+  apply(group, value) {
+    return Promise.resolve(persist(group.telegram_group_id, { custom_prompt: value }));
   },
 };
 
@@ -347,8 +364,9 @@ export async function applyGroupSetting(
   group: Group,
   raw: string,
 ): Promise<ApplyGroupSettingResult> {
-  // The switch narrows `def` to a concrete variant so `parse`/`apply` stay correlated
-  // on the same value type V — no casts needed.
+  // Each arm narrows `def` to a concrete variant so the generic runSetting can correlate
+  // parse/apply on one value type V — the arms are load-bearing, not duplication. A new
+  // `kind` makes the `never` guard below fail to compile.
   switch (def.kind) {
     case 'currency':
       return runSetting(def, group, raw);
@@ -360,13 +378,17 @@ export async function applyGroupSetting(
       return runSetting(def, group, raw);
     case 'text':
       return runSetting(def, group, raw);
+    default: {
+      const exhaustive: never = def;
+      return exhaustive;
+    }
   }
 }
 
 async function runSetting<V>(
   def: {
     parse(raw: string, group: Group): SettingParseResult<V>;
-    apply(group: Group, value: V): Promise<void>;
+    apply(group: Group, value: V): Promise<boolean>;
   },
   group: Group,
   raw: string,
@@ -375,6 +397,9 @@ async function runSetting<V>(
   if (!parsed.ok) {
     return { ok: false, error: parsed.error };
   }
-  await def.apply(group, parsed.value);
+  const persisted = await def.apply(group, parsed.value);
+  if (!persisted) {
+    return { ok: false, error: 'Не удалось сохранить настройку — попробуй ещё раз.' };
+  }
   return { ok: true };
 }

--- a/src/services/settings/group-settings-registry.ts
+++ b/src/services/settings/group-settings-registry.ts
@@ -58,8 +58,6 @@ export type EditableGroupSettingKey = Exclude<
 
 // ── Setting definition shape ──────────────────────────────────────────────────
 
-export type GroupSettingKind = 'currency' | 'currency_multi' | 'toggle' | 'topic' | 'text';
-
 export type SettingParseResult<V> = { ok: true; value: V } | { ok: false; error: string };
 
 interface BaseSettingDef {

--- a/src/services/settings/group-settings-registry.ts
+++ b/src/services/settings/group-settings-registry.ts
@@ -11,7 +11,11 @@
  * being keyed by `EditableGroupSettingKey` then forces an entry for every editable key.
  * `group-settings-registry.test.ts` re-checks the same invariant at runtime.
  */
-import { type CurrencyCode, SUPPORTED_CURRENCIES } from '../../config/constants';
+import {
+  type CurrencyCode,
+  isValidCurrencyCode,
+  SUPPORTED_CURRENCIES,
+} from '../../config/constants';
 import { database } from '../../database';
 import type { Group, UpdateGroupData } from '../../database/types';
 
@@ -148,8 +152,17 @@ const TOGGLE_OFF = new Set([
   'нет',
 ]);
 
+/** default_currency is restricted to built-in codes — they have reliable EUR rates. */
 function isSupportedCurrency(code: string): code is CurrencyCode {
   return SUPPORTED_CURRENCIES.some((c) => c === code);
+}
+
+/**
+ * enabled_currencies accepts any valid ISO-format code (matching onboarding's custom-currency
+ * support), so a group that added e.g. GEL/TRY during setup can still edit its set here.
+ */
+function isEnabledCurrencyCode(code: string): code is CurrencyCode {
+  return isValidCurrencyCode(code);
 }
 
 function supportedCurrencyList(): string {
@@ -180,15 +193,15 @@ function parseCurrencyMulti(raw: string, group: Group): SettingParseResult<Curre
     return { ok: false, error: 'Перечисли хотя бы одну валюту, например "USD, EUR".' };
   }
 
-  const invalid = tokens.filter((t) => !isSupportedCurrency(t));
+  const invalid = tokens.filter((t) => !isEnabledCurrencyCode(t));
   if (invalid.length > 0) {
     return {
       ok: false,
-      error: `Неизвестные валюты: ${invalid.join(', ')}. Поддерживаются: ${supportedCurrencyList()}.`,
+      error: `Неизвестные валюты: ${invalid.join(', ')}. Используй трёхбуквенные коды, например USD, EUR.`,
     };
   }
 
-  const valid = tokens.filter(isSupportedCurrency);
+  const valid = tokens.filter(isEnabledCurrencyCode);
   // The default currency must always stay enabled — a default outside the set is a bug.
   const withDefault = valid.includes(group.default_currency)
     ? valid


### PR DESCRIPTION
## Why
A user asked the bot to change the group's default currency to Egyptian pounds. The AI replied it has no such ability and deflected to `/settings`. The `/settings` menu itself was read-only except one toggle. Requirement: the AI must be able to change ANY group setting, and it must be architecturally impossible to add a setting the AI/menu can't change.

## What
- **Single source of truth**: `src/services/settings/group-settings-registry.ts` — `GROUP_SETTINGS` registry drives BOTH the AI tool and the `/settings` menu through one shared `applyGroupSetting` mutation path.
- **Enforcement (can't add an unreachable setting)**:
  - Compile-time: `ALL_UPDATE_KEYS satisfies Record<keyof UpdateGroupData, true>` + `EditableGroupSettingKey` + `GROUP_SETTINGS` keyed by it — a new column fails to compile unless classified system-or-setting with a typed def.
  - Runtime tests: registry keys == editable keys; and every registry key produces a reachable `/settings` menu button.
- **Generic AI tool** `update_group_setting` covering default_currency, enabled_currencies, bank_cards_enabled, active_topic_id (clear-only), custom_prompt; `get_group_settings` rebuilt from the registry.
- **Editable `/settings` menu** generated from the registry (currency picker, multi-select, toggles), not hand-coded buttons.
- **EGP** (Egyptian Pound) added to supported currencies (the headline use-case).

## Safety / review hardening
- `active_topic_id` is **clear-only** via AI/menu (binding stays in `/topic`, where Telegram guarantees the thread exists) — prevents bricking a group by setting a non-existent topic.
- `custom_prompt` write contract documented (append via `set_custom_prompt`, overwrite via `update_group_setting`) to avoid wiping accumulated notes.
- **HTML-injection fix**: a `custom_prompt` containing tags would render as active formatting because the global `sanitizeOutgoingMessages` hook restores whitelisted tags after escaping — neutralized both raw and pre-encoded tag delimiters.
- Non-persisting writes now report a Russian error instead of false success.

## Tests
3511 pass / 0 fail (151 files, +23 new tests). type-check clean, biome lint clean (0 warnings). Reviewed by a 4-model panel + 2 codex rounds; all findings addressed.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq7c53bgYsq6uZ9hmdhXu9
