### PR TITLE
fix(ai): informative AI failures + throttled admin report + retry cap + provider circuit-breaker

### DIFF
--- a/src/bot/commands/ask.test.ts
+++ b/src/bot/commands/ask.test.ts
@@ -78,7 +78,7 @@ mock.module('../../services/ai/streaming', () => ({
   stripThinkingTags: (text: string) => text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim(),
   isRetryableError: mock(() => false),
   getBackoffDelay: mock(() => 0),
-  formatApiError: mock(() => 'mock-error'),
+  classifyAiError: mock(() => null),
 }));
 
 // ── StatusWriter ────────────────────────────────────────────────────────

--- a/src/bot/commands/ask.test.ts
+++ b/src/bot/commands/ask.test.ts
@@ -136,6 +136,10 @@ mock.module('../../services/analytics/advice-triggers', () => ({
 const mockSendMessage = mock(async () => null);
 mock.module('../../services/bank/telegram-sender', () => ({
   sendMessage: mockSendMessage,
+  // error-reporter.ts (pulled in transitively via the agent) does `import { sendDirect }`, so this
+  // module mock must export it or bun fails the test at link time with
+  // "Export named 'sendDirect' not found". ask.ts itself never calls sendDirect.
+  sendDirect: mock(async () => null),
   editMessageText: mock(async () => undefined),
   deleteMessage: mock(async () => undefined),
   sendChatAction: mock(async () => undefined),

--- a/src/services/ai/agent.test.ts
+++ b/src/services/ai/agent.test.ts
@@ -32,13 +32,27 @@ mock.module('./streaming', () => ({
   classifyAiError: mockClassifyAiError,
 }));
 
+const mockValidateResponse = mock<
+  (input: {
+    userMessage: string;
+    toolCalls: string[];
+    response: string;
+  }) => Promise<{ approved: true } | { approved: false; reason: string }>
+>(async () => ({ approved: true }));
 mock.module('./response-validator', () => ({
-  validateResponse: mock(async () => ({ approved: true })),
+  validateResponse: mockValidateResponse,
 }));
 
 const mockReportAiFailureToAdmin = mock<(input: unknown) => Promise<void>>(() => Promise.resolve());
 mock.module('./error-reporter', () => ({
   reportAiFailureToAdmin: mockReportAiFailureToAdmin,
+}));
+
+const mockExecuteTool = mock<(name: string, input: unknown, ctx: unknown) => Promise<unknown>>(
+  async () => ({ success: true, output: 'ok', data: { total: 100 }, summary: 'done' }),
+);
+mock.module('./tool-executor', () => ({
+  executeTool: mockExecuteTool,
 }));
 
 import { ExpenseBotAgent } from './agent';
@@ -83,6 +97,24 @@ function mockStreamReturn(chunks: string[] = ['ok']) {
   });
 }
 
+/** Queue a single tool-calling round (no text), so runAgentLoop executes a tool then loops. */
+function mockToolCallRound(name: string, args = '{}') {
+  mockAiStreamRound.mockImplementationOnce(async (_opts, callbacks) => {
+    callbacks.onToolCallStart?.(name);
+    return {
+      text: '',
+      toolCalls: [{ id: 'call_1', name, arguments: args }],
+      finishReason: 'tool_calls',
+      assistantMessage: {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'call_1', type: 'function', function: { name, arguments: args } }],
+      },
+      providerUsed: 'mock',
+    } satisfies StreamRoundResult;
+  });
+}
+
 /** Extract the LAST call's options from mockAiStreamRound (most recent invocation) */
 function getLastCallOpts(): import('./streaming').StreamRoundOptions {
   const calls = mockAiStreamRound.mock.calls;
@@ -121,6 +153,16 @@ describe('ExpenseBotAgent', () => {
     mockGetBackoffDelay.mockClear();
     mockClassifyAiError.mockClear();
     mockReportAiFailureToAdmin.mockClear();
+    // mockReset (not mockClear) so any queued one-shot impl can't leak into the next test.
+    mockValidateResponse.mockReset();
+    mockValidateResponse.mockResolvedValue({ approved: true });
+    mockExecuteTool.mockReset();
+    mockExecuteTool.mockResolvedValue({
+      success: true,
+      output: 'ok',
+      data: { total: 100 },
+      summary: 'done',
+    });
 
     // Default: errors are not retryable (unless overridden per test)
     mockIsRetryableError.mockReturnValue(false);
@@ -188,6 +230,98 @@ describe('ExpenseBotAgent', () => {
 
       await agent.run('How much did I spend?', [], mockBot as unknown as import('gramio').Bot);
       expect(mockAiStreamRound).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-run when the initial answer passes validation', async () => {
+      mockStreamReturn(['fine answer']);
+
+      const result = await agent.run('q', [], mockBot as unknown as import('gramio').Bot);
+      expect(mockAiStreamRound).toHaveBeenCalledTimes(1);
+      expect(mockValidateResponse).toHaveBeenCalledTimes(1);
+      expect(result).toBe('fine answer');
+    });
+
+    it('skips validation entirely when the initial answer already called tools', async () => {
+      mockToolCallRound('get_expenses'); // initial round 1: calls a tool
+      mockStreamReturn(['grounded answer']); // initial round 2: final text
+
+      const result = await agent.run(
+        'How much did I spend?',
+        [],
+        mockBot as unknown as import('gramio').Bot,
+      );
+      expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+      // Tool-grounded → the validation pass is never entered.
+      expect(mockValidateResponse).not.toHaveBeenCalled();
+      expect(result).toBe('grounded answer');
+    });
+
+    it('caps at exactly one re-run (validates once) and surfaces the retry on a reject', async () => {
+      // Initial answer and the retry both call no tools; the validator rejects the initial.
+      mockStreamReturn(['initial bad answer']);
+      mockStreamReturn(['retry bad answer']);
+      mockValidateResponse.mockResolvedValue({ approved: false, reason: 'no tools used' });
+
+      const result = await agent.run(
+        'How much did I spend?',
+        [],
+        mockBot as unknown as import('gramio').Bot,
+      );
+      // Exactly one re-run: initial + one retry = 2 stream calls, never a 3rd (no 60s loop).
+      expect(mockAiStreamRound).toHaveBeenCalledTimes(2);
+      // Validated only ONCE (the initial) — the retry is surfaced without a second validator call.
+      expect(mockValidateResponse).toHaveBeenCalledTimes(1);
+      // Surfaced answer is the retry (the last attempt) rather than an error/abort.
+      expect(result).toBe('retry bad answer');
+      // A validation cap is a quality event, NOT a failure — it must not page the admin.
+      expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
+    });
+
+    it('trusts a retry that calls tools (no second validation of grounded data)', async () => {
+      mockStreamReturn(['initial bad answer']); // initial: no tools → rejected
+      mockToolCallRound('get_expenses'); // retry round 1: calls a tool
+      mockStreamReturn(['grounded answer']); // retry round 2: final text after the tool
+      mockValidateResponse.mockResolvedValueOnce({ approved: false, reason: 'no tools' });
+
+      const result = await agent.run(
+        'How much did I spend?',
+        [],
+        mockBot as unknown as import('gramio').Bot,
+      );
+      expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+      // Only the initial answer was validated; the tool-grounded retry is trusted.
+      expect(mockValidateResponse).toHaveBeenCalledTimes(1);
+      expect(result).toBe('grounded answer');
+    });
+
+    it('returns empty (caller treats as silent) when the capped retry produced no text', async () => {
+      mockStreamReturn(['initial bad answer']); // non-empty, rejected
+      mockStreamReturn([]); // retry streams nothing
+      mockValidateResponse.mockResolvedValue({ approved: false, reason: 'no tools used' });
+
+      const result = await agent.run(
+        'How much did I spend?',
+        [],
+        mockBot as unknown as import('gramio').Bot,
+      );
+      // The return value is the retry's getText() = '' (NOT the stale initial). The writer's
+      // finalize() substitutes a placeholder for display, but the returned/history text is '',
+      // which the caller (ask.ts: `if (!finalResponse) return;`) treats as a silent no-op.
+      expect(result).toBe('');
+    });
+
+    it('propagates a retry failure to the catch path (AgentError + admin report)', async () => {
+      mockStreamReturn(['initial bad answer']); // initial: no tools
+      mockValidateResponse.mockResolvedValueOnce({ approved: false, reason: 'no tools' });
+      const retryErr = Object.assign(new Error('retry stream failed'), { status: 500 });
+      mockAiStreamRound.mockImplementationOnce(() => Promise.reject(retryErr)); // the re-run throws
+
+      const { AgentError } = await import('../../errors');
+      await expect(
+        agent.run('How much did I spend?', [], mockBot as unknown as import('gramio').Bot),
+      ).rejects.toBeInstanceOf(AgentError);
+      // The retry error propagated through finalizeWithValidation into run()'s catch.
+      expect(mockReportAiFailureToAdmin).toHaveBeenCalledTimes(1);
     });
 
     it('passes maxTokens to aiStreamRound', async () => {

--- a/src/services/ai/agent.test.ts
+++ b/src/services/ai/agent.test.ts
@@ -837,4 +837,116 @@ describe('ExpenseBotAgent', () => {
       expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
     });
   });
+
+  // -- run() -- admin paging gate + user-facing string surfacing -------------
+  // Only genuine failures (provider_down / generic) page the admin; transient/user-side classes
+  // (rate_limit / overloaded / timeout) surface a user message but must NOT spam the operator.
+  // The real error→message mapping is pinned in streaming.test.ts; here we assert the agent SENDS
+  // the classified string to the user (via bot.api.sendMessage) and applies the paging gate.
+  describe('run() -- admin paging gate and user message surfacing', () => {
+    beforeEach(() => {
+      spyOn(
+        agent as unknown as { sleep: (ms: number) => Promise<void> },
+        'sleep',
+      ).mockResolvedValue(undefined);
+      mockIsRetryableError.mockReturnValue(false); // go straight to the terminal catch
+    });
+
+    /** All text strings the agent sent to the user this run (placeholder + error message). */
+    function sentText(): string[] {
+      return mockBot.api.sendMessage.mock.calls
+        .map((c: unknown[]) =>
+          typeof c[0] === 'object' ? (c[0] as { text?: string }).text : undefined,
+        )
+        .filter((t): t is string => typeof t === 'string');
+    }
+
+    it('rate_limit (429): surfaces the rate-limit message and does NOT page the admin', async () => {
+      mockClassifyAiError.mockReturnValue({
+        kind: 'rate_limit',
+        userMessage: '⏳ Слишком много запросов к AI. Подожди минуту.',
+      });
+      mockAiStreamRound.mockRejectedValue(Object.assign(new Error('429'), { status: 429 }));
+
+      await agent
+        .run('сколько я потратил', [], mockBot as unknown as import('gramio').Bot)
+        .catch(() => {});
+
+      expect(sentText().some((t) => t.includes('Слишком много запросов к AI'))).toBe(true);
+      expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
+    });
+
+    it('overloaded (529): surfaces the overloaded message and does NOT page the admin', async () => {
+      mockClassifyAiError.mockReturnValue({
+        kind: 'overloaded',
+        userMessage: '⚡ AI сервер перегружен. Попробуй позже.',
+      });
+      mockAiStreamRound.mockRejectedValue(Object.assign(new Error('529'), { status: 529 }));
+
+      await agent
+        .run('сколько я потратил', [], mockBot as unknown as import('gramio').Bot)
+        .catch(() => {});
+
+      expect(sentText().some((t) => t.includes('перегружен'))).toBe(true);
+      expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
+    });
+
+    it('timeout (60s abort): surfaces the timeout message and does NOT page the admin', async () => {
+      const abortErr = new Error('The operation was aborted');
+      abortErr.name = 'AbortError';
+      mockClassifyAiError.mockReturnValue({
+        kind: 'timeout',
+        userMessage: '⏳ Время ожидания истекло. Попробуй ещё раз.',
+      });
+      mockAiStreamRound.mockRejectedValue(abortErr);
+
+      await agent
+        .run('сколько я потратил', [], mockBot as unknown as import('gramio').Bot)
+        .catch(() => {});
+
+      expect(sentText().some((t) => t.includes('Время ожидания истекло'))).toBe(true);
+      expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
+    });
+
+    it('provider_down (connection/5xx): surfaces the outage message AND pages the admin', async () => {
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '⚠️ AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
+      mockAiStreamRound.mockRejectedValue(Object.assign(new Error('down'), { code: 'ECONNRESET' }));
+
+      await agent
+        .run('сколько я потратил', [], mockBot as unknown as import('gramio').Bot)
+        .catch(() => {});
+
+      expect(sentText().some((t) => t.includes('временно недоступен'))).toBe(true);
+      expect(mockReportAiFailureToAdmin).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausted-chain empty-response (generic): user gets the generic message AND the admin is paged (no silent rethrow)', async () => {
+      // Regression for the empty-response bypass: classifyAiError now returns generic (not null) for
+      // the "All N providers … chain failed" empty-response aggregate (pinned in streaming.test.ts),
+      // so the agent surfaces a user message and pages the admin via the generic path instead of
+      // rethrowing the raw aggregate after deleting the in-progress message.
+      const emptyAggregate = new Error(
+        'All 3 providers in smart chain failed: z.ai (glm): Provider z.ai (glm) returned empty ' +
+          'response (no text, no tool calls) — treating as failure; Gemini (g): returned empty ' +
+          'response; HF (h): returned empty response',
+      );
+      mockClassifyAiError.mockReturnValue({
+        kind: 'generic',
+        userMessage: '❌ Ошибка AI. Попробуй позже.',
+      });
+      mockAiStreamRound.mockRejectedValue(emptyAggregate);
+
+      const { AgentError } = await import('../../errors');
+      await expect(
+        agent.run('сколько я потратил', [], mockBot as unknown as import('gramio').Bot),
+      ).rejects.toBeInstanceOf(AgentError); // AgentError, NOT the raw aggregate rethrown
+
+      expect(sentText().some((t) => t.includes('Ошибка AI'))).toBe(true);
+      expect(mockReportAiFailureToAdmin).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/services/ai/agent.test.ts
+++ b/src/services/ai/agent.test.ts
@@ -36,6 +36,11 @@ mock.module('./response-validator', () => ({
   validateResponse: mock(async () => ({ approved: true })),
 }));
 
+const mockReportAiFailureToAdmin = mock<(input: unknown) => Promise<void>>(() => Promise.resolve());
+mock.module('./error-reporter', () => ({
+  reportAiFailureToAdmin: mockReportAiFailureToAdmin,
+}));
+
 import { ExpenseBotAgent } from './agent';
 import type { AgentContext } from './types';
 
@@ -115,6 +120,7 @@ describe('ExpenseBotAgent', () => {
     mockIsRetryableError.mockClear();
     mockGetBackoffDelay.mockClear();
     mockClassifyAiError.mockClear();
+    mockReportAiFailureToAdmin.mockClear();
 
     // Default: errors are not retryable (unless overridden per test)
     mockIsRetryableError.mockReturnValue(false);
@@ -526,6 +532,31 @@ describe('ExpenseBotAgent', () => {
       expect(errorCall).toBeTruthy();
     });
 
+    it('reports the failure to the admin (fire-and-forget) on a terminal error', async () => {
+      const apiError = Object.assign(new Error('Server error'), { status: 500 });
+      mockIsRetryableError.mockReturnValue(true);
+      mockGetBackoffDelay.mockReturnValue(0);
+      mockAiStreamRound.mockRejectedValue(apiError);
+
+      try {
+        await agent.run('change currency', [], mockBot as unknown as import('gramio').Bot);
+      } catch {
+        // expected
+      }
+      expect(mockReportAiFailureToAdmin).toHaveBeenCalledTimes(1);
+      const [input] = mockReportAiFailureToAdmin.mock.calls[0] as [
+        { userMessage: string; error: unknown; telegramGroupId: number },
+      ];
+      expect(input.userMessage).toContain('change currency');
+      expect(input.error).toBe(apiError);
+    });
+
+    it('does NOT report to the admin on a successful run', async () => {
+      mockStreamReturn(['All good.']);
+      await agent.run('hello', [], mockBot as unknown as import('gramio').Bot);
+      expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
+    });
+
     it('cleans up placeholder message on error', async () => {
       const apiError = Object.assign(new Error('Server error'), { status: 500 });
       mockIsRetryableError.mockReturnValue(true);
@@ -668,6 +699,8 @@ describe('ExpenseBotAgent', () => {
       await expect(
         agent.run('question', [], mockBot as unknown as import('gramio').Bot),
       ).rejects.toBeInstanceOf(TypeError);
+      // A non-AI error is not an "AI failure" — it must not be reported to the admin.
+      expect(mockReportAiFailureToAdmin).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/ai/agent.test.ts
+++ b/src/services/ai/agent.test.ts
@@ -22,13 +22,14 @@ const mockAiStreamRound =
 
 const mockIsRetryableError = mock<(error: unknown) => boolean>();
 const mockGetBackoffDelay = mock<(attempt: number, error: unknown) => number>();
-const mockFormatApiError = mock<(error: unknown) => string>();
+const mockClassifyAiError =
+  mock<(error: unknown) => import('./streaming').AiErrorClassification | null>();
 
 mock.module('./streaming', () => ({
   aiStreamRound: mockAiStreamRound,
   isRetryableError: mockIsRetryableError,
   getBackoffDelay: mockGetBackoffDelay,
-  formatApiError: mockFormatApiError,
+  classifyAiError: mockClassifyAiError,
 }));
 
 mock.module('./response-validator', () => ({
@@ -113,12 +114,16 @@ describe('ExpenseBotAgent', () => {
     mockAiStreamRound.mockClear();
     mockIsRetryableError.mockClear();
     mockGetBackoffDelay.mockClear();
-    mockFormatApiError.mockClear();
+    mockClassifyAiError.mockClear();
 
     // Default: errors are not retryable (unless overridden per test)
     mockIsRetryableError.mockReturnValue(false);
     mockGetBackoffDelay.mockReturnValue(0);
-    mockFormatApiError.mockReturnValue('\u274c Ошибка AI. Попробуйте позже.');
+    // Default: classify as a generic recognized AI error (wrapped + sent to user).
+    mockClassifyAiError.mockReturnValue({
+      kind: 'generic',
+      userMessage: '\u274c Ошибка AI. Попробуйте позже.',
+    });
   });
 
   afterEach(() => {
@@ -383,7 +388,10 @@ describe('ExpenseBotAgent', () => {
       const apiError = Object.assign(new Error('Rate limit exceeded'), { status: 429 });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
-      mockFormatApiError.mockReturnValue('\u23f3 Слишком много запросов к AI. Подождите минуту.');
+      mockClassifyAiError.mockReturnValue({
+        kind: 'rate_limit',
+        userMessage: '\u23f3 Слишком много запросов к AI. Подождите минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(apiError);
 
       const { AgentError } = await import('../../errors');
@@ -402,7 +410,10 @@ describe('ExpenseBotAgent', () => {
       const overloadedError = Object.assign(new Error('Overloaded'), { status: 529 });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
-      mockFormatApiError.mockReturnValue('\u26a1 AI сервер перегружен. Попробуйте позже.');
+      mockClassifyAiError.mockReturnValue({
+        kind: 'overloaded',
+        userMessage: '\u26a1 AI сервер перегружен. Попробуйте позже.',
+      });
       mockAiStreamRound.mockRejectedValue(overloadedError);
 
       const { AgentError } = await import('../../errors');
@@ -415,11 +426,15 @@ describe('ExpenseBotAgent', () => {
       }
     });
 
-    it('throws AgentError on other API error after retries', async () => {
+    it('throws AgentError on provider 5xx (provider_down) after retries', async () => {
       const apiError = Object.assign(new Error('Server error'), { status: 500 });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
-      mockFormatApiError.mockReturnValue('\u274c Ошибка AI. Попробуйте позже.');
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '⚠️ AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(apiError);
 
       const { AgentError } = await import('../../errors');
@@ -428,7 +443,9 @@ describe('ExpenseBotAgent', () => {
         expect.unreachable('should have thrown');
       } catch (err) {
         expect(err).toBeInstanceOf(AgentError);
-        expect((err as InstanceType<typeof AgentError>).userMessage).toContain('Ошибка AI');
+        expect((err as InstanceType<typeof AgentError>).userMessage).toContain(
+          'временно недоступен',
+        );
       }
     });
 
@@ -437,6 +454,10 @@ describe('ExpenseBotAgent', () => {
       abortError.name = 'AbortError';
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
+      mockClassifyAiError.mockReturnValue({
+        kind: 'timeout',
+        userMessage: '\u23f3 Время ожидания истекло. Попробуйте ещё раз.',
+      });
       mockAiStreamRound.mockRejectedValue(abortError);
 
       const { AgentError } = await import('../../errors');
@@ -453,7 +474,6 @@ describe('ExpenseBotAgent', () => {
       const apiError = Object.assign(new Error('Server error'), { status: 500 });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
-      mockFormatApiError.mockReturnValue('\u274c Ошибка AI. Попробуйте позже.');
       mockAiStreamRound.mockRejectedValue(apiError);
 
       try {
@@ -490,7 +510,6 @@ describe('ExpenseBotAgent', () => {
       const apiError = Object.assign(new Error('Server error'), { status: 500 });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
-      mockFormatApiError.mockReturnValue('\u274c Ошибка AI. Попробуйте позже.');
       mockAiStreamRound.mockRejectedValue(apiError);
 
       try {
@@ -511,7 +530,6 @@ describe('ExpenseBotAgent', () => {
       const apiError = Object.assign(new Error('Server error'), { status: 500 });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
-      mockFormatApiError.mockReturnValue('\u274c Ошибка AI. Попробуйте позже.');
       mockAiStreamRound.mockRejectedValue(apiError);
 
       try {
@@ -538,7 +556,10 @@ describe('ExpenseBotAgent', () => {
     it('wraps error with status:429 (non-API class) as AgentError', async () => {
       const rawErr = Object.assign(new Error('Rate limit exceeded'), { status: 429 });
       mockIsRetryableError.mockReturnValue(false);
-      mockFormatApiError.mockReturnValue('\u23f3 Слишком много запросов к AI. Подождите минуту.');
+      mockClassifyAiError.mockReturnValue({
+        kind: 'rate_limit',
+        userMessage: '\u23f3 Слишком много запросов к AI. Подождите минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(rawErr);
 
       const { AgentError } = await import('../../errors');
@@ -550,7 +571,11 @@ describe('ExpenseBotAgent', () => {
     it('wraps error with status:500 (non-API class) as AgentError', async () => {
       const serverErr = Object.assign(new Error('Internal server error'), { status: 500 });
       mockIsRetryableError.mockReturnValue(false);
-      mockFormatApiError.mockReturnValue('\u274c Ошибка AI. Попробуйте позже.');
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '⚠️ AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(serverErr);
 
       const { AgentError } = await import('../../errors');
@@ -563,6 +588,11 @@ describe('ExpenseBotAgent', () => {
       const timeoutErr = Object.assign(new Error('Request timed out'), { code: 'ETIMEDOUT' });
       mockIsRetryableError.mockReturnValue(true);
       mockGetBackoffDelay.mockReturnValue(0);
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '\u26a0\ufe0f AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(timeoutErr);
 
       const { AgentError } = await import('../../errors');
@@ -576,6 +606,11 @@ describe('ExpenseBotAgent', () => {
     it('wraps ECONNREFUSED error as AgentError', async () => {
       const connErr = Object.assign(new Error('Connection refused'), { code: 'ECONNREFUSED' });
       mockIsRetryableError.mockReturnValue(false);
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '\u26a0\ufe0f AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(connErr);
 
       const { AgentError } = await import('../../errors');
@@ -587,6 +622,11 @@ describe('ExpenseBotAgent', () => {
     it('wraps ENOTFOUND error as AgentError', async () => {
       const dnsErr = Object.assign(new Error('DNS lookup failed'), { code: 'ENOTFOUND' });
       mockIsRetryableError.mockReturnValue(false);
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '\u26a0\ufe0f AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(dnsErr);
 
       const { AgentError } = await import('../../errors');
@@ -598,6 +638,11 @@ describe('ExpenseBotAgent', () => {
     it('sends network error message to user', async () => {
       const connErr = Object.assign(new Error('Connection refused'), { code: 'ECONNREFUSED' });
       mockIsRetryableError.mockReturnValue(false);
+      mockClassifyAiError.mockReturnValue({
+        kind: 'provider_down',
+        userMessage:
+          '\u26a0\ufe0f AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+      });
       mockAiStreamRound.mockRejectedValue(connErr);
 
       try {
@@ -608,7 +653,8 @@ describe('ExpenseBotAgent', () => {
       const sendCalls = mockBot.api.sendMessage.mock.calls;
       const errorCall = sendCalls.find(
         (c: unknown[]) =>
-          typeof c[0] === 'object' && (c[0] as { text?: string }).text?.includes('Ошибка сети'),
+          typeof c[0] === 'object' &&
+          (c[0] as { text?: string }).text?.includes('временно недоступен'),
       );
       expect(errorCall).toBeTruthy();
     });
@@ -616,6 +662,7 @@ describe('ExpenseBotAgent', () => {
     it('rethrows unknown error without wrapping', async () => {
       const unknownErr = new TypeError('Unexpected type error');
       mockIsRetryableError.mockReturnValue(false);
+      mockClassifyAiError.mockReturnValue(null);
       mockAiStreamRound.mockRejectedValue(unknownErr);
 
       await expect(

--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -14,6 +14,7 @@ import type { ChatMessage } from '../../database/types';
 import { AgentError } from '../../errors';
 import { createLogger } from '../../utils/logger.ts';
 import { AiDebugLogger, type AiDebugRunContext } from './debug-logger';
+import { reportAiFailureToAdmin } from './error-reporter';
 import { validateResponse } from './response-validator';
 import {
   aiStreamRound,
@@ -142,8 +143,20 @@ export class ExpenseBotAgent {
       if (!classification) {
         // Not a recognizable AI/network/timeout failure — propagate so the caller
         // (and logs) see the real, unrelated error instead of a masked generic one.
+        // (No admin AI-failure report here: it isn't an AI failure.)
         throw error;
       }
+
+      // Notify the admin with full diagnostics (throttled, fire-and-forget — never blocks
+      // the user path, never throws back into it).
+      reportAiFailureToAdmin({
+        groupId: this.ctx.groupId,
+        telegramGroupId: this.ctx.telegramGroupId,
+        userMessage,
+        error,
+      }).catch((reportErr) =>
+        logger.error({ err: reportErr }, '[AGENT] admin failure report errored'),
+      );
       // Keep the original error (stack, status) in the logs — the user only sees the
       // short classified message, so this is the one place it's recorded at the boundary.
       // Server-side / unknown failures are error-level; transient client-side ones are warn.

--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -17,7 +17,7 @@ import { AiDebugLogger, type AiDebugRunContext } from './debug-logger';
 import { validateResponse } from './response-validator';
 import {
   aiStreamRound,
-  formatApiError,
+  classifyAiError,
   getBackoffDelay,
   isRetryableError,
   type StreamCallbacks,
@@ -138,32 +138,24 @@ export class ExpenseBotAgent {
     } catch (error) {
       await writer.deleteSentMessage();
 
-      if (error instanceof Error && error.name === 'AbortError') {
-        const timeoutMsg = '\u23f3 Время ожидания истекло. Попробуйте ещё раз.';
-        await this.sendErrorToUser(bot, timeoutMsg);
-        throw new AgentError(timeoutMsg);
+      const classification = classifyAiError(error);
+      if (!classification) {
+        // Not a recognizable AI/network/timeout failure — propagate so the caller
+        // (and logs) see the real, unrelated error instead of a masked generic one.
+        throw error;
       }
-
-      if (error instanceof Error && 'status' in error) {
-        const errorMsg = formatApiError(error);
-        await this.sendErrorToUser(bot, errorMsg);
-        throw new AgentError(errorMsg);
+      // Keep the original error (stack, status) in the logs — the user only sees the
+      // short classified message, so this is the one place it's recorded at the boundary.
+      // Server-side / unknown failures are error-level; transient client-side ones are warn.
+      const logFields = { err: error, kind: classification.kind };
+      const logMsg = '[AGENT] AI run failed — surfacing classified error to user';
+      if (classification.kind === 'provider_down' || classification.kind === 'generic') {
+        logger.error(logFields, logMsg);
+      } else {
+        logger.warn(logFields, logMsg);
       }
-
-      const networkCodes = ['ETIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND', 'ENETUNREACH'];
-      const errCode = (error as NodeJS.ErrnoException).code;
-      if (errCode && networkCodes.includes(errCode)) {
-        const msg = '\u274c Ошибка сети. Попробуйте позже.';
-        await this.sendErrorToUser(bot, msg);
-        throw new AgentError(msg);
-      }
-      const errStatus = (error as { status?: number }).status;
-      if (typeof errStatus === 'number') {
-        const msg = '\u274c Ошибка AI. Попробуйте позже.';
-        await this.sendErrorToUser(bot, msg);
-        throw new AgentError(msg);
-      }
-      throw error;
+      await this.sendErrorToUser(bot, classification.userMessage);
+      throw new AgentError(classification.userMessage);
     }
   }
 

--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -84,50 +84,20 @@ export class ExpenseBotAgent {
         return '';
       }
 
-      // --- Validation pass (always runs when no tools were called AND tools were available) ---
-      // Skip if the model already called tools (data is real) or if no tools existed at all.
+      // --- Validation pass (runs only when no tools were called AND tools were available) ---
+      // If the model already called tools the data is real; if no tools existed there's nothing
+      // to validate against.
       if (toolCallNames.length === 0 && TOOL_DEFINITIONS.length > 0) {
-        const validation = await validateResponse({
+        const validated = await this.finalizeWithValidation({
           userMessage,
-          toolCalls: toolCallNames,
-          response: finalText,
+          messages,
+          writer,
+          debugCtx,
+          toolCallNames,
+          initial: { text: finalText, toolCount: totalToolCalls },
         });
-
-        if (!validation.approved) {
-          logger.info(`[AGENT] Validation REJECTED: ${validation.reason}`);
-
-          writer.reset();
-          toolCallNames.length = 0;
-
-          const retryController = new AbortController();
-          const retryTimeout = setTimeout(() => retryController.abort(), AGENT_TIMEOUT_MS);
-
-          messages.push({ role: 'assistant', content: finalText });
-          messages.push({
-            role: 'user',
-            content: `[SYSTEM] Your previous response was rejected by the quality validator. Reason: ${validation.reason}. You MUST call the appropriate tools and re-answer the question properly. Do NOT repeat the same mistake.`,
-          });
-
-          try {
-            const retry = await this.runAgentLoop(
-              messages,
-              writer,
-              debugCtx,
-              retryController.signal,
-              toolCallNames,
-            );
-            finalText = retry.text;
-            totalToolCalls = retry.toolCount;
-
-            logger.info(
-              `[AGENT] Retry response (${finalText.length} chars): "${finalText.substring(0, 200)}${finalText.length > 200 ? '...' : ''}"`,
-            );
-          } finally {
-            clearTimeout(retryTimeout);
-          }
-        } else {
-          logger.info('[AGENT] Validation APPROVED');
-        }
+        finalText = validated.text;
+        totalToolCalls = validated.toolCount;
       }
 
       debugCtx?.logAiText(finalText);
@@ -237,6 +207,104 @@ export class ExpenseBotAgent {
       }
     }
     throw new Error('[AGENT] Retry loop exhausted');
+  }
+
+  /**
+   * Validate the no-tool answer and, on a REJECT, re-run the agent EXACTLY ONCE. The re-run is
+   * then surfaced as-is: trusted if it grounded itself in tool calls, otherwise surfaced
+   * best-effort with a warning. We deliberately do NOT re-validate the re-run — at a one-retry
+   * cap a second validator verdict can't change the outcome (we surface the re-run either way),
+   * so re-validating would only add a second validator round-trip on the unhappy path.
+   */
+  private async finalizeWithValidation(args: {
+    userMessage: string;
+    messages: OpenAI.ChatCompletionMessageParam[];
+    writer: TelegramStreamWriter;
+    debugCtx: AiDebugRunContext | null;
+    toolCallNames: string[];
+    initial: { text: string; toolCount: number };
+  }): Promise<{ text: string; toolCount: number }> {
+    const { userMessage, messages, writer, debugCtx, toolCallNames, initial } = args;
+
+    const validation = await validateResponse({
+      userMessage,
+      toolCalls: toolCallNames,
+      response: initial.text,
+    });
+    if (validation.approved) {
+      logger.info('[AGENT] Validation APPROVED');
+      return initial;
+    }
+
+    logger.info(`[AGENT] Validation REJECTED: ${validation.reason} — re-running once`);
+    const retry = await this.rerunAfterRejection({
+      messages,
+      writer,
+      debugCtx,
+      toolCallNames,
+      rejectedText: initial.text,
+      reason: validation.reason,
+    });
+
+    // Surface the re-run either way; the only difference is how we log it.
+    if (toolCallNames.length > 0) {
+      // The re-run grounded its answer in tool calls — trust it (same rule as the entry guard).
+      logger.info('[AGENT] Retry called tools — accepted');
+    } else {
+      // Cap: one re-run already happened and it still called no tools. Surface the re-run's answer
+      // (already streamed to the user) instead of looping toward the per-attempt timeout. This is
+      // a quality cap, not a failure — no exception, and since no tools were called nothing was
+      // mutated/persisted — so it stays a warn, not an admin failure report.
+      logger.warn(
+        { reason: validation.reason },
+        '[AGENT] Validator rejected and the retry still used no tools — capping, surfacing best-effort answer',
+      );
+    }
+    return retry;
+  }
+
+  /**
+   * Re-run the agent loop after a validator rejection, prompting it to use tools this time.
+   * Intentionally a single attempt via `runAgentLoop` (not `runWithRetry`): the initial run
+   * already spent its backoff budget, and capping the re-run at one attempt bounds total latency
+   * — a transient error here propagates to the caller's catch instead of compounding the wait.
+   */
+  private async rerunAfterRejection(args: {
+    messages: OpenAI.ChatCompletionMessageParam[];
+    writer: TelegramStreamWriter;
+    debugCtx: AiDebugRunContext | null;
+    toolCallNames: string[];
+    rejectedText: string;
+    reason: string;
+  }): Promise<{ text: string; toolCount: number }> {
+    const { messages, writer, debugCtx, toolCallNames, rejectedText, reason } = args;
+    writer.reset();
+    toolCallNames.length = 0;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), AGENT_TIMEOUT_MS);
+
+    messages.push({ role: 'assistant', content: rejectedText });
+    messages.push({
+      role: 'user',
+      content: `[SYSTEM] Your previous response was rejected by the quality validator. Reason: ${reason}. You MUST call the appropriate tools and re-answer the question properly. Do NOT repeat the same mistake.`,
+    });
+
+    try {
+      const retry = await this.runAgentLoop(
+        messages,
+        writer,
+        debugCtx,
+        controller.signal,
+        toolCallNames,
+      );
+      logger.info(
+        `[AGENT] Retry response (${retry.text.length} chars): "${retry.text.substring(0, 200)}${retry.text.length > 200 ? '...' : ''}"`,
+      );
+      return retry;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   protected async sleep(ms: number): Promise<void> {

--- a/src/services/ai/agent.ts
+++ b/src/services/ai/agent.ts
@@ -117,22 +117,30 @@ export class ExpenseBotAgent {
         throw error;
       }
 
-      // Notify the admin with full diagnostics (throttled, fire-and-forget — never blocks
-      // the user path, never throws back into it).
-      reportAiFailureToAdmin({
-        groupId: this.ctx.groupId,
-        telegramGroupId: this.ctx.telegramGroupId,
-        userMessage,
-        error,
-      }).catch((reportErr) =>
-        logger.error({ err: reportErr }, '[AGENT] admin failure report errored'),
-      );
+      // Only genuine failures page the admin: provider_down (chain unreachable / 5xx) and generic
+      // (a recognized-but-uncategorized API error, including an exhausted-chain empty-response). The
+      // transient / user-side classes — rate_limit (429), overloaded (529), timeout (our own 60s
+      // abort) — are self-resolving and would only spam the operator, so they are logged warn and
+      // skipped here. This is the SAME split as the warn-vs-error logging below.
+      const isGenuineFailure =
+        classification.kind === 'provider_down' || classification.kind === 'generic';
+      if (isGenuineFailure) {
+        // Throttled, fire-and-forget — never blocks the user path, never throws back into it.
+        reportAiFailureToAdmin({
+          groupId: this.ctx.groupId,
+          telegramGroupId: this.ctx.telegramGroupId,
+          userMessage,
+          error,
+        }).catch((reportErr) =>
+          logger.error({ err: reportErr }, '[AGENT] admin failure report errored'),
+        );
+      }
       // Keep the original error (stack, status) in the logs — the user only sees the
       // short classified message, so this is the one place it's recorded at the boundary.
       // Server-side / unknown failures are error-level; transient client-side ones are warn.
       const logFields = { err: error, kind: classification.kind };
       const logMsg = '[AGENT] AI run failed — surfacing classified error to user';
-      if (classification.kind === 'provider_down' || classification.kind === 'generic') {
+      if (isGenuineFailure) {
         logger.error(logFields, logMsg);
       } else {
         logger.warn(logFields, logMsg);

--- a/src/services/ai/error-reporter.test.ts
+++ b/src/services/ai/error-reporter.test.ts
@@ -1,0 +1,232 @@
+// Tests for reportAiFailureToAdmin — admin notification on terminal AI failures, throttled.
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createMockLogger } from '../../test-utils/mocks/logger';
+// Real (un-mocked) sanitizer — the same transform the outgoing preRequest hook applies.
+import { sanitizeHtmlForTelegram } from '../../utils/html';
+
+const logMock = createMockLogger();
+mock.module('../../utils/logger.ts', () => ({
+  createLogger: () => logMock,
+  logger: logMock,
+}));
+
+// Mutable env so individual tests can flip BOT_ADMIN_CHAT_ID on/off.
+const mockEnv: { BOT_ADMIN_CHAT_ID: number | null } = { BOT_ADMIN_CHAT_ID: 555 };
+mock.module('../../config/env', () => ({ env: mockEnv }));
+
+const sendDirectMock =
+  mock<(chatId: number, text: string) => Promise<{ message_id: number } | null>>();
+mock.module('../bank/telegram-sender', () => ({ sendDirect: sendDirectMock }));
+
+const findByIdMock = mock<(id: number) => { title: string | null } | null>();
+mock.module('../../database', () => ({ database: { groups: { findById: findByIdMock } } }));
+
+import { reportAiFailureToAdmin, resetAiFailureThrottle } from './error-reporter';
+
+const TEN_MIN = 10 * 60 * 1000;
+const FAIL_RETRY = 60 * 1000; // quick-retry floor after a failed admin send
+
+function ctx(overrides?: Partial<Parameters<typeof reportAiFailureToAdmin>[0]>) {
+  return {
+    groupId: 1,
+    telegramGroupId: -100123,
+    userMessage: 'смени валюту на египетские фунты',
+    error: new Error('All 3 providers in smart chain failed: z.ai (glm-5.1): Connection error.'),
+    ...overrides,
+  };
+}
+
+describe('reportAiFailureToAdmin', () => {
+  beforeEach(() => {
+    resetAiFailureThrottle();
+    sendDirectMock.mockClear();
+    findByIdMock.mockClear();
+    mockEnv.BOT_ADMIN_CHAT_ID = 555;
+    sendDirectMock.mockResolvedValue({ message_id: 1 });
+    findByIdMock.mockReturnValue({ title: 'Family budget' });
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('sends a detailed report to the admin when BOT_ADMIN_CHAT_ID is set', async () => {
+    await reportAiFailureToAdmin(ctx({ error: new Error('uniqueA: boom') }), 1_000);
+
+    expect(sendDirectMock).toHaveBeenCalledTimes(1);
+    const [chatId, text] = sendDirectMock.mock.calls[0] as [number, string];
+    expect(chatId).toBe(555);
+    expect(text).toContain('Family budget');
+    expect(text).toContain('-100123');
+    expect(text).toContain('египетские фунты');
+    expect(text).toContain('uniqueA: boom');
+  });
+
+  it('is a no-op when BOT_ADMIN_CHAT_ID is unset', async () => {
+    mockEnv.BOT_ADMIN_CHAT_ID = null;
+    await reportAiFailureToAdmin(ctx({ error: new Error('uniqueB: boom') }), 2_000);
+    expect(sendDirectMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses a duplicate within the throttle window, then allows after it', async () => {
+    const sig = new Error('uniqueC: same signature error');
+    await reportAiFailureToAdmin(ctx({ error: sig }), 10_000);
+    await reportAiFailureToAdmin(ctx({ error: sig }), 10_000 + TEN_MIN - 1);
+    expect(sendDirectMock).toHaveBeenCalledTimes(1); // 2nd suppressed
+
+    await reportAiFailureToAdmin(ctx({ error: sig }), 10_000 + TEN_MIN + 1);
+    expect(sendDirectMock).toHaveBeenCalledTimes(2); // window elapsed → allowed
+  });
+
+  it('groups by provider-chain signature (different chains are not throttled together)', async () => {
+    await reportAiFailureToAdmin(
+      ctx({ error: new Error('All 3 providers in smart chain failed: x') }),
+      50_000,
+    );
+    await reportAiFailureToAdmin(
+      ctx({ error: new Error('All 3 providers in fast chain failed: y') }),
+      50_000,
+    );
+    expect(sendDirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throttle the same chain across different statuses (429 vs 500)', async () => {
+    await reportAiFailureToAdmin(
+      ctx({
+        error: Object.assign(new Error('All 3 providers in smart chain failed: a'), {
+          status: 429,
+        }),
+      }),
+      60_000,
+    );
+    await reportAiFailureToAdmin(
+      ctx({
+        error: Object.assign(new Error('All 3 providers in smart chain failed: b'), {
+          status: 500,
+        }),
+      }),
+      60_000,
+    );
+    expect(sendDirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('neutralizes HTML-special user/error content and stays within Telegram limits', async () => {
+    const nasty = '<script>alert(1)</script> & <b>x</b>'.repeat(500);
+    await reportAiFailureToAdmin(
+      ctx({ userMessage: nasty, error: new Error(`${nasty} boom`) }),
+      110_000,
+    );
+    const [, text] = sendDirectMock.mock.calls[0] as [number, string];
+    expect(text.length).toBeLessThan(4096);
+    // Angle brackets are neutralized to look-alikes so the outgoing-HTML sanitizer can't
+    // restore them into real markup in the admin report (a user's <b>/<a href> stays inert).
+    expect(text).not.toContain('<script>');
+    expect(text).toContain('‹script›');
+  });
+
+  it('collapses newlines in inline fields so users cannot inject fake report lines', async () => {
+    await reportAiFailureToAdmin(
+      ctx({ userMessage: 'hi\nПровайдеры: FAKE — all data deleted' }),
+      150_000,
+    );
+    const [, text] = sendDirectMock.mock.calls[0] as [number, string];
+    const lines = text.split('\n');
+    // Only the real, system-built "Провайдеры:" line — not a user-spoofed extra one.
+    expect(lines.filter((line) => line.startsWith('Провайдеры:'))).toHaveLength(1);
+    // The injected text still appears, but inline within the request line (not as its own line).
+    expect(text).toContain('FAKE — all data deleted');
+  });
+
+  it('handles a missing group row (findById returns null)', async () => {
+    findByIdMock.mockReturnValue(null);
+    await reportAiFailureToAdmin(ctx({ error: new Error('uniqueF: boom') }), 120_000);
+    const [, text] = sendDirectMock.mock.calls[0] as [number, string];
+    expect(text).toContain('-100123');
+  });
+
+  it('neutralizes HTML in the group title (no markup injection via title)', async () => {
+    findByIdMock.mockReturnValue({ title: '<a href="http://evil">Family</a>' });
+    await reportAiFailureToAdmin(ctx({ error: new Error('uniqueG: boom') }), 170_000);
+    const [, text] = sendDirectMock.mock.calls[0] as [number, string];
+    expect(text).not.toContain('<a href');
+    expect(text).toContain('‹a href');
+  });
+
+  it('survives the REAL outgoing-HTML sanitizer without injecting user markup', async () => {
+    const nasty = 'click <a href="http://evil">here</a> <script>x</script> & done';
+    findByIdMock.mockReturnValue({ title: '<b>spoof</b>' });
+    await reportAiFailureToAdmin(ctx({ userMessage: nasty, error: new Error(nasty) }), 180_000);
+    const [, raw] = sendDirectMock.mock.calls[0] as [number, string];
+    // Run the report through the actual sanitizer the preRequest hook uses end-to-end.
+    const sanitized = sanitizeHtmlForTelegram(raw);
+    // User-supplied tags must NOT be restored into real markup.
+    expect(sanitized).not.toContain('<a ');
+    expect(sanitized).not.toContain('<script');
+    // The report's own structural tag DOES survive — proving the sanitizer actually ran.
+    expect(sanitized).toContain('<b>AI failure</b>');
+  });
+
+  it('does not throttle distinct non-chain error classes together (429 vs 500)', async () => {
+    await reportAiFailureToAdmin(
+      ctx({ error: Object.assign(new Error('rl'), { status: 429 }) }),
+      90_000,
+    );
+    await reportAiFailureToAdmin(
+      ctx({ error: Object.assign(new Error('srv'), { status: 500 }) }),
+      90_000,
+    );
+    expect(sendDirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('a failed admin send (null) shortens to the quick-retry floor (not the full window)', async () => {
+    const err = Object.assign(new Error('outage'), { status: 503 });
+    sendDirectMock.mockImplementationOnce(() => Promise.resolve(null)); // first send doesn't land
+    await reportAiFailureToAdmin(ctx({ error: err }), 100_000);
+    await reportAiFailureToAdmin(ctx({ error: err }), 100_000 + FAIL_RETRY + 1); // past floor → retried
+    expect(sendDirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('a failed send within the quick-retry floor is still throttled (no Telegram storm)', async () => {
+    const err = Object.assign(new Error('outage'), { status: 504 });
+    sendDirectMock.mockImplementation(() => Promise.resolve(null)); // every send fails
+    await reportAiFailureToAdmin(ctx({ error: err }), 200_000);
+    await reportAiFailureToAdmin(ctx({ error: err }), 200_000 + 1_000); // within floor → suppressed
+    expect(sendDirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a rejected admin send shortens to the quick-retry floor (retry allowed after it)', async () => {
+    const err = new Error('All 3 providers in smart chain failed: reject');
+    sendDirectMock.mockImplementationOnce(() => Promise.reject(new Error('telegram down')));
+    await reportAiFailureToAdmin(ctx({ error: err }), 140_000);
+    await reportAiFailureToAdmin(ctx({ error: err }), 140_000 + FAIL_RETRY + 1);
+    expect(sendDirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('collapses concurrent identical failures into a single admin alert', async () => {
+    const err = new Error('All 3 providers in smart chain failed: concurrent');
+    // The window is reserved synchronously before the first send is awaited, so the second
+    // concurrent call sees the reservation and is suppressed.
+    await Promise.all([
+      reportAiFailureToAdmin(ctx({ error: err }), 130_000),
+      reportAiFailureToAdmin(ctx({ error: err }), 130_000),
+    ]);
+    expect(sendDirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a sendDirect failure (never throws into the caller)', async () => {
+    sendDirectMock.mockImplementation(() => Promise.reject(new Error('telegram 500')));
+    await expect(
+      reportAiFailureToAdmin(ctx({ error: new Error('uniqueD: boom') }), 70_000),
+    ).resolves.toBeUndefined();
+    // The path was exercised (send attempted) and the rejection did not propagate.
+    expect(sendDirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the telegram group id when the group has no title', async () => {
+    findByIdMock.mockReturnValue({ title: null });
+    await reportAiFailureToAdmin(ctx({ error: new Error('uniqueE: boom') }), 80_000);
+    const [, text] = sendDirectMock.mock.calls[0] as [number, string];
+    expect(text).toContain('-100123');
+  });
+});

--- a/src/services/ai/error-reporter.ts
+++ b/src/services/ai/error-reporter.ts
@@ -1,0 +1,193 @@
+// Sends a detailed, throttled report to the bot admin when the AI agent hits a terminal
+// failure. The user only sees a short classified message (see classifyAiError); this is where
+// the operator gets the group, the request, the provider-chain failure summary, and the stack.
+// Reached from ExpenseBotAgent's terminal catch as fire-and-forget — it never throws.
+
+import { env } from '../../config/env';
+import { database } from '../../database';
+import { createLogger } from '../../utils/logger.ts';
+import { sendDirect } from '../bank/telegram-sender';
+
+const logger = createLogger('ai-error-reporter');
+
+/** After a delivered alert, stay quiet for the same failure signature this long. */
+const THROTTLE_WINDOW_MS = 10 * 60 * 1000;
+/**
+ * After a FAILED send (Telegram blip), allow a retry this soon — short enough that a real
+ * outage isn't hidden for the full window, long enough that repeated AI failures don't hammer
+ * a down Telegram on every single one.
+ */
+const FAILED_SEND_RETRY_MS = 60 * 1000;
+const USER_MESSAGE_MAX = 400;
+const PROVIDER_SUMMARY_MAX = 700;
+const STACK_MAX = 1200;
+
+/**
+ * signature → earliest epoch ms a new send is allowed. In-memory; a process restart resets it
+ * (acceptable). Intentionally GLOBAL, not per-group: when a provider is down it fails for every
+ * group, and the operator wants ONE "smart chain is down" alert — not one per group (which would
+ * be the spam this throttle exists to prevent). The signature is keyed by failure class, not group.
+ */
+const nextAllowedAt = new Map<string, number>();
+
+/** Test-only: clear the throttle state so each test case starts from a clean slate. */
+export function resetAiFailureThrottle(): void {
+  nextAllowedAt.clear();
+}
+
+export interface AiFailureContext {
+  /** Internal DB group id (used to resolve the human-readable title). */
+  groupId: number;
+  /** Telegram group id — always shown so the operator can locate the chat. */
+  telegramGroupId: number;
+  /** The user message that triggered the AI run (truncated in the report). */
+  userMessage: string;
+  /** The terminal error surfaced from the agent. */
+  error: unknown;
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : 'UnknownError';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const value = (error as { status?: unknown }).status;
+    return typeof value === 'number' ? value : undefined;
+  }
+  return undefined;
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const value = (error as { code?: unknown }).code;
+    return typeof value === 'string' ? value : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Group failures so a single dead provider doesn't spam the admin: prefer the provider-chain
+ * name from the aggregated "All N providers in <chain> chain failed" message; otherwise key on
+ * the error name plus its status/code so distinct error classes (429 vs 500 vs ECONNREFUSED)
+ * don't suppress each other.
+ */
+function failureSignature(error: unknown): string {
+  const status = errorStatus(error) ?? '';
+  const code = errorCode(error) ?? '';
+  const chain = /in (\w+) chain failed/i.exec(errorMessage(error))?.[1];
+  // Include status/code so distinct incidents on the same chain (429 vs 500 vs a network
+  // error) aren't collapsed into one throttle bucket.
+  if (chain) return `chain:${chain}:${status}:${code}`;
+  return `err:${errorName(error)}:${status}:${code}`;
+}
+
+/** Pure check — true when this signature is still inside its throttle window. */
+function isThrottled(signature: string, now: number): boolean {
+  const next = nextAllowedAt.get(signature);
+  return next !== undefined && now < next;
+}
+
+const NAME_MAX = 80;
+
+/**
+ * Make untrusted text safe inside the HTML report. A plain escapeHtml() would be UNDONE here:
+ * the outgoing-HTML sanitizer (sanitizeHtmlForTelegram) decodes entities and restores whitelisted
+ * tags, so a user's `<b>` / `<a href>` would become real markup in the admin alert. So neutralize
+ * angle brackets to look-alikes (no tag can form) and escape `&` (idempotent through the sanitizer).
+ */
+function neutralizeHtml(raw: string): string {
+  return raw.replace(/</g, '‹').replace(/>/g, '›').replace(/&/g, '&amp;');
+}
+
+/** Cap to `max` chars, dropping a trailing half-written `&entity;` so the HTML stays valid. */
+function capSafe(safe: string, max: number): string {
+  if (safe.length <= max) return safe;
+  let cut = safe.slice(0, max);
+  // Don't split a UTF-16 surrogate pair (would leave a stray replacement char before the …).
+  const lastCode = cut.charCodeAt(cut.length - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) cut = cut.slice(0, -1);
+  const lastAmp = cut.lastIndexOf('&');
+  if (lastAmp !== -1 && !cut.slice(lastAmp).includes(';')) cut = cut.slice(0, lastAmp);
+  return `${cut}…`;
+}
+
+/**
+ * Inline (single-line) field: neutralize HTML and collapse newlines so user content can't inject
+ * fake `\n`-delimited report lines (e.g. a spoofed "Провайдеры:" / "Ошибка:" line), then cap.
+ */
+function clip(raw: string, max: number): string {
+  return capSafe(neutralizeHtml(raw).replace(/[\r\n]+/g, ' '), max);
+}
+
+/** Multi-line block (a stack trace shown inside `<pre>`): keep newlines, just neutralize + cap. */
+function clipBlock(raw: string, max: number): string {
+  return capSafe(neutralizeHtml(raw), max);
+}
+
+function groupLabel(groupId: number, telegramGroupId: number): string {
+  const title = database.groups.findById(groupId)?.title;
+  const safeTitle = title ? `${clip(title, NAME_MAX)} ` : '';
+  return `${safeTitle}(<code>${telegramGroupId}</code>)`;
+}
+
+function buildReport(input: AiFailureContext, now: number): string {
+  const { error } = input;
+  const status = errorStatus(error);
+  const statusSuffix = status !== undefined ? ` (status ${status})` : '';
+  const stack = error instanceof Error && error.stack ? error.stack : errorMessage(error);
+
+  return [
+    '🚨 <b>AI failure</b>',
+    `Группа: ${groupLabel(input.groupId, input.telegramGroupId)}`,
+    `Запрос: ${clip(input.userMessage, USER_MESSAGE_MAX)}`,
+    `Провайдеры: ${clip(errorMessage(error), PROVIDER_SUMMARY_MAX)}`,
+    `Ошибка: <code>${clip(errorName(error), NAME_MAX)}${statusSuffix}</code>`,
+    `<pre>${clipBlock(stack, STACK_MAX)}</pre>`,
+    `<i>${new Date(now).toISOString()}</i>`,
+  ].join('\n');
+}
+
+/**
+ * Fire-and-forget admin report. No-op when BOT_ADMIN_CHAT_ID is unset; throttled per failure
+ * signature; never throws (a send failure is swallowed and logged). `now` is injectable so the
+ * throttle is deterministic in tests — the throttle logic never calls Date.now() itself.
+ */
+export async function reportAiFailureToAdmin(
+  input: AiFailureContext,
+  now: number = Date.now(),
+): Promise<void> {
+  const adminChatId = env.BOT_ADMIN_CHAT_ID;
+  if (!adminChatId) return;
+
+  const signature = failureSignature(input.error);
+  if (isThrottled(signature, now)) {
+    logger.debug({ signature }, '[AI_REPORT] throttled duplicate admin alert');
+    return;
+  }
+  // Reserve the full window synchronously BEFORE awaiting the send. In JS's single-threaded
+  // model the check-and-set is atomic, so a burst of identical failures (a provider dying for
+  // many groups at once) collapses to one alert instead of every concurrent call racing past
+  // the check and sending its own.
+  const reservedUntil = now + THROTTLE_WINDOW_MS;
+  nextAllowedAt.set(signature, reservedUntil);
+
+  try {
+    const sent = await sendDirect(adminChatId, buildReport(input, now));
+    // Didn't land → shorten our reservation to a quick-retry floor: a Telegram blip neither
+    // suppresses the next real alert for the full window NOR lets every subsequent failure
+    // hammer a down Telegram. The `=== reservedUntil` guard avoids clobbering a newer reserve.
+    if (!sent && nextAllowedAt.get(signature) === reservedUntil) {
+      nextAllowedAt.set(signature, now + FAILED_SEND_RETRY_MS);
+    }
+  } catch (sendError) {
+    if (nextAllowedAt.get(signature) === reservedUntil) {
+      nextAllowedAt.set(signature, now + FAILED_SEND_RETRY_MS);
+    }
+    logger.error({ err: sendError }, '[AI_REPORT] failed to send admin failure report');
+  }
+}

--- a/src/services/ai/error-reporter.ts
+++ b/src/services/ai/error-reporter.ts
@@ -144,6 +144,9 @@ function buildReport(input: AiFailureContext, now: number): string {
   return [
     '🚨 <b>AI failure</b>',
     `Группа: ${groupLabel(input.groupId, input.telegramGroupId)}`,
+    // Forwarding the triggering user message to the admin chat is a deliberate decision: this is a
+    // single-operator personal bot, the admin is the owner, and the request text is the key clue for
+    // diagnosing why the AI run failed. It is neutralized/clipped above, never sent raw.
     `Запрос: ${clip(input.userMessage, USER_MESSAGE_MAX)}`,
     `Провайдеры: ${clip(errorMessage(error), PROVIDER_SUMMARY_MAX)}`,
     `Ошибка: <code>${clip(errorName(error), NAME_MAX)}${statusSuffix}</code>`,

--- a/src/services/ai/provider-breaker.test.ts
+++ b/src/services/ai/provider-breaker.test.ts
@@ -1,0 +1,178 @@
+// Tests for the AI provider circuit breaker — deterministic via injected `now` (fake clock).
+
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+  isProviderDemoted,
+  orderByHealth,
+  recordProviderConnectionFailure,
+  recordProviderReachable,
+  recordProviderResponded,
+  resetProviderBreaker,
+} from './provider-breaker';
+
+const WINDOW = 5 * 60_000;
+const COOLDOWN = 5 * 60_000;
+const slots = [{ key: 'zai' }, { key: 'gemini' }, { key: 'hf' }];
+
+describe('provider-breaker', () => {
+  beforeEach(() => {
+    resetProviderBreaker();
+  });
+
+  it('does not demote before the failure threshold', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000);
+    expect(isProviderDemoted('zai', 1_000)).toBe(false);
+    expect(orderByHealth(slots, 1_000)).toEqual(slots);
+  });
+
+  it('demotes after 3 connection failures within the window and moves it to the back', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000);
+    recordProviderConnectionFailure('zai', 2_000);
+    expect(isProviderDemoted('zai', 2_000)).toBe(true);
+    expect(orderByHealth(slots, 2_000).map((s) => s.key)).toEqual(['gemini', 'hf', 'zai']);
+  });
+
+  it('keeps non-demoted providers in their original relative order', () => {
+    recordProviderConnectionFailure('gemini', 0);
+    recordProviderConnectionFailure('gemini', 1_000);
+    recordProviderConnectionFailure('gemini', 2_000);
+    expect(orderByHealth(slots, 2_000).map((s) => s.key)).toEqual(['zai', 'hf', 'gemini']);
+  });
+
+  it('rehabilitates the provider after the cooldown elapses', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000);
+    recordProviderConnectionFailure('zai', 2_000);
+    expect(isProviderDemoted('zai', 2_000 + COOLDOWN - 1)).toBe(true);
+    expect(isProviderDemoted('zai', 2_000 + COOLDOWN + 1)).toBe(false);
+    expect(orderByHealth(slots, 2_000 + COOLDOWN + 1)).toEqual(slots);
+  });
+
+  it('stays demoted at the exact cooldown boundary (demotedUntil === now is still demoted)', () => {
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    const demotedUntil = 2_000 + COOLDOWN; // isProviderDemoted is strictly `> now`
+    expect(isProviderDemoted('zai', demotedUntil - 1)).toBe(true);
+    expect(isProviderDemoted('zai', demotedUntil)).toBe(false); // boundary: not strictly after
+  });
+
+  it('a connection failure while already demoted extends the cooldown', () => {
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    const firstUntil = 2_000 + COOLDOWN;
+    // Still inside the demotion (cooldown not lapsed) — another failure pushes demotedUntil forward.
+    recordProviderConnectionFailure('zai', 3_000);
+    expect(isProviderDemoted('zai', firstUntil + 1)).toBe(true); // extended past the original window
+    expect(isProviderDemoted('zai', 3_000 + COOLDOWN + 1)).toBe(false);
+  });
+
+  it('extends the cooldown for an active-demotion failure after the original cluster aged out', () => {
+    // Failures at 0/1s/2s demote until 302_000 with clusterStartedAt=0. WINDOW === COOLDOWN, so the
+    // original cluster ages out at 300_000 — INSIDE the still-active demotion. A demoted provider is
+    // still tried last; if it fails again in that tail window the cooldown MUST move forward, not let
+    // it expire milliseconds later on the original schedule (a flap straight back to the chain head).
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    const lateFailure = 301_999; // past the cluster age-out (> WINDOW) but before demotedUntil
+    expect(isProviderDemoted('zai', lateFailure)).toBe(true); // still inside the original cooldown
+    recordProviderConnectionFailure('zai', lateFailure);
+    expect(isProviderDemoted('zai', 302_001)).toBe(true); // would be false on the original schedule
+    expect(isProviderDemoted('zai', lateFailure + COOLDOWN - 1)).toBe(true);
+    expect(isProviderDemoted('zai', lateFailure + COOLDOWN + 1)).toBe(false);
+  });
+
+  it('orderByHealth moves ALL slots to the back in original order when all are demoted', () => {
+    for (const key of ['zai', 'gemini', 'hf']) {
+      for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure(key, t);
+    }
+    // Every slot is demoted → healthy is empty, so the order is unchanged (all at the "back").
+    expect(orderByHealth(slots, 2_000).map((s) => s.key)).toEqual(['zai', 'gemini', 'hf']);
+  });
+
+  it('does not accumulate failures spread beyond the window', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', WINDOW + 1); // stale → fresh cluster (count 1)
+    recordProviderConnectionFailure('zai', WINDOW + 2); // count 2 — still below threshold
+    expect(isProviderDemoted('zai', WINDOW + 2)).toBe(false);
+  });
+
+  it('a successful round rehabilitates a demoted provider immediately', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000);
+    recordProviderConnectionFailure('zai', 2_000);
+    expect(isProviderDemoted('zai', 2_000)).toBe(true);
+
+    recordProviderReachable('zai'); // a clean round — full rehab, clears the active demotion
+    expect(isProviderDemoted('zai', 2_000)).toBe(false);
+    expect(orderByHealth(slots, 2_000)).toEqual(slots);
+  });
+
+  it('a successful round clears a sub-threshold connection streak', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000); // 2 failures — one short of demotion
+    recordProviderReachable('zai'); // a clean round resets the counter
+    recordProviderConnectionFailure('zai', 2_000); // fresh count 1, not 3
+    expect(isProviderDemoted('zai', 2_000)).toBe(false);
+  });
+
+  it('a status response between connection failures resets the cluster (no demotion)', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000);
+    recordProviderResponded('zai', 1_500); // a real 400/500 response proves the endpoint is reachable
+    recordProviderConnectionFailure('zai', 2_000); // fresh cluster — count 1, not 3
+    expect(isProviderDemoted('zai', 2_000)).toBe(false);
+  });
+
+  it('a status response does NOT lift an active demotion (only a clean round does)', () => {
+    recordProviderConnectionFailure('zai', 0);
+    recordProviderConnectionFailure('zai', 1_000);
+    recordProviderConnectionFailure('zai', 2_000);
+    expect(isProviderDemoted('zai', 2_000)).toBe(true);
+
+    recordProviderResponded('zai', 2_500); // a 5xx is reachable, but not proof it can serve
+    expect(isProviderDemoted('zai', 2_500)).toBe(true); // still at the back of the chain
+  });
+
+  it('a status response after the cooldown expires clears the stale demotion (no instant re-demote)', () => {
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    const afterCooldown = 2_000 + COOLDOWN + 1;
+    expect(isProviderDemoted('zai', afterCooldown)).toBe(false); // cooldown lapsed
+
+    recordProviderResponded('zai', afterCooldown); // half-open probe got a reachable (5xx) response
+    // The stale demotion is cleared, so a later lone connection failure starts a fresh count — it
+    // must NOT hit the half-open branch and re-demote off a single strike.
+    recordProviderConnectionFailure('zai', afterCooldown + 1_000);
+    expect(isProviderDemoted('zai', afterCooldown + 1_000)).toBe(false);
+  });
+
+  it('orderByHealth returns the same array reference when nothing is demoted', () => {
+    expect(orderByHealth(slots, 5_000)).toBe(slots);
+  });
+
+  it('demotes multiple providers and keeps all of them (never drops)', () => {
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('gemini', t);
+    const ordered = orderByHealth(slots, 2_000).map((s) => s.key);
+    expect(ordered).toEqual(['hf', 'zai', 'gemini']);
+    expect(ordered).toHaveLength(slots.length);
+  });
+
+  it('re-demotes after a single post-cooldown probe failure (half-open)', () => {
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    const afterCooldown = 2_000 + COOLDOWN + 1;
+    expect(isProviderDemoted('zai', afterCooldown)).toBe(false); // cooldown lapsed → half-open probe
+
+    // The half-open probe fails → re-demote immediately (don't make users eat 3 fresh timeouts).
+    recordProviderConnectionFailure('zai', afterCooldown);
+    expect(isProviderDemoted('zai', afterCooldown)).toBe(true);
+    expect(isProviderDemoted('zai', afterCooldown + COOLDOWN - 1)).toBe(true);
+    expect(isProviderDemoted('zai', afterCooldown + COOLDOWN + 1)).toBe(false);
+  });
+
+  it('shares state by stable key across chains (smart vs fast z.ai)', () => {
+    // Connection failures are endpoint-level: the breaker is keyed by 'zai', not the model name,
+    // so a demotion accrued on one chain applies to the other chain's z.ai slot too.
+    for (const t of [0, 1_000, 2_000]) recordProviderConnectionFailure('zai', t);
+    const fastChainSlots = [{ key: 'zai' }, { key: 'gemini' }, { key: 'hf' }];
+    expect(orderByHealth(fastChainSlots, 2_000).map((s) => s.key)).toEqual(['gemini', 'hf', 'zai']);
+  });
+});

--- a/src/services/ai/provider-breaker.ts
+++ b/src/services/ai/provider-breaker.ts
@@ -1,0 +1,132 @@
+// Circuit breaker for AI provider slots: when a provider hits repeated connection-type failures
+// it is moved to the BACK of the fallback chain for a cooldown (never dropped), so a flapping
+// provider stops being tried first while the others answer. A success rehabilitates it instantly.
+// Scope is deliberately CONNECTION failures only: a reachable-but-erroring provider (5xx) is handled
+// by per-round fallback (try next), not demotion — so a 5xx response never demotes and never lifts
+// an ACTIVE demotion (recordProviderResponded resets the connection-failure counter and resolves an
+// already-EXPIRED half-open demotion, but leaves a still-active one in place).
+// All logic is pure and clock-injected (no Date.now() inside) so the windows are deterministic
+// in tests; the orchestrator (aiStreamRound) passes a single `now` per round.
+// State is a single module-global Map (in-process, single Node process). Concurrent rounds may
+// interleave failure counts, but with 5-min windows the skew is negligible — an accepted trade-off
+// over locking a hot path.
+
+/** Consecutive connection failures, clustered within the window, before a provider is demoted. */
+const FAILURE_THRESHOLD = 3;
+/** Failures must cluster within this window (ms) to count toward demotion. */
+const FAILURE_WINDOW_MS = 5 * 60_000;
+/** How long a demoted provider stays at the back of the chain (ms). */
+const DEMOTION_MS = 5 * 60_000;
+
+interface ProviderHealth {
+  /** Connection failures in the current cluster. */
+  failures: number;
+  /** Epoch ms of the first failure in the current cluster. */
+  clusterStartedAt: number;
+  /** Epoch ms until which the provider is demoted; 0 = not demoted. */
+  demotedUntil: number;
+}
+
+const health = new Map<string, ProviderHealth>();
+
+/**
+ * Record a connection-type failure for provider `key` (a stable id like 'zai'/'gemini'/'hf', NOT
+ * the per-model display name — connection failures are endpoint-level, shared across chains).
+ * Non-connection failures (4xx/5xx responses) and successes are NOT routed here — only true
+ * "provider unreachable" errors. Demotes the provider once it accumulates FAILURE_THRESHOLD
+ * failures within FAILURE_WINDOW_MS. After a demotion's cooldown lapses the provider gets one
+ * half-open probe at its normal slot; if that probe also fails it is re-demoted immediately (no
+ * fresh THRESHOLD strikes), so a persistently-down provider costs one failed request per cooldown,
+ * not THRESHOLD.
+ */
+export function recordProviderConnectionFailure(key: string, now: number): void {
+  const existing = health.get(key);
+  if (!existing) {
+    health.set(key, { failures: 1, clusterStartedAt: now, demotedUntil: 0 });
+    return;
+  }
+  // The provider already carries a demotion (active OR just-lapsed) and failed again — re-demote for
+  // a fresh cooldown. This MUST run before the window-aging branch below: FAILURE_WINDOW_MS ===
+  // DEMOTION_MS, so the original failure cluster ages out right at the tail of the cooldown while the
+  // demotion is still active. If active failures fell through instead, a failure in that tail window
+  // would hit the aging branch, reset the count to 1, leave demotedUntil on its original schedule, and
+  // let the provider flap back to the front milliseconds after a fresh drop. One rule, two cases:
+  //  - active (demotedUntil > now): a still-demoted provider (tried last) keeps failing → push it out.
+  //  - lapsed (demotedUntil <= now): the half-open post-cooldown probe (tried at its normal slot)
+  //    failed → re-demote immediately rather than making users eat THRESHOLD fresh timeouts before it
+  //    drops back. Roughly one failed probe per cooldown (single-threaded; under concurrent rounds
+  //    several may probe before the first failure is recorded). recordProviderResponded clears an
+  //    EXPIRED demotion to 0 first, so a probe that got a reachable response never reaches here.
+  if (existing.demotedUntil !== 0) {
+    existing.failures = FAILURE_THRESHOLD;
+    existing.clusterStartedAt = now;
+    existing.demotedUntil = now + DEMOTION_MS;
+    return;
+  }
+  if (now - existing.clusterStartedAt > FAILURE_WINDOW_MS) {
+    // The cluster aged out — start a clean cluster.
+    existing.failures = 1;
+    existing.clusterStartedAt = now;
+  } else {
+    existing.failures += 1;
+  }
+  if (existing.failures >= FAILURE_THRESHOLD) {
+    existing.demotedUntil = now + DEMOTION_MS;
+  }
+}
+
+/**
+ * A clean round fully rehabilitates the provider — clears its connection-failure cluster AND any
+ * active demotion. Only a successful round proves the provider can actually serve.
+ */
+export function recordProviderReachable(key: string): void {
+  health.delete(key);
+}
+
+/**
+ * A status-bearing response (4xx/5xx) proves the endpoint answered, so it breaks the connection-
+ * failure streak: the next drop starts a fresh count (one 400 between drops won't reach the
+ * threshold). It does NOT lift an ACTIVE demotion — an error response is not proof the provider can
+ * serve, just that it replied, so a provider demoted for being unreachable stays at the back until a
+ * clean round (recordProviderReachable) or the cooldown expires.
+ */
+export function recordProviderResponded(key: string, now: number): void {
+  const existing = health.get(key);
+  if (!existing) return;
+  existing.failures = 0;
+  existing.clusterStartedAt = now;
+  // Clear an EXPIRED demotion: this reachable probe resolves the half-open state, so a later lone
+  // connection failure starts a fresh count instead of instantly re-demoting via the cooldown-lapsed
+  // branch. An ACTIVE demotion (demotedUntil > now) is kept — a 5xx must not lift it.
+  if (existing.demotedUntil !== 0 && existing.demotedUntil <= now) {
+    existing.demotedUntil = 0;
+  }
+}
+
+/** True while provider `key` is inside its demotion cooldown. */
+export function isProviderDemoted(key: string, now: number): boolean {
+  const existing = health.get(key);
+  return existing !== undefined && existing.demotedUntil > now;
+}
+
+/**
+ * Stable reorder: providers currently in their demotion cooldown move to the back, every other
+ * provider keeps its original order. Demoted providers are kept (tried last), never dropped.
+ */
+export function orderByHealth<T extends { key: string }>(slots: T[], now: number): T[] {
+  const healthy: T[] = [];
+  const demoted: T[] = [];
+  for (const slot of slots) {
+    if (isProviderDemoted(slot.key, now)) {
+      demoted.push(slot);
+    } else {
+      healthy.push(slot);
+    }
+  }
+  return demoted.length === 0 ? slots : [...healthy, ...demoted];
+}
+
+/** Test-only: clear all breaker state. */
+export function resetProviderBreaker(): void {
+  health.clear();
+}

--- a/src/services/ai/streaming.test.ts
+++ b/src/services/ai/streaming.test.ts
@@ -1439,13 +1439,26 @@ describe('classifyAiError', () => {
     expect(mod.classifyAiError(err)?.kind).toBe('generic');
   });
 
-  it('returns null for an aggregated empty-response failure (no status/connection signal)', () => {
+  it('classifies an aggregated empty-response failure (no status/connection signal) as generic', () => {
+    // Every provider returned an empty body → a plain Error with no status, no abort, no connection
+    // match. An exhausted chain is still an AI failure, so it must surface the safe generic message
+    // (and let the agent page the admin) — NOT fall through to null and silently rethrow.
     const err = new Error(
       'All 3 providers in smart chain failed: z.ai (glm-5.1): Provider z.ai (glm-5.1) ' +
         'returned empty response (no text, no tool calls) — treating as failure; ' +
         'Gemini (g): returned empty response; HF (h): returned empty response',
     );
-    expect(mod.classifyAiError(err)).toBeNull();
+    const c = mod.classifyAiError(err);
+    expect(c?.kind).toBe('generic');
+    expect(c?.userMessage).toContain('Ошибка AI');
+  });
+
+  it('does NOT treat a non-aggregate plain Error as an exhausted-chain failure (stays null)', () => {
+    // The exhausted-chain floor is scoped to the aggregate prefix only — a bare message that merely
+    // mentions providers must still return null so the agent rethrows an unrelated bug.
+    expect(
+      mod.classifyAiError(new Error('the provider list in smart chain failed to load')),
+    ).toBeNull();
   });
 
   it('classifies ECONNRESET as provider_down', () => {

--- a/src/services/ai/streaming.test.ts
+++ b/src/services/ai/streaming.test.ts
@@ -37,7 +37,13 @@ mock.module('./clients', () => ({
 }));
 
 import OpenAI from 'openai';
-import { getBackoffDelay, isRetryableError } from './streaming';
+import { isProviderDemoted, resetProviderBreaker } from './provider-breaker';
+import {
+  classifyAiError,
+  getBackoffDelay,
+  isRetryableError,
+  pickRepresentativeError,
+} from './streaming';
 
 describe('isRetryableError', () => {
   it('returns true for 429 rate limit', () => {
@@ -90,6 +96,31 @@ describe('isRetryableError', () => {
   it('returns false for generic Error', () => {
     expect(isRetryableError(new Error('some error'))).toBe(false);
   });
+
+  it('returns false (never throws) for a thrown null/undefined/primitive', () => {
+    expect(isRetryableError(null)).toBe(false);
+    expect(isRetryableError(undefined)).toBe(false);
+    expect(isRetryableError('boom')).toBe(false);
+  });
+
+  it('returns true for a connection-outage aggregate (plain Error, no status/code)', () => {
+    // An all-APIConnectionError chain yields a plain aggregate with no status/code, only a joined
+    // "Connection error" message — it must still be retryable (matched connection-like by message).
+    const aggregate = new Error('All 3 providers in smart chain failed: z.ai: Connection error.');
+    expect(isRetryableError(aggregate)).toBe(true);
+  });
+
+  it('returns false for a concrete 4xx whose message mentions connection/timeout', () => {
+    // A defined status is authoritative — a 400 is a client error and must stay non-retryable even
+    // though its message says "connection error" (matches classifyAiError keeping it generic).
+    const err = new OpenAI.APIError(
+      400,
+      { message: 'connection error' },
+      'connection error',
+      new Headers(),
+    );
+    expect(isRetryableError(err)).toBe(false);
+  });
 });
 
 describe('getBackoffDelay', () => {
@@ -111,6 +142,11 @@ describe('getBackoffDelay', () => {
     expect(getBackoffDelay(2, new Error('fail'))).toBe(18000);
     expect(getBackoffDelay(3, new Error('fail'))).toBe(30_000); // capped
   });
+
+  it('uses the 429 backoff for an aggregate plain Error carrying status 429', () => {
+    const aggregate = Object.assign(new Error('All 3 providers failed'), { status: 429 });
+    expect(getBackoffDelay(0, aggregate)).toBe(5000); // rate-limit path, not the 2000ms exponential
+  });
 });
 
 describe('aiStreamRound fallback chain', () => {
@@ -120,6 +156,8 @@ describe('aiStreamRound fallback chain', () => {
   let streamingModule: any;
 
   beforeEach(async () => {
+    // The provider breaker is module-global state — reset it so demotions don't leak between tests.
+    resetProviderBreaker();
     // Re-import to get fresh module with mocked deps
     streamingModule = await import('./streaming');
   });
@@ -663,6 +701,604 @@ describe('aiStreamRound fallback chain', () => {
     expect(modelsCalled).toContain('test-model');
     expect(modelsCalled).toContain('gemini-test');
     expect(result.text).toBe('ok');
+  });
+
+  it('demotes a provider to the back of the chain after repeated connection failures', async () => {
+    const clientsMod = await import('./clients');
+    const order: string[] = [];
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      order.push(params.model);
+      if (params.model === 'test-model') {
+        // z.ai unreachable (connection-type failure the breaker counts).
+        throw Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    const round = () =>
+      streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+
+    // Three rounds where z.ai connection-fails first each time (gemini answers).
+    for (let i = 0; i < 3; i++) {
+      order.length = 0;
+      await round();
+      expect(order[0]).toBe('test-model'); // still tried first while it has < 3 failures
+    }
+
+    // 4th round: z.ai is now demoted → gemini is tried first, z.ai is not the head of the chain.
+    order.length = 0;
+    const result = await round();
+    expect(order[0]).toBe('gemini-test');
+    expect(order).not.toContain('test-model'); // gemini answered, so the demoted z.ai isn't reached
+    expect(result.text).toBe('ok');
+  });
+
+  it('does not demote a provider for response-level (4xx) failures', async () => {
+    const clientsMod = await import('./clients');
+    const order: string[] = [];
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      order.push(params.model);
+      if (params.model === 'test-model') {
+        // A 4xx is a response, not a connection failure — the breaker must NOT count it.
+        throw new OpenAI.APIError(400, { message: 'bad' }, 'bad', new Headers());
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    const round = () =>
+      streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    for (let i = 0; i < 4; i++) {
+      order.length = 0;
+      await round();
+      expect(order[0]).toBe('test-model'); // never demoted for 4xx — always tried first
+    }
+  });
+
+  it('does not demote a provider for a 4xx whose message mentions "connection"', async () => {
+    const clientsMod = await import('./clients');
+    const order: string[] = [];
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      order.push(params.model);
+      if (params.model === 'test-model') {
+        // A real response (status 400) whose text mentions "connection" — provider WAS reachable,
+        // so the breaker must not count it (status defined → not an unreachable failure).
+        throw new OpenAI.APIError(
+          400,
+          { message: 'connection error' },
+          'connection error',
+          new Headers(),
+        );
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    const round = () =>
+      streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    for (let i = 0; i < 4; i++) {
+      order.length = 0;
+      await round();
+      expect(order[0]).toBe('test-model'); // 400 response never demotes — always tried first
+    }
+  });
+
+  it('does not demote a provider when the connection failure happens mid-stream', async () => {
+    // Text already emitted means the connection was fine up to that point — a later drop must NOT
+    // count toward the breaker, or a flaky-late provider would wrongly get demoted.
+    const clientsMod = await import('./clients');
+    const create = mock(async () => ({
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'partial' }, finish_reason: null }] };
+        throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+      },
+    }));
+    spyOn(clientsMod, 'zaiClient').mockReturnValue({
+      chat: { completions: { create } },
+    } as unknown as OpenAI);
+    for (let i = 0; i < 4; i++) {
+      await expect(
+        streamingModule.aiStreamRound(
+          { messages: [{ role: 'user', content: 'hi' }], maxTokens: 50, chain: 'smart' },
+          { onTextDelta: () => {} },
+        ),
+      ).rejects.toThrow();
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(false);
+  });
+
+  it('does not demote a provider that streamed a tool-call before dropping mid-stream', async () => {
+    // The provider emitted a tool-call (proof of reachability), then dropped with ECONNRESET — that
+    // late drop must NOT count toward the breaker even though no TEXT was emitted.
+    const clientsMod = await import('./clients');
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        return {
+          [Symbol.asyncIterator]: async function* () {
+            yield {
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      { index: 0, id: 'call_1', function: { name: 'foo', arguments: '{}' } },
+                    ],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            };
+            throw Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+          },
+        };
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    for (let i = 0; i < 4; i++) {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(false);
+  });
+
+  it('does not demote a provider that streamed a nameless tool-call chunk before dropping', async () => {
+    // Tool-call id/arguments can arrive before the function name; that chunk is still proof of
+    // reachability. A subsequent ECONNRESET must not demote (the breaker reads the error tag, not
+    // onToolCallStart which only fires once a name is present).
+    const clientsMod = await import('./clients');
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        return {
+          [Symbol.asyncIterator]: async function* () {
+            yield {
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [{ index: 0, id: 'call_1', function: { arguments: '{}' } }],
+                  },
+                  finish_reason: null,
+                },
+              ],
+            };
+            throw Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+          },
+        };
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    for (let i = 0; i < 4; i++) {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(false);
+  });
+
+  it('an abort does not mutate breaker state (does not reset accrued connection failures)', async () => {
+    // An abort (the agent's 60s timeout / caller cancellation) is not evidence about the provider —
+    // it must neither demote nor clear accrued connection failures.
+    const clientsMod = await import('./clients');
+    let round = 0;
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        if (round === 2) {
+          const abort = new Error('The operation was aborted');
+          abort.name = 'AbortError';
+          throw abort; // a real connection failure would be ECONNREFUSED; this is a cancellation
+        }
+        throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    // conn(1), conn(2), abort(ignored), conn(3) — the abort must not reset, so the 3rd demotes.
+    for (round = 0; round < 4; round++) {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(true);
+  });
+
+  it('text-then-drop resets the accrued connection-failure cluster', async () => {
+    // A provider that streams text then drops mid-stream proved it was reachable, so its accrued
+    // connection-failure cluster must reset — even though the round bails out (cannot fallback).
+    const clientsMod = await import('./clients');
+    let round = 0;
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        if (round === 2) {
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield { choices: [{ delta: { content: 'partial' }, finish_reason: null }] };
+              throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+            },
+          };
+        }
+        throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    // conn(1), conn(2), text-then-drop(RESET), conn(1) — the reset means the 4th round is only count 1.
+    for (round = 0; round < 4; round++) {
+      const pending = streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+      if (round === 2) {
+        await expect(pending).rejects.toThrow(); // text emitted → cannot fallback
+      } else {
+        await pending;
+      }
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(false);
+  });
+
+  it('an all-provider connection outage yields a retryable aggregate', async () => {
+    // Every provider throws a real OpenAI.APIConnectionError (status undefined, no code). The
+    // aggregate is a plain Error, but isRetryableError must still retry the chain-level outage.
+    const clientsMod = await import('./clients');
+    const create = mock(async () => {
+      throw new OpenAI.APIConnectionError({ message: 'Connection error.' });
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    let thrown: unknown;
+    try {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(isRetryableError(thrown)).toBe(true);
+  });
+
+  it('demotes a provider after 3 real APIConnectionError outages', async () => {
+    // APIConnectionError has status undefined and no code — it must still count as unreachable (and
+    // must NOT be mistaken for an abort, which would skip the breaker).
+    const clientsMod = await import('./clients');
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        throw new OpenAI.APIConnectionError({ message: 'Connection error.' });
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    for (let i = 0; i < 3; i++) {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(true);
+  });
+
+  it('an APIUserAbortError does not mutate breaker state', async () => {
+    // The SDK abort error has status undefined and name "Error" (matched only by its "was aborted"
+    // message) — it must be treated as an abort and leave accrued connection failures intact.
+    const clientsMod = await import('./clients');
+    let round = 0;
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        if (round === 2) throw new OpenAI.APIUserAbortError();
+        throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    // conn(1), conn(2), abort(ignored), conn(3) — the abort must not reset, so the 3rd demotes.
+    for (round = 0; round < 4; round++) {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(true);
+  });
+
+  it('a mixed transient+4xx chain intentionally retries and reads as provider_down', async () => {
+    // Documents the deliberate choice (pickRepresentativeError): a transient signal outranks a
+    // co-occurring 4xx, so a chain that is mostly down but has one provider 4xx still retries rather
+    // than reading as a (non-retryable) bad request — failing safe toward "try later".
+    const clientsMod = await import('./clients');
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model')
+        throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+      throw new OpenAI.APIError(400, { message: 'bad' }, 'bad', new Headers());
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    let thrown: unknown;
+    try {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(isRetryableError(thrown)).toBe(true);
+    expect(classifyAiError(thrown)?.kind).toBe('provider_down');
+  });
+
+  it('a 5xx response does not lift an existing connection-demotion', async () => {
+    const clientsMod = await import('./clients');
+    const conn = () => Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+    const ok = () => ({
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+      },
+    });
+    let round = 0;
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (round < 3) {
+        if (params.model === 'test-model') throw conn(); // z.ai unreachable → accrues toward demotion
+        return ok(); // gemini answers
+      }
+      // Final round: the whole chain fails and the demoted z.ai is reached, returning a 503.
+      if (params.model === 'test-model') {
+        throw new OpenAI.APIError(503, { message: 'down' }, 'down', new Headers());
+      }
+      throw conn();
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    const runRound = () =>
+      streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    for (round = 0; round < 3; round++) await runRound();
+    expect(isProviderDemoted('zai', Date.now())).toBe(true); // demoted after 3 connection failures
+    await expect(runRound()).rejects.toThrow(); // round 3: z.ai returns a 503 (reachable)
+    // The 503 only reset the connection counter — it did NOT rehabilitate the demoted provider.
+    expect(isProviderDemoted('zai', Date.now())).toBe(true);
+  });
+
+  it('a reachable empty-response between connection failures resets the breaker streak', async () => {
+    // The empty-response fallback throws a plain Error (no status, not connection-like) — it proves
+    // the provider was reachable, so it must break the connection streak, not be ignored.
+    const clientsMod = await import('./clients');
+    let round = 0;
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        if (round === 2) {
+          // Reachable but empty → streamingSlot throws the plain "empty response" Error.
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield { choices: [{ delta: {}, finish_reason: 'stop' }] };
+            },
+          };
+        }
+        throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+      }
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };
+        },
+      };
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    // conn, conn, empty(reset), conn — the empty response resets, so the final conn is only count 1.
+    for (round = 0; round < 4; round++) {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    }
+    expect(isProviderDemoted('zai', Date.now())).toBe(false);
+  });
+
+  it('aggregate error prefers a transient (5xx) signal over a co-occurring 4xx (keeps retry)', async () => {
+    const clientsMod = await import('./clients');
+    const create = mock(async (params: OpenAI.ChatCompletionCreateParamsStreaming) => {
+      if (params.model === 'test-model') {
+        throw new OpenAI.APIError(400, { message: 'bad' }, 'bad', new Headers()); // one provider 4xx
+      }
+      throw new OpenAI.APIError(503, { message: 'down' }, 'down', new Headers()); // the rest 5xx
+    });
+    for (const fn of ['zaiClient', 'geminiClient', 'hfClient'] as const) {
+      spyOn(clientsMod, fn).mockReturnValue({
+        chat: { completions: { create } },
+      } as unknown as OpenAI);
+    }
+    let thrown: unknown;
+    try {
+      await streamingModule.aiStreamRound({
+        messages: [{ role: 'user', content: 'hi' }],
+        maxTokens: 50,
+        chain: 'smart',
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    // The transient 503 is carried, NOT the 400 — so the chain reads as provider_down, not a
+    // (non-retryable) "bad request", independent of which provider failed last.
+    expect((thrown as { status?: number }).status).toBe(503);
+    // The aggregate is a plain Error, but isRetryableError reads status structurally → still retried.
+    expect(isRetryableError(thrown)).toBe(true);
+  });
+});
+
+describe('pickRepresentativeError', () => {
+  const api = (status: number) => new OpenAI.APIError(status, { message: 'x' }, 'x', new Headers());
+  const conn = () => Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
+
+  const statusOf = (e: Error | null) => (e as { status?: number } | null)?.status;
+
+  it('surfaces a 429 rate-limit over any smaller co-occurring status', () => {
+    expect(statusOf(pickRepresentativeError([api(500), api(400), api(429)], null))).toBe(429);
+  });
+
+  it('surfaces 529 overloaded when no 429 is present', () => {
+    expect(statusOf(pickRepresentativeError([api(500), api(529), api(400)], null))).toBe(529);
+  });
+
+  it('prefers a transient connection failure over a 4xx (keeps the chain retryable)', () => {
+    const c = conn();
+    expect(pickRepresentativeError([c, api(400)], null)).toBe(c);
+  });
+
+  it('prefers a 5xx transient over a co-occurring 4xx', () => {
+    const five = api(500);
+    expect(pickRepresentativeError([five, api(400)], null)).toBe(five);
+  });
+
+  it('surfaces a 4xx only when no transient (5xx/connection) failure occurred', () => {
+    expect(statusOf(pickRepresentativeError([api(400), api(403)], null))).toBe(400);
+  });
+
+  it('falls back to the provided error when nothing matched (no status, not connection-like)', () => {
+    const weird = new Error('totally unexpected');
+    const fallback = new Error('the last error');
+    expect(pickRepresentativeError([weird], fallback)).toBe(fallback);
+  });
+
+  it('always surfaces a transient signal (never the 4xx) regardless of try order', () => {
+    const cases: Error[][] = [
+      [api(500), api(400), conn()],
+      [conn(), api(400), api(500)],
+      [api(400), conn(), api(500)],
+    ];
+    for (const errors of cases) {
+      const status = statusOf(pickRepresentativeError(errors, null));
+      // A 5xx or a status-less connection error — both classify as retryable provider_down.
+      expect(status === undefined || status >= 500).toBe(true);
+    }
+  });
+
+  // Locks the docstring assumption: every member of the transient tier classifies identically, so
+  // which one the breaker's reordering surfaces never changes the user-facing message.
+  it('every transient-tier error (5xx / connection) classifies as provider_down', () => {
+    expect(classifyAiError(api(500))?.kind).toBe('provider_down');
+    expect(classifyAiError(api(503))?.kind).toBe('provider_down');
+    expect(classifyAiError(conn())?.kind).toBe('provider_down');
+  });
+
+  // The aggregate is a plain Error with status/code COPIED on — classifyAiError must read it
+  // structurally (not via `instanceof OpenAI.APIError`), or pickRepresentativeError's copy is moot.
+  it('classifies the aggregate plain Error by its copied status', () => {
+    const down = Object.assign(new Error('All 3 providers in smart chain failed: …'), {
+      status: 503,
+    });
+    const bad = Object.assign(new Error('All 3 providers in smart chain failed: …'), {
+      status: 400,
+    });
+    expect(classifyAiError(down)?.kind).toBe('provider_down');
+    expect(classifyAiError(bad)?.kind).toBe('generic');
   });
 });
 

--- a/src/services/ai/streaming.test.ts
+++ b/src/services/ai/streaming.test.ts
@@ -666,36 +666,6 @@ describe('aiStreamRound fallback chain', () => {
   });
 });
 
-describe('formatApiError', () => {
-  let mod: typeof import('./streaming');
-  beforeEach(async () => {
-    mod = await import('./streaming');
-  });
-
-  it('returns rate-limit message for 429', () => {
-    const err = new OpenAI.APIError(429, { message: 'rl' }, 'rl', new Headers());
-    const msg = mod.formatApiError(err);
-    expect(msg).toContain('Слишком много');
-  });
-
-  it('returns overloaded message for 529', () => {
-    const err = new OpenAI.APIError(529, { message: 'over' }, 'over', new Headers());
-    const msg = mod.formatApiError(err);
-    expect(msg).toContain('перегружен');
-  });
-
-  it('returns generic error for other statuses', () => {
-    const err = new OpenAI.APIError(500, { message: 'srv' }, 'srv', new Headers());
-    const msg = mod.formatApiError(err);
-    expect(msg).toContain('Ошибка AI');
-  });
-
-  it('returns generic error for non-APIError', () => {
-    const msg = mod.formatApiError(new Error('anything'));
-    expect(msg).toContain('Ошибка AI');
-  });
-});
-
 describe('stripThinkingTags', () => {
   let mod: typeof import('./streaming');
   beforeEach(async () => {
@@ -724,5 +694,134 @@ describe('stripThinkingTags', () => {
 
   it('handles empty string', () => {
     expect(mod.stripThinkingTags('')).toBe('');
+  });
+});
+
+describe('classifyAiError', () => {
+  let mod: typeof import('./streaming');
+  beforeEach(async () => {
+    mod = await import('./streaming');
+  });
+
+  it('classifies an aggregated all-providers connection failure as provider_down', () => {
+    const err = new Error(
+      'All 3 providers in smart chain failed: z.ai (glm-5.1): Connection error.; ' +
+        'Gemini (g): Connection error.; HF (h): Connection error.',
+    );
+    const c = mod.classifyAiError(err);
+    expect(c?.kind).toBe('provider_down');
+    expect(c?.userMessage).toContain('временно недоступен');
+  });
+
+  it('classifies an OpenAI APIConnectionError as provider_down', () => {
+    const err = new OpenAI.APIConnectionError({ message: 'Connection error.' });
+    expect(mod.classifyAiError(err)?.kind).toBe('provider_down');
+  });
+
+  it('classifies ECONNREFUSED as provider_down', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    expect(mod.classifyAiError(err)?.kind).toBe('provider_down');
+  });
+
+  it('classifies a non-429/529 5xx as provider_down', () => {
+    const err = Object.assign(new Error('Server error'), { status: 503 });
+    expect(mod.classifyAiError(err)?.kind).toBe('provider_down');
+  });
+
+  it('classifies 429 as rate_limit', () => {
+    const err = Object.assign(new Error('rate limited'), { status: 429 });
+    const c = mod.classifyAiError(err);
+    expect(c?.kind).toBe('rate_limit');
+    expect(c?.userMessage).toContain('Слишком много');
+  });
+
+  it('reads status off a real OpenAI.APIError instance (429 → rate_limit)', () => {
+    const err = new OpenAI.APIError(429, { message: 'rl' }, 'rl', new Headers());
+    expect(mod.classifyAiError(err)?.kind).toBe('rate_limit');
+  });
+
+  it('classifies an aggregate carrying code=ECONNREFUSED as provider_down', () => {
+    // aiStreamRound copies the last error's status+code onto the aggregate, so a
+    // connection-down chain stays classifiable even if the joined message is terse.
+    const err = Object.assign(new Error('All 3 providers in smart chain failed: …'), {
+      code: 'ECONNREFUSED',
+    });
+    expect(mod.classifyAiError(err)?.kind).toBe('provider_down');
+  });
+
+  it('classifies 529 as overloaded', () => {
+    const err = Object.assign(new Error('overloaded'), { status: 529 });
+    const c = mod.classifyAiError(err);
+    expect(c?.kind).toBe('overloaded');
+    expect(c?.userMessage).toContain('перегружен');
+  });
+
+  it('classifies an AbortError as timeout', () => {
+    const err = new Error('The operation was aborted');
+    err.name = 'AbortError';
+    const c = mod.classifyAiError(err);
+    expect(c?.kind).toBe('timeout');
+    expect(c?.userMessage).toContain('ожидания');
+  });
+
+  it('classifies an aggregated abort (60s agent timeout) as timeout, not provider_down', () => {
+    const err = new Error(
+      'All 3 providers in smart chain failed: z.ai (glm-5.1): Request was aborted.; ' +
+        'Gemini (g): Request was aborted.; HF (h): Request was aborted.',
+    );
+    expect(mod.classifyAiError(err)?.kind).toBe('timeout');
+  });
+
+  it('classifies a 4xx (other than 429) as a generic recognized AI error', () => {
+    const err = Object.assign(new Error('bad request'), { status: 400 });
+    const c = mod.classifyAiError(err);
+    expect(c?.kind).toBe('generic');
+    expect(c?.userMessage).toContain('Ошибка AI');
+  });
+
+  it('does NOT mask an aggregated all-400 failure as provider_down (stays generic)', () => {
+    const err = Object.assign(
+      new Error(
+        'All 3 providers in smart chain failed: z.ai (glm-5.1): 400 Bad Request; ' +
+          'Gemini (g): 400 Bad Request; HF (h): 400 Bad Request',
+      ),
+      { status: 400 },
+    );
+    expect(mod.classifyAiError(err)?.kind).toBe('generic');
+  });
+
+  it('does NOT mask a mixed 4xx aggregate (last=400, earlier connection blip) as an outage', () => {
+    // A concrete 4xx is a request bug — the earlier "Connection error." in the summary
+    // must not flip it to provider_down.
+    const err = Object.assign(
+      new Error(
+        'All 3 providers in smart chain failed: z.ai (glm-5.1): Connection error.; ' +
+          'Gemini (g): 400 Bad Request; HF (h): 400 Bad Request',
+      ),
+      { status: 400 },
+    );
+    expect(mod.classifyAiError(err)?.kind).toBe('generic');
+  });
+
+  it('returns null for an aggregated empty-response failure (no status/connection signal)', () => {
+    const err = new Error(
+      'All 3 providers in smart chain failed: z.ai (glm-5.1): Provider z.ai (glm-5.1) ' +
+        'returned empty response (no text, no tool calls) — treating as failure; ' +
+        'Gemini (g): returned empty response; HF (h): returned empty response',
+    );
+    expect(mod.classifyAiError(err)).toBeNull();
+  });
+
+  it('classifies ECONNRESET as provider_down', () => {
+    const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    expect(mod.classifyAiError(err)?.kind).toBe('provider_down');
+  });
+
+  it('classifies a "fetch failed" message as provider_down', () => {
+    expect(mod.classifyAiError(new Error('fetch failed'))?.kind).toBe('provider_down');
+  });
+
+  it('returns null for an unrecognized error so the caller can rethrow', () => {
+    expect(mod.classifyAiError(new TypeError('boom'))).toBeNull();
   });
 });

--- a/src/services/ai/streaming.ts
+++ b/src/services/ai/streaming.ts
@@ -12,13 +12,23 @@
  * Fallback rules:
  *  - Any error (including 4xx)             → try next provider in the chain
  *  - Provider streams text then fails      → propagate (cannot splice another model's output)
- *  - All providers exhausted               → propagate the last error
+ *  - All providers exhausted               → throw an aggregated error (status/code chosen
+ *                                            order-independently, see pickRepresentativeError)
+ *
+ * A circuit breaker (provider-breaker.ts) demotes a provider that hits repeated connection-type
+ * failures to the back of the chain for a cooldown, so a flapping endpoint stops being tried first.
  */
 
 import OpenAI from 'openai';
 import { env } from '../../config/env';
 import { createLogger } from '../../utils/logger';
 import { geminiClient, hfClient, zaiClient } from './clients';
+import {
+  orderByHealth,
+  recordProviderConnectionFailure,
+  recordProviderReachable,
+  recordProviderResponded,
+} from './provider-breaker';
 
 const logger = createLogger('ai-streaming');
 
@@ -63,47 +73,67 @@ export interface StreamCallbacks {
 
 // ── Error helpers (exported for tests) ──────────────────────────────────────
 
-/** Provider-down: 5xx, timeout, network. Means "try next", retrying same provider is hopeless. */
+// Internal tag: marks a thrown stream error as "the provider had already emitted output (text or a
+// tool-call chunk) before failing" — i.e. it was reachable. A Symbol keeps it off any real error
+// shape so it never collides with status/code/message.
+const PROVIDER_RESPONDED: unique symbol = Symbol('providerResponded');
+interface RespondedTag {
+  [PROVIDER_RESPONDED]?: boolean;
+}
+
+function markProviderResponded(error: unknown, responded: boolean): void {
+  if (responded && error && typeof error === 'object') {
+    (error as RespondedTag)[PROVIDER_RESPONDED] = true;
+  }
+}
+
+function providerResponded(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && (error as RespondedTag)[PROVIDER_RESPONDED]);
+}
+
+/**
+ * Provider-down: 5xx or a connection/network failure. Means "try next", retrying same provider is
+ * hopeless. A DEFINED status is authoritative (only >= 500 is down) — a concrete 4xx is a client
+ * error and stays non-retryable even if its message mentions "connection"/"timed out", matching
+ * classifyAiError (which keeps a non-429 4xx generic). Only a STATUS-LESS error falls through to
+ * isConnectionLike (code/message), so an `APIConnectionError` outage aggregate (no status, joined
+ * "Connection error" message) is still recognised. (429 retryability is handled by isRetryableError.)
+ */
 function isProviderDown(error: unknown): boolean {
-  if (error instanceof OpenAI.APIError && error.status !== undefined && error.status >= 500) {
-    return true;
-  }
-  if (error instanceof Error) {
-    if (error.message.includes('timed out')) return true;
-    const code = (error as NodeJS.ErrnoException).code;
-    if (
-      code &&
-      ['ETIMEDOUT', 'ECONNREFUSED', 'ECONNRESET', 'ENETUNREACH', 'ENOTFOUND'].includes(code)
-    ) {
-      return true;
-    }
-  }
-  return false;
+  const status = numericStatus(error);
+  if (status !== undefined) return status >= 500;
+  return isConnectionLike(error);
 }
 
 /**
  * Retryable for same-provider retry (backoff): 429, 5xx, timeout, abort.
  * NOT used for cross-provider fallback — the chain always tries the next provider.
+ * Status is read structurally so the aggregate chain error (a plain `Error` with a copied transient
+ * `status`) stays retryable — otherwise a chain that ends in 5xx/429 would silently lose its retry.
  */
 export function isRetryableError(error: unknown): boolean {
   if (isProviderDown(error)) return true;
+  if (numericStatus(error) === 429) return true;
   if (error instanceof Error && error.name === 'AbortError') return true;
   // OpenAI SDK v6: APIUserAbortError extends APIError with status=undefined —
   // catches abort errors that don't set .name to 'AbortError'.
   if (error instanceof OpenAI.APIError && error.status === undefined) return true;
-  if (error instanceof OpenAI.APIError) {
-    return error.status === 429 || (error.status ?? 0) >= 500;
-  }
   return false;
 }
 
 /** Exponential backoff: 2s → 6s → 18s capped at 30s. 429 uses Retry-After if present. */
 export function getBackoffDelay(attempt: number, error: unknown): number {
-  if (error instanceof OpenAI.APIError && error.status === 429) {
-    const retryAfter = error.headers?.['retry-after'];
-    if (retryAfter) {
-      const seconds = Number.parseInt(retryAfter, 10);
-      if (!Number.isNaN(seconds) && seconds > 0) return Math.min(seconds * 1000, 30_000);
+  // Read 429 structurally so the aggregate chain error (a plain Error with a copied status) also
+  // gets the rate-limit backoff, not the generic exponential one. Retry-After is read only off a
+  // real APIError — a chain-wide 429 aggregate loses the provider's Retry-After and uses the flat
+  // 5000ms floor; a 529 aggregate falls to the exponential path (acceptable, low frequency).
+  if (numericStatus(error) === 429) {
+    if (error instanceof OpenAI.APIError) {
+      const retryAfter = error.headers?.['retry-after'];
+      if (retryAfter) {
+        const seconds = Number.parseInt(retryAfter, 10);
+        if (!Number.isNaN(seconds) && seconds > 0) return Math.min(seconds * 1000, 30_000);
+      }
     }
     return 5000;
   }
@@ -113,7 +143,10 @@ export function getBackoffDelay(attempt: number, error: unknown): number {
 // ── Provider slots ──────────────────────────────────────────────────────────
 
 interface ProviderSlot {
+  /** Human-readable, per-model label for logs/errors, e.g. "z.ai (glm-5.1)". */
   name: string;
+  /** Stable endpoint id shared across chains/models ('zai'/'gemini'/'hf') — the breaker key. */
+  key: string;
   stream: (opts: StreamRoundOptions, cbs: StreamCallbacks) => Promise<StreamRoundResult>;
 }
 
@@ -121,9 +154,15 @@ interface ProviderSlot {
  * Standard OpenAI streaming adapter. Works for any OpenAI-compat provider
  * (z.ai, Gemini, HF) via the shared OpenAI SDK.
  */
-function streamingSlot(name: string, getClient: () => OpenAI, model: string): ProviderSlot {
+function streamingSlot(
+  name: string,
+  key: string,
+  getClient: () => OpenAI,
+  model: string,
+): ProviderSlot {
   return {
     name,
+    key,
     stream: async (opts, cbs) => {
       const params: OpenAI.ChatCompletionCreateParamsStreaming = {
         model,
@@ -146,51 +185,59 @@ function streamingSlot(name: string, getClient: () => OpenAI, model: string): Pr
       let lastToolCallKey = -1;
       let finishReason = 'stop';
 
-      for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta;
-        if (!delta) continue;
+      try {
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta;
+          if (!delta) continue;
 
-        if (delta.content) {
-          text += delta.content;
-          cbs.onTextDelta?.(delta.content);
-        }
+          if (delta.content) {
+            text += delta.content;
+            cbs.onTextDelta?.(delta.content);
+          }
 
-        if (delta.tool_calls) {
-          for (const tc of delta.tool_calls) {
-            // Resolve index: some providers (HF Router, early Gemini) omit tc.index.
-            // Fallback: new tool call if id/name present, otherwise append to last.
-            let key: number;
-            if (typeof tc.index === 'number') {
-              key = tc.index;
-            } else if (tc.id || tc.function?.name) {
-              key = toolCalls.size;
-            } else if (lastToolCallKey >= 0) {
-              key = lastToolCallKey;
-            } else {
-              continue;
-            }
+          if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              // Resolve index: some providers (HF Router, early Gemini) omit tc.index.
+              // Fallback: new tool call if id/name present, otherwise append to last.
+              let key: number;
+              if (typeof tc.index === 'number') {
+                key = tc.index;
+              } else if (tc.id || tc.function?.name) {
+                key = toolCalls.size;
+              } else if (lastToolCallKey >= 0) {
+                key = lastToolCallKey;
+              } else {
+                continue;
+              }
 
-            const existing = toolCalls.get(key);
-            if (existing) {
-              existing.args += tc.function?.arguments ?? '';
-              if (tc.id && !existing.id) existing.id = tc.id;
-              if (tc.function?.name && !existing.name) existing.name = tc.function.name;
-            } else {
-              const tcName = tc.function?.name ?? '';
-              if (tcName) cbs.onToolCallStart?.(tcName);
-              toolCalls.set(key, {
-                id: tc.id ?? '',
-                name: tcName,
-                args: tc.function?.arguments ?? '',
-              });
-              lastToolCallKey = key;
+              const existing = toolCalls.get(key);
+              if (existing) {
+                existing.args += tc.function?.arguments ?? '';
+                if (tc.id && !existing.id) existing.id = tc.id;
+                if (tc.function?.name && !existing.name) existing.name = tc.function.name;
+              } else {
+                const tcName = tc.function?.name ?? '';
+                if (tcName) cbs.onToolCallStart?.(tcName);
+                toolCalls.set(key, {
+                  id: tc.id ?? '',
+                  name: tcName,
+                  args: tc.function?.arguments ?? '',
+                });
+                lastToolCallKey = key;
+              }
             }
           }
-        }
 
-        if (chunk.choices[0]?.finish_reason) {
-          finishReason = chunk.choices[0].finish_reason;
+          if (chunk.choices[0]?.finish_reason) {
+            finishReason = chunk.choices[0].finish_reason;
+          }
         }
+      } catch (streamError) {
+        // Tag whether ANY output (text or a tool-call chunk — even before a tool name arrives) was
+        // received before the drop. The chain uses this so the breaker doesn't treat a late drop
+        // after a real response as "provider unreachable".
+        markProviderResponded(streamError, text.length > 0 || toolCalls.size > 0);
+        throw streamError;
       }
 
       const toolCallsArray: StreamToolCall[] = [...toolCalls.values()].map((tc) => ({
@@ -239,24 +286,34 @@ function streamingSlot(name: string, getClient: () => OpenAI, model: string): Pr
 
 function buildSmartChain(): ProviderSlot[] {
   return [
-    streamingSlot(`z.ai (${env.AI_MODEL})`, zaiClient, env.AI_MODEL),
-    streamingSlot(`Gemini (${env.GEMINI_MODEL})`, geminiClient, env.GEMINI_MODEL),
-    streamingSlot(`HF (${env.HF_MODEL})`, hfClient, env.HF_MODEL),
+    streamingSlot(`z.ai (${env.AI_MODEL})`, 'zai', zaiClient, env.AI_MODEL),
+    streamingSlot(`Gemini (${env.GEMINI_MODEL})`, 'gemini', geminiClient, env.GEMINI_MODEL),
+    streamingSlot(`HF (${env.HF_MODEL})`, 'hf', hfClient, env.HF_MODEL),
   ];
 }
 
 function buildFastChain(): ProviderSlot[] {
   return [
-    streamingSlot(`z.ai (${env.AI_FAST_MODEL})`, zaiClient, env.AI_FAST_MODEL),
-    streamingSlot(`Gemini (${env.GEMINI_FAST_MODEL})`, geminiClient, env.GEMINI_FAST_MODEL),
-    streamingSlot(`HF (${env.HF_FAST_MODEL})`, hfClient, env.HF_FAST_MODEL),
+    streamingSlot(`z.ai (${env.AI_FAST_MODEL})`, 'zai', zaiClient, env.AI_FAST_MODEL),
+    streamingSlot(
+      `Gemini (${env.GEMINI_FAST_MODEL})`,
+      'gemini',
+      geminiClient,
+      env.GEMINI_FAST_MODEL,
+    ),
+    streamingSlot(`HF (${env.HF_FAST_MODEL})`, 'hf', hfClient, env.HF_FAST_MODEL),
   ];
 }
 
 function buildOcrChain(): ProviderSlot[] {
   return [
-    streamingSlot(`Gemini (${env.GEMINI_VISION_MODEL})`, geminiClient, env.GEMINI_VISION_MODEL),
-    streamingSlot(`HF (${env.HF_VISION_MODEL})`, hfClient, env.HF_VISION_MODEL),
+    streamingSlot(
+      `Gemini (${env.GEMINI_VISION_MODEL})`,
+      'gemini',
+      geminiClient,
+      env.GEMINI_VISION_MODEL,
+    ),
+    streamingSlot(`HF (${env.HF_VISION_MODEL})`, 'hf', hfClient, env.HF_VISION_MODEL),
   ];
 }
 
@@ -269,6 +326,54 @@ function buildChain(chain: ChainName): ProviderSlot[] {
     case 'ocr':
       return buildOcrChain();
   }
+}
+
+function numericStatus(error: unknown): number | undefined {
+  // Optional chain: isProviderDown/isRetryableError call this on `unknown`, which may be a thrown
+  // null/undefined/primitive — those must classify as not-retryable, never throw a TypeError.
+  const status = (error as { status?: unknown } | null | undefined)?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+/**
+ * Pick the error whose status/code best represents an all-providers-failed chain. The aggregate
+ * feeds BOTH the user-facing classifier (classifyAiError) and the retry decision (isRetryableError),
+ * so a transient signal must win over a co-occurring 4xx — otherwise a chain where one provider 400s
+ * and the rest 5xx would lose its retry. Priority:
+ *   1. 429 (rate limit) / 529 (overloaded) — the most actionable, retryable signals.
+ *   2. any other transient failure — a 5xx response or a connection error — → provider_down + retry.
+ *   3. otherwise a 4xx response — the request itself is the problem (generic, not retryable).
+ *   4. fallback (the last error) when nothing else matched.
+ *
+ * The resulting CATEGORY is independent of the order providers were tried (the breaker can reorder
+ * the chain). The exact status WITHIN a tier follows try order — but every error in a tier maps to
+ * the same classifyAiError/isRetryableError category, so the user-facing outcome is stable.
+ */
+export function pickRepresentativeError(errors: Error[], fallback: Error | null): Error | null {
+  const rateLimited = errors.find((e) => numericStatus(e) === 429);
+  if (rateLimited) return rateLimited;
+  const overloaded = errors.find((e) => numericStatus(e) === 529);
+  if (overloaded) return overloaded;
+
+  const transient = errors.find((e) => {
+    const status = numericStatus(e);
+    return (status !== undefined && status >= 500) || (status === undefined && isConnectionLike(e));
+  });
+  if (transient) return transient;
+
+  const clientError = errors.find((e) => numericStatus(e) !== undefined);
+  return clientError ?? fallback;
+}
+
+/**
+ * Breaker-specific: only a STATUS-less connection error is a true "provider unreachable" event.
+ * A 4xx/5xx response — even one whose message happens to mention "connection" / "timed out" — means
+ * the provider WAS reachable, so it must not demote it (isConnectionLike also matches by message and
+ * would otherwise count such responses).
+ */
+function isUnreachableFailure(error: unknown): boolean {
+  if (numericStatus(error) !== undefined) return false;
+  return isConnectionLike(error);
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────
@@ -287,12 +392,17 @@ export async function aiStreamRound(
   callbacks: StreamCallbacks = {},
 ): Promise<StreamRoundResult> {
   const chainName: ChainName = options.chain ?? 'smart';
-  const chain = buildChain(chainName);
+  // Round-start snapshot used ONLY to order the chain: demoted providers (repeated connection
+  // failures) drop to the back instead of being tried first; they're never removed. Breaker
+  // mutations below read a fresh `Date.now()` at failure time so a cooldown that expires mid-round
+  // is honored (the boundary check `demotedUntil <= now` must not use a stale anchor).
+  const now = Date.now();
+  const chain = orderByHealth(buildChain(chainName), now);
   let lastError: Error | null = null;
+  // Once text reaches the user we cannot splice another model's output on a fallback. (Whether the
+  // provider was reachable before a failure is read separately, off the thrown error's tag.)
   let textEmitted = false;
 
-  // Wrap callbacks to track whether text was actually sent to the user —
-  // if so, we cannot splice another model's output in a fallback.
   const wrappedCallbacks: StreamCallbacks = {
     onTextDelta: (text) => {
       textEmitted = true;
@@ -308,18 +418,43 @@ export async function aiStreamRound(
   for (const slot of chain) {
     try {
       logger.info(`[AI_STREAM] Trying ${chainName} → ${slot.name}`);
-      return await slot.stream(options, wrappedCallbacks);
+      const result = await slot.stream(options, wrappedCallbacks);
+      recordProviderReachable(slot.key); // a clean round rehabilitates a previously-demoted slot
+      return result;
     } catch (error) {
+      // A fresh read at FAILURE time — the round-start `now` (used only for orderByHealth) can
+      // predate a cooldown that expires mid-round, which would wrongly skip clearing an expired
+      // half-open demotion or extend a cooldown from a stale anchor.
+      const failedAt = Date.now();
       lastError = error instanceof Error ? error : new Error(String(error));
       providerErrors.push({ name: slot.name, error: lastError });
       logger.error({ err: lastError }, `[AI_STREAM] ${slot.name} failed: ${lastError.message}`);
 
-      // Text already sent to user — can't splice another model's output
+      // Text already sent to user — can't splice another model's output. The provider proved it was
+      // reachable (it streamed text), so reset its connection-failure cluster before bailing out.
       if (textEmitted) {
+        if (!isAbortLike(lastError)) recordProviderResponded(slot.key, failedAt);
         logger.error(
           `[AI_STREAM] ${slot.name} died mid-stream after text was emitted — cannot fallback`,
         );
         throw error;
+      }
+
+      // An abort (the agent's 60s timeout / caller cancellation) is not evidence about the provider
+      // — it neither proves nor disproves reachability — so it must leave the breaker untouched.
+      // Otherwise: a truly unreachable failure (no status, connection-like, AND no output this
+      // attempt) demotes; anything else means the provider answered (a 4xx/5xx status, a plain
+      // reachable error like the empty-response above, or a late drop AFTER it streamed text/
+      // tool-calls), so it only resets the connection-failure counter (recordProviderResponded —
+      // does NOT lift an active demotion; only a clean round does).
+      // Read the responded tag off the ORIGINAL thrown value — it's set on `error`, while `lastError`
+      // may be a fresh wrapper Error (for a non-Error throw) that never carried the tag.
+      if (!isAbortLike(lastError)) {
+        if (isUnreachableFailure(lastError) && !providerResponded(error)) {
+          recordProviderConnectionFailure(slot.key, failedAt);
+        } else {
+          recordProviderResponded(slot.key, failedAt);
+        }
       }
 
       // Always try the next provider in the chain.
@@ -338,14 +473,19 @@ export async function aiStreamRound(
   const aggregated = new Error(
     `All ${providerErrors.length} providers in ${chainName} chain failed: ${summary}`,
   );
-  // Preserve the last error's properties (status, code) for upstream error
-  // classification (classifyAiError reads error.status and error.code) — keeps an
-  // all-connection-failure chain classifiable even when the joined message text
-  // doesn't obviously read as a network error.
-  if (lastError) {
+  // Carry status/code for upstream classification (classifyAiError) and retry (isRetryableError),
+  // both of which read error.status/code. The choice must NOT depend on which provider failed LAST
+  // — the breaker can reorder the chain, so "last error" is unstable. pickRepresentativeError
+  // prefers a transient signal (429/529/5xx/connection → retryable provider_down) over a co-occurring
+  // 4xx, so a chain where one provider 400s and the rest are down still reads as "try later".
+  const representative = pickRepresentativeError(
+    providerErrors.map((e) => e.error),
+    lastError,
+  );
+  if (representative) {
     Object.assign(aggregated, {
-      status: (lastError as { status?: number }).status,
-      code: (lastError as { code?: string }).code,
+      status: (representative as { status?: number }).status,
+      code: (representative as { code?: string }).code,
     });
   }
   throw aggregated;
@@ -405,6 +545,11 @@ function errorText(error: unknown): string {
 }
 
 /** The agent's abort timer fired (or a user/SDK abort) — distinct from a provider being down. */
+// INVARIANT (the provider breaker depends on this): this must distinguish APIUserAbortError (an
+// abort → skip the breaker) from APIConnectionError (a real outage → must demote). Both are
+// `APIError` with `status === undefined`, so the match is by name/message ("aborted"), NEVER by
+// `status === undefined` — broadening it that way would silently stop demoting real connection
+// outages, the main case the breaker exists for.
 function isAbortLike(error: unknown): boolean {
   if (
     error instanceof Error &&

--- a/src/services/ai/streaming.ts
+++ b/src/services/ai/streaming.ts
@@ -338,33 +338,119 @@ export async function aiStreamRound(
   const aggregated = new Error(
     `All ${providerErrors.length} providers in ${chainName} chain failed: ${summary}`,
   );
-  // Preserve the last error's properties (status, code, etc.) for upstream
-  // error classification (formatApiError checks error.status).
+  // Preserve the last error's properties (status, code) for upstream error
+  // classification (classifyAiError reads error.status and error.code) — keeps an
+  // all-connection-failure chain classifiable even when the joined message text
+  // doesn't obviously read as a network error.
   if (lastError) {
-    Object.assign(aggregated, { status: (lastError as { status?: number }).status });
+    Object.assign(aggregated, {
+      status: (lastError as { status?: number }).status,
+      code: (lastError as { code?: string }).code,
+    });
   }
   throw aggregated;
-}
-
-// ── User-facing error formatting ────────────────────────────────────────────
-
-/** Format an API error into a user-facing Telegram message. */
-export function formatApiError(error: unknown): string {
-  if (error instanceof OpenAI.APIError) {
-    if (error.status === 429) {
-      logger.warn('[AI_STREAM] Rate limited (429)');
-      return '\u23f3 Слишком много запросов к AI. Подождите минуту.';
-    }
-    if (error.status === 529) {
-      logger.warn('[AI_STREAM] Overloaded (529)');
-      return '\u26a1 AI сервер перегружен. Попробуйте позже.';
-    }
-    logger.error({ err: error }, `[AI_STREAM] API error: ${error.status}`);
-  }
-  return '\u274c Ошибка AI. Попробуйте позже.';
 }
 
 /** Strip `<think>…</think>` blocks emitted by reasoning models (DeepSeek-R1, Qwen3). */
 export function stripThinkingTags(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+}
+
+// ── Error classification (informative, user-safe) ────────────────────────────
+
+/** User-facing Telegram messages per error class. Short, no internals, address user as "ты". */
+const AI_ERROR_MESSAGES = {
+  rateLimit: '⏳ Слишком много запросов к AI. Подожди минуту.',
+  overloaded: '⚡ AI сервер перегружен. Попробуй позже.',
+  timeout: '⏳ Время ожидания истекло. Попробуй ещё раз.',
+  providerDown:
+    '⚠️ AI временно недоступен (сбой на стороне провайдера). Уже разбираемся — попробуй через минуту.',
+  generic: '❌ Ошибка AI. Попробуй позже.',
+} as const;
+
+/**
+ * Error classes the agent surfaces to the user. `provider_down` covers connection/network
+ * failures and 5xx from the providers (the whole chain is unreachable); `generic` is a
+ * recognized-but-uncategorized API error; a null classification (see `classifyAiError`)
+ * means "not an AI error" and the caller should rethrow.
+ */
+export type AiErrorKind = 'rate_limit' | 'overloaded' | 'timeout' | 'provider_down' | 'generic';
+
+export interface AiErrorClassification {
+  kind: AiErrorKind;
+  /** Short, user-safe Telegram message (no stack, no IDs, no provider internals). */
+  userMessage: string;
+}
+
+const NETWORK_ERROR_CODES = ['ETIMEDOUT', 'ECONNREFUSED', 'ECONNRESET', 'ENETUNREACH', 'ENOTFOUND'];
+
+function errorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const value = (error as { status?: unknown }).status;
+    return typeof value === 'number' ? value : undefined;
+  }
+  return undefined;
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const value = (error as { code?: unknown }).code;
+    return typeof value === 'string' ? value : undefined;
+  }
+  return undefined;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** The agent's abort timer fired (or a user/SDK abort) — distinct from a provider being down. */
+function isAbortLike(error: unknown): boolean {
+  if (
+    error instanceof Error &&
+    (error.name === 'AbortError' || error.name === 'APIUserAbortError')
+  ) {
+    return true;
+  }
+  return /\baborted\b|was aborted|operation was aborted/i.test(errorText(error));
+}
+
+/** Connection/network failure to a provider (includes the z.ai "Connection error." case). */
+function isConnectionLike(error: unknown): boolean {
+  if (error instanceof OpenAI.APIConnectionError) return true;
+  const code = errorCode(error);
+  if (code && NETWORK_ERROR_CODES.includes(code)) return true;
+  return /connection error|connection refused|network error|fetch failed|socket hang up|timed out|econnreset|econnrefused|enotfound|enetunreach|etimedout/i.test(
+    errorText(error),
+  );
+}
+
+/**
+ * Classify an error from the AI pipeline into a user-facing message.
+ *
+ * Returns `null` when the error is not recognizably an AI/network/timeout failure, so the
+ * caller can rethrow it instead of masking an unrelated bug behind a generic AI message.
+ *
+ * Order matters: rate-limit/overloaded are checked by status first; a concrete non-429 4xx
+ * is authoritative next (a request/client error — don't let an aggregate's text about an
+ * earlier provider's connection blip mask it as an outage); then the agent-level abort
+ * (60s timeout) is detected before connection failures so a timed-out chain reads as
+ * "timeout" rather than "provider down". Aggregated "All N providers failed" errors are
+ * thus classified by their real status/code/message (e.g. all-400 stays generic, not masked
+ * as an outage), since the aggregate carries the last provider's status/code and the joined
+ * messages.
+ */
+export function classifyAiError(error: unknown): AiErrorClassification | null {
+  const status = errorStatus(error);
+  if (status === 429) return { kind: 'rate_limit', userMessage: AI_ERROR_MESSAGES.rateLimit };
+  if (status === 529) return { kind: 'overloaded', userMessage: AI_ERROR_MESSAGES.overloaded };
+  if (status !== undefined && status >= 400 && status < 500) {
+    return { kind: 'generic', userMessage: AI_ERROR_MESSAGES.generic };
+  }
+  if (isAbortLike(error)) return { kind: 'timeout', userMessage: AI_ERROR_MESSAGES.timeout };
+  if (isConnectionLike(error) || (status !== undefined && status >= 500)) {
+    return { kind: 'provider_down', userMessage: AI_ERROR_MESSAGES.providerDown };
+  }
+  if (status !== undefined) return { kind: 'generic', userMessage: AI_ERROR_MESSAGES.generic };
+  return null;
 }

--- a/src/services/ai/streaming.ts
+++ b/src/services/ai/streaming.ts
@@ -571,6 +571,16 @@ function isConnectionLike(error: unknown): boolean {
 }
 
 /**
+ * The "All N providers in <chain> chain failed: …" aggregate thrown by aiStreamRound once every
+ * provider in the chain has failed. That exact prefix is produced ONLY there, so matching it can't
+ * swallow an unrelated non-AI error (a bug elsewhere never carries this message). Used as a final
+ * floor in classifyAiError: an exhausted chain is, by construction, always an AI failure.
+ */
+function isExhaustedChainError(error: unknown): boolean {
+  return /^All \d+ providers? in \w+ chain failed/.test(errorText(error));
+}
+
+/**
  * Classify an error from the AI pipeline into a user-facing message.
  *
  * Returns `null` when the error is not recognizably an AI/network/timeout failure, so the
@@ -583,7 +593,10 @@ function isConnectionLike(error: unknown): boolean {
  * "timeout" rather than "provider down". Aggregated "All N providers failed" errors are
  * thus classified by their real status/code/message (e.g. all-400 stays generic, not masked
  * as an outage), since the aggregate carries the last provider's status/code and the joined
- * messages.
+ * messages. As a final floor, an exhausted-chain aggregate with NO classifiable signal — every
+ * provider returned an empty body (a plain Error: no status, no abort, no connection match) — is
+ * still `generic` rather than `null`, so the user gets a safe message and the admin a report
+ * instead of the in-progress message silently vanishing on a rethrow.
  */
 export function classifyAiError(error: unknown): AiErrorClassification | null {
   const status = errorStatus(error);
@@ -597,5 +610,8 @@ export function classifyAiError(error: unknown): AiErrorClassification | null {
     return { kind: 'provider_down', userMessage: AI_ERROR_MESSAGES.providerDown };
   }
   if (status !== undefined) return { kind: 'generic', userMessage: AI_ERROR_MESSAGES.generic };
+  if (isExhaustedChainError(error)) {
+    return { kind: 'generic', userMessage: AI_ERROR_MESSAGES.generic };
+  }
   return null;
 }


### PR DESCRIPTION
## Why
A user saw a bare "❌ Ошибка AI. Попробуйте позже." that looked spontaneous. Root cause: an unsatisfiable mutation request made the response-validator REJECT-loop while the head provider z.ai returned connection errors; after 60s the agent aborted all providers. The message was uninformative, no admin notification, no detail.

## What
- **Informative, class-specific errors** (`classifyAiError` + `AI_ERROR_MESSAGES`): rate-limit (429), overloaded (529), timeout, provider-down (connection/5xx → "AI временно недоступен, сбой на стороне провайдера"), generic. Non-AI errors are rethrown, not masked.
- **Throttled admin report** (`error-reporter.ts`, fire-and-forget, no-op without `BOT_ADMIN_CHAT_ID`): group, clipped user message, provider-chain failure summary, error name/status, clipped stack, timestamp. Untrusted fields HTML-neutralized + newline-collapsed. Throttle keyed by failure signature, global (one alert per outage), 10-min window reserved synchronously to collapse concurrent bursts; injectable clock.
- **Validator retry cap**: a no-tool answer is validated once; on REJECT it re-runs exactly once (structural cap, no loop) — stops the 60s death-loop.
- **Provider circuit-breaker** (`provider-breaker.ts`): per-provider consecutive connection failures; ≥3 within ~5 min → demoted to the BACK of the chain (never dropped) for ~5 min; a clean round rehabilitates; half-open probe after cooldown; injectable clock. Keeps a dead head provider (z.ai) from wasting a connection timeout on every call.

## Tests / review
152 files, 3521 passed / 0 failed; type-check clean; biome lint clean (0 warnings). Reviewed by codex (gpt-5.5, xhigh) which found one genuine P2 (cooldown not extended in the aging-tail window) — fixed with a regression test.

Refs #106
Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq7c53bgYsq6uZ9hmdhXu9
