### PR TITLE
fix(sheets): heal & prevent EUR(calc) #VALUE! breakage from currency-column inserts

### DIFF
--- a/scripts/repair-all-sheets.ts
+++ b/scripts/repair-all-sheets.ts
@@ -25,23 +25,43 @@ const GROUP_ID = Number(getArg('--group-id', '1'));
 if (DRY_RUN) console.log('*** DRY RUN — no changes will be made ***\n');
 
 const db = new Database('./data/expenses.db', { readonly: true });
-const group = db
-  .query('SELECT id, google_refresh_token, oauth_client FROM groups WHERE id = ?')
-  .get(GROUP_ID) as {
+
+interface GroupRow {
   id: number;
   google_refresh_token: string;
   oauth_client: string | null;
-} | null;
+}
+
+// `oauth_client` (migration 042) selects which OAuth credentials to use. The
+// old code read a non-existent `oauth_client_type` column, swallowed the error,
+// and always fell back to 'legacy' — so it 401'd for groups on the 'current'
+// client and could never authenticate to repair their sheets. Read the real
+// column, but if it is genuinely absent (a DB from before migration 042),
+// degrade to 'legacy' with a VISIBLE warning rather than crashing the repair.
+function loadGroup(groupId: number): GroupRow | null {
+  try {
+    return db
+      .query('SELECT id, google_refresh_token, oauth_client FROM groups WHERE id = ?')
+      .get(groupId) as GroupRow | null;
+  } catch (err) {
+    console.warn(
+      '⚠️  Could not read oauth_client (migration 042 not applied?); falling back to legacy OAuth client.',
+      err,
+    );
+    const base = db
+      .query('SELECT id, google_refresh_token FROM groups WHERE id = ?')
+      .get(groupId) as { id: number; google_refresh_token: string } | null;
+    return base ? { ...base, oauth_client: null } : null;
+  }
+}
+
+const group = loadGroup(GROUP_ID);
 
 if (!group?.google_refresh_token) {
   console.error(`Group ${GROUP_ID} not found or has no Google refresh token.`);
   process.exit(1);
 }
 
-// `oauth_client` (migration 042) selects which OAuth credentials to use. The
-// old code read a non-existent `oauth_client_type` column, swallowed the error,
-// and always fell back to 'legacy' — so it 401'd for groups on the 'current'
-// client and could never authenticate to repair their sheets.
 const oauthClientType: 'current' | 'legacy' = group.oauth_client === 'current' ? 'current' : 'legacy';
 
 const auth = getAuthenticatedClient(group.google_refresh_token, oauthClientType);

--- a/scripts/repair-all-sheets.ts
+++ b/scripts/repair-all-sheets.ts
@@ -11,6 +11,7 @@
 
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../src/services/google/oauth';
+import { type GoogleConn, repairEurFormulas } from '../src/services/google/sheets';
 import { Database } from 'bun:sqlite';
 
 const args = process.argv.slice(2);
@@ -24,9 +25,12 @@ const GROUP_ID = Number(getArg('--group-id', '1'));
 if (DRY_RUN) console.log('*** DRY RUN — no changes will be made ***\n');
 
 const db = new Database('./data/expenses.db', { readonly: true });
-const group = db.query('SELECT id, google_refresh_token FROM groups WHERE id = ?').get(GROUP_ID) as {
+const group = db
+  .query('SELECT id, google_refresh_token, oauth_client FROM groups WHERE id = ?')
+  .get(GROUP_ID) as {
   id: number;
   google_refresh_token: string;
+  oauth_client: string | null;
 } | null;
 
 if (!group?.google_refresh_token) {
@@ -34,15 +38,15 @@ if (!group?.google_refresh_token) {
   process.exit(1);
 }
 
-// Try to read oauth_client_type if column exists
-let oauthClientType = 'legacy';
-try {
-  const row = db.query('SELECT oauth_client_type FROM groups WHERE id = ?').get(group.id) as { oauth_client_type: string | null } | null;
-  if (row?.oauth_client_type) oauthClientType = row.oauth_client_type;
-} catch { /* column doesn't exist yet */ }
+// `oauth_client` (migration 042) selects which OAuth credentials to use. The
+// old code read a non-existent `oauth_client_type` column, swallowed the error,
+// and always fell back to 'legacy' — so it 401'd for groups on the 'current'
+// client and could never authenticate to repair their sheets.
+const oauthClientType: 'current' | 'legacy' = group.oauth_client === 'current' ? 'current' : 'legacy';
 
-const auth = getAuthenticatedClient(group.google_refresh_token, oauthClientType as 'current' | 'legacy');
+const auth = getAuthenticatedClient(group.google_refresh_token, oauthClientType);
 const sheetsApi = google.sheets({ version: 'v4', auth });
+const conn: GoogleConn = { refreshToken: group.google_refresh_token, oauthClient: oauthClientType };
 
 // Get all spreadsheets for this group
 const spreadsheetRows = db
@@ -381,91 +385,64 @@ for (const { name, id: spreadsheetId } of toProcess) {
     }
   }
 
-  // ── Step 3: Fix remaining static EUR(calc) and missing Rate (via same logic as migrate script) ──
+  // ── Step 3: Repair static / broken EUR(calc) formulas ──
+  //
+  // The formula repair delegates to the shared repairEurFormulas so this path
+  // can't drift from the bot's own repair logic. It rewrites both static-number
+  // cells (migration artifacts) AND formula cells that ERROR because a column
+  // insert shifted the columns their baked-in INDIRECT letters reference
+  // (#VALUE!) — the inline copy that used to live here skipped any cell already
+  // holding a formula, so it healed zero of the #VALUE! rows.
 
   if (rateIdx >= 0 && eurCalcIdx >= 0 && !DRY_RUN) {
-    // Re-read with FORMULA to check for static EUR values
-    const formulaResp2 = await sheetsApi.spreadsheets.values.get({
-      spreadsheetId,
-      range: 'Expenses!A:Z',
-      valueRenderOption: 'FORMULA',
-    });
-    const fRows = formulaResp2.data.values || [];
+    // repairEurFormulas only scans non-EUR rows, so fill Rate=1 for EUR-native
+    // rows here first (preserves this script's prior behaviour for those rows).
+    await fillEurNativeRates(spreadsheetId, currCols, rateIdx);
 
-    const rateFixes: { range: string; values: (string | number)[][] }[] = [];
-    const eurFixes: { range: string; values: (string | number)[][] }[] = [];
+    const fixed = await repairEurFormulas(conn, spreadsheetId);
+    if (fixed > 0) console.log(`  ✅ Repaired ${fixed} EUR(calc) formulas`);
+  }
+}
 
-    for (let i = 1; i < fRows.length; i++) {
-      const row = fRows[i] as (string | number | null | undefined)[];
-      if (!row || !row[0]) continue;
+/**
+ * Set Rate=1 on EUR-native rows (an EUR amount with an empty Rate cell).
+ * repairEurFormulas intentionally skips EUR rows, so this keeps the marker the
+ * inline Step 3 used to write.
+ */
+async function fillEurNativeRates(
+  spreadsheetId: string,
+  currCols: { idx: number; code: string }[],
+  rateIdx: number,
+): Promise<void> {
+  const eurCol = currCols.find((c) => c.code === 'EUR');
+  if (!eurCol) return;
 
-      const eurVal = row[eurCalcIdx];
-      // Already a formula — skip
-      if (typeof eurVal === 'string' && eurVal.startsWith('=')) continue;
-      if (eurVal === '' || eurVal === undefined || eurVal === null) continue;
+  // FORMULA render returns numeric cells as raw numbers, avoiding locale-
+  // formatted display strings (e.g. "1,234.56") that would make Number() NaN.
+  const resp = await sheetsApi.spreadsheets.values.get({
+    spreadsheetId,
+    range: 'Expenses!A:Z',
+    valueRenderOption: 'FORMULA',
+  });
+  const rows = resp.data.values || [];
 
-      // Find amount column
-      let amountColIdx = -1;
-      let amountCode = '';
-      for (const { idx, code } of currCols) {
-        const val = row[idx];
-        if (val !== '' && val !== undefined && val !== null && Number(val) > 0) {
-          amountColIdx = idx;
-          amountCode = code;
-          break;
-        }
-      }
-      if (amountColIdx === -1) continue;
-
-      // EUR expenses: keep static EUR(calc) but ensure Rate=1
-      if (amountCode === 'EUR') {
-        const rateVal = row[rateIdx];
-        if (rateVal === '' || rateVal === undefined || rateVal === null) {
-          rateFixes.push({
-            range: `Expenses!${colLetter(rateIdx)}${i + 1}`,
-            values: [[1]],
-          });
-        }
-        continue;
-      }
-
-      // Non-EUR: derive rate and set formula
-      const rateVal = row[rateIdx];
-      const rateEmpty = rateVal === '' || rateVal === undefined || rateVal === null;
-
-      if (rateEmpty) {
-        const eurNum = Number(eurVal);
-        const amountNum = Number(row[amountColIdx]);
-        if (amountNum > 0 && eurNum > 0) {
-          const derivedRate = Math.round((eurNum / amountNum) * 1_000_000) / 1_000_000;
-          rateFixes.push({
-            range: `Expenses!${colLetter(rateIdx)}${i + 1}`,
-            values: [[derivedRate]],
-          });
-        }
-      }
-
-      const sheetRow = i + 1;
-      eurFixes.push({
-        range: `Expenses!${colLetter(eurCalcIdx)}${sheetRow}`,
-        values: [[`=${colLetter(amountColIdx)}${sheetRow}*${colLetter(rateIdx)}${sheetRow}`]],
-      });
-    }
-
-    if (rateFixes.length > 0 || eurFixes.length > 0) {
-      const allFixes = [...rateFixes, ...eurFixes];
-      for (let batch = 0; batch < allFixes.length; batch += 300) {
-        await sheetsApi.spreadsheets.values.batchUpdate({
-          spreadsheetId,
-          requestBody: {
-            valueInputOption: 'USER_ENTERED',
-            data: allFixes.slice(batch, batch + 300),
-          },
-        });
-      }
-      console.log(`  ✅ Fixed ${rateFixes.length} rates, ${eurFixes.length} EUR formulas`);
+  const rateFills: { range: string; values: (string | number)[][] }[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i] as (string | number | null | undefined)[];
+    if (!row || !row[0]) continue;
+    const eurAmount = Number(row[eurCol.idx]);
+    const rateVal = row[rateIdx];
+    if (eurAmount > 0 && (rateVal === undefined || rateVal === null || rateVal === '')) {
+      rateFills.push({ range: `Expenses!${colLetter(rateIdx)}${i + 1}`, values: [[1]] });
     }
   }
+
+  if (rateFills.length === 0) return;
+  await sheetsApi.spreadsheets.values.batchUpdate({
+    spreadsheetId,
+    requestBody: { valueInputOption: 'USER_ENTERED', data: rateFills },
+  });
+  console.log(`  ✅ Set Rate=1 for ${rateFills.length} EUR rows`);
 }
 
 // ── Step 4: Check for DB expenses missing from sheet ──

--- a/scripts/repair-all-sheets.ts
+++ b/scripts/repair-all-sheets.ts
@@ -399,8 +399,8 @@ for (const { name, id: spreadsheetId } of toProcess) {
     // rows here first (preserves this script's prior behaviour for those rows).
     await fillEurNativeRates(spreadsheetId, currCols, rateIdx);
 
-    const fixed = await repairEurFormulas(conn, spreadsheetId);
-    if (fixed > 0) console.log(`  ✅ Repaired ${fixed} EUR(calc) formulas`);
+    // repairEurFormulas reports its own repaired-formula/derived-rate counts via logger.
+    await repairEurFormulas(conn, spreadsheetId);
   }
 }
 
@@ -442,7 +442,6 @@ async function fillEurNativeRates(
     spreadsheetId,
     requestBody: { valueInputOption: 'USER_ENTERED', data: rateFills },
   });
-  console.log(`  ✅ Set Rate=1 for ${rateFills.length} EUR rows`);
 }
 
 // ── Step 4: Check for DB expenses missing from sheet ──

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -110,6 +110,7 @@ const {
   appendExpenseRow,
   appendExpenseRows,
   appendExpenseRowsRaw,
+  chunkArray,
   cloneMonthTab,
   createEmptyMonthTab,
   createExpenseSpreadsheet,
@@ -123,6 +124,7 @@ const {
   isRateLimitError,
   listMonthTabs,
   monthTabExists,
+  nonEurCurrencyColumnIndices,
   readExpenseHeaders,
   readExpenseRowsRaw,
   readExpensesFromSheet,
@@ -1298,6 +1300,43 @@ describe('insertCurrencyColumn — rewrites EUR(calc) formulas after column shif
     expect(usdRow?.values[0]?.[0]).toBe('=INDIRECT("B"&ROW())*INDIRECT("H"&ROW())');
     expect(rsdRow?.values[0]?.[0]).toBe('=INDIRECT("C"&ROW())*INDIRECT("H"&ROW())');
   });
+
+  test('chunks the rewrite across >300 existing rows (regression: unbounded batchUpdate)', async () => {
+    // A currency insert on a large history must not pile every row's rewrite
+    // into one batchUpdate that can blow the payload limit.
+    const ROW_COUNT = 301;
+    wireSheet(
+      Array.from({ length: ROW_COUNT }, () => [
+        '2026-04-10',
+        20, // USD amount (B)
+        '', // EGP (C, inserted, empty for old rows)
+        '=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())', // stale rate ref → must be rewritten
+        'Travel',
+        'taxi',
+        0.905,
+      ]),
+    );
+
+    await appendExpenseRows(TEST_CONN, TEST_SPREADSHEET, [
+      {
+        date: '2026-04-11',
+        category: 'Food',
+        comment: '',
+        amounts: { EGP: 50 },
+        eurAmount: 0.95,
+        rate: 0.019,
+      },
+    ]);
+
+    // 301 rewrites chunked at 300 → two batchUpdate requests covering D2..D302.
+    expect(mockValuesBatchUpdate).toHaveBeenCalledTimes(2);
+    const writtenRanges = mockValuesBatchUpdate.mock.calls
+      .flatMap((c) => (c[0] as BatchUpdateArgs).requestBody.data)
+      .map((d) => d.range);
+    expect(writtenRanges).toHaveLength(ROW_COUNT);
+    const expectedRanges = Array.from({ length: ROW_COUNT }, (_, i) => `Expenses!D${i + 2}`);
+    expect(new Set(writtenRanges)).toEqual(new Set(expectedRanges));
+  });
 });
 
 // ── ensureSheetColumns ──────────────────────────────────────────────────────
@@ -1841,6 +1880,56 @@ describe('repairDateSerials', () => {
   });
 });
 
+// ── chunkArray ──────────────────────────────────────────────────────────────
+
+describe('chunkArray', () => {
+  test('splits into fixed-size chunks with a smaller trailing chunk', () => {
+    expect(chunkArray([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([[1, 2, 3], [4, 5, 6], [7]]);
+  });
+
+  test('returns a single chunk when the array fits', () => {
+    expect(chunkArray([1, 2], 300)).toEqual([[1, 2]]);
+  });
+
+  test('splits exactly at the boundary with no empty trailing chunk', () => {
+    const chunks = chunkArray(
+      Array.from({ length: 600 }, (_, i) => i),
+      300,
+    );
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(300);
+    expect(chunks[1]).toHaveLength(300);
+  });
+
+  test('returns no chunks for an empty array', () => {
+    expect(chunkArray([], 300)).toEqual([]);
+  });
+});
+
+// ── nonEurCurrencyColumnIndices ──────────────────────────────────────────────
+
+describe('nonEurCurrencyColumnIndices', () => {
+  test('excludes EUR (calc), the Rate column, and the EUR currency column', () => {
+    // The "EUR (calc)" computed column matches the bare ^[A-Z]{3}\s*\( shape, so
+    // it MUST be excluded explicitly — otherwise a static EUR(calc) number would
+    // be mistaken for a currency amount and corrupt the repair/rewrite. This is
+    // the same exclusion the repair script's isCurrencyHeader relies on to avoid
+    // setting Rate=1 on a non-EUR row (#112 robustness review).
+    const headers = [
+      'Дата',
+      'USD ($)',
+      'EUR (€)',
+      'RSD (дин.)',
+      'EUR (calc)',
+      'Категория',
+      'Комментарий',
+      'Rate (→EUR)',
+    ];
+    // Only USD (idx 1) and RSD (idx 3) are non-EUR currency amount columns.
+    expect(nonEurCurrencyColumnIndices(headers)).toEqual([1, 3]);
+  });
+});
+
 // ── repairEurFormulas ───────────────────────────────────────────────────────
 
 describe('repairEurFormulas — heals broken/stale EUR(calc) formulas', () => {
@@ -1964,6 +2053,46 @@ describe('repairEurFormulas — heals broken/stale EUR(calc) formulas', () => {
 
     expect(count).toBe(0);
     expect(mockValuesBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('chunks the batch write across >300 rows (regression: unbounded batchUpdate payload)', async () => {
+    // A single unbounded batchUpdate on a multi-thousand-row sheet can exceed
+    // the API payload limit and fail the whole repair atomically. The write
+    // must be split into bounded chunks, each covering a distinct row slice.
+    const ROW_COUNT = 301;
+    const formulaRows = Array.from({ length: ROW_COUNT }, () => [
+      '2026-04-10',
+      20,
+      '',
+      '=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())', // stale: rate ref F now the text column
+      'Travel',
+      'taxi',
+      0.905,
+    ]);
+    const valueRows = Array.from({ length: ROW_COUNT }, () => [
+      '2026-04-10',
+      '20',
+      '',
+      '#VALUE!',
+      'Travel',
+      'taxi',
+      '0.905',
+    ]);
+    wireRepair(formulaRows, valueRows);
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
+    expect(count).toBe(ROW_COUNT);
+    // 301 updates chunked at 300 → two batchUpdate requests.
+    expect(mockValuesBatchUpdate).toHaveBeenCalledTimes(2);
+
+    // Every data row (D2..D302) must be covered exactly once across all chunks.
+    const writtenRanges = mockValuesBatchUpdate.mock.calls
+      .flatMap((c) => (c[0] as RepairBatchArgs).requestBody.data)
+      .map((d) => d.range);
+    expect(writtenRanges).toHaveLength(ROW_COUNT);
+    const expectedRanges = Array.from({ length: ROW_COUNT }, (_, i) => `Expenses!D${i + 2}`);
+    expect(new Set(writtenRanges)).toEqual(new Set(expectedRanges));
   });
 });
 

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -129,6 +129,7 @@ const {
   readMonthBudget,
   renameSpreadsheet,
   repairDateSerials,
+  repairEurFormulas,
   sortExpensesTab,
   verifySpreadsheetAccess,
   withSheetsRetry,
@@ -1152,6 +1153,153 @@ describe('appendExpenseRows — column-insertion paths', () => {
   });
 });
 
+// ── insertCurrencyColumn — EUR(calc) formula integrity (regression: #VALUE!) ──
+
+describe('insertCurrencyColumn — rewrites EUR(calc) formulas after column shift', () => {
+  // Real sheet layout: Дата | <currencies> | EUR (calc) | Категория | Комментарий | Rate
+  // A=0     B=1(USD)   C=2(EUR calc)   D=3(Кат)   E=4(Комм)   F=5(Rate)
+  const PRE_INSERT_HEADERS = [
+    'Дата',
+    'USD ($)',
+    'EUR (calc)',
+    'Категория',
+    'Комментарий',
+    'Rate (→EUR)',
+  ];
+
+  interface BatchUpdateArgs {
+    requestBody: { data: { range: string; values: string[][] }[] };
+  }
+
+  // Wire the header read to return the PRE-insert layout, and any data read
+  // (FORMULA render) to return rows in the POST-insert layout — exactly what
+  // Google returns after the column insert: cells move with the inserted
+  // column, but the column letters baked into INDIRECT() strings do not.
+  function wireSheet(dataRows: unknown[][]): void {
+    mockValuesGet.mockReset().mockImplementation((args: unknown) => {
+      const range = (args as { range: string }).range;
+      if (range.includes('!1:1')) {
+        return Promise.resolve({ data: { values: [PRE_INSERT_HEADERS] } });
+      }
+      return Promise.resolve({ data: { values: dataRows } });
+    });
+  }
+
+  test('reproduces #VALUE! break: rewrites the rate-column reference to the shifted column', async () => {
+    // Existing USD row. After EGP is inserted before EUR(calc), Rate shifts
+    // F→G and EUR(calc) C→D, but the stored formula still says "F" (now the
+    // Комментарий text column) → #VALUE!.
+    wireSheet([
+      [
+        '2026-04-10',
+        20, // USD amount (B, unchanged by the insert)
+        '', // EGP (C, newly inserted, empty for old rows)
+        '=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())', // EUR(calc) at D, still points at old F
+        'Travel', // Категория (E)
+        'taxi', // Комментарий (F) — the text column the broken formula now hits
+        0.905, // Rate (G, shifted from F)
+      ],
+    ]);
+
+    await appendExpenseRows(TEST_CONN, TEST_SPREADSHEET, [
+      {
+        date: '2026-04-11',
+        category: 'Food',
+        comment: '',
+        amounts: { EGP: 50 },
+        eurAmount: 0.95,
+        rate: 0.019,
+      },
+    ]);
+
+    expect(mockValuesBatchUpdate).toHaveBeenCalled();
+    const batchArgs = mockValuesBatchUpdate.mock.calls[0]?.[0] as BatchUpdateArgs;
+    const eurUpdate = batchArgs.requestBody.data.find((d) => d.range.endsWith('!D2'));
+    expect(eurUpdate).toBeDefined();
+    const formula = eurUpdate?.values[0]?.[0];
+    // Amount column (USD = B) unchanged; rate reference now points at the
+    // SHIFTED Rate column (G), no longer at the text column (F).
+    expect(formula).toBe('=INDIRECT("B"&ROW())*INDIRECT("G"&ROW())');
+    expect(formula).not.toContain('"F"');
+  });
+
+  test('leaves rows with a static EUR(calc) value untouched', async () => {
+    // A row whose EUR(calc) is a literal number (not a formula) cannot break on
+    // a column shift — it must NOT be rewritten.
+    wireSheet([['2026-04-10', 20, '', 18.1, 'Travel', 'taxi', 0.905]]);
+
+    await appendExpenseRows(TEST_CONN, TEST_SPREADSHEET, [
+      {
+        date: '2026-04-11',
+        category: 'Food',
+        comment: '',
+        amounts: { EGP: 50 },
+        eurAmount: 0.95,
+        rate: 0.019,
+      },
+    ]);
+
+    expect(mockValuesBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rewrites each row against its own currency column in a multi-currency sheet', async () => {
+    // Pre-insert: Дата | USD | RSD | EUR (calc) | Категория | Комментарий | Rate
+    //              A=0   B=1   C=2   D=3          E=4         F=5           G=6
+    const MULTI_HEADERS = [
+      'Дата',
+      'USD ($)',
+      'RSD (дин.)',
+      'EUR (calc)',
+      'Категория',
+      'Комментарий',
+      'Rate (→EUR)',
+    ];
+    mockValuesGet.mockReset().mockImplementation((args: unknown) => {
+      const range = (args as { range: string }).range;
+      if (range.includes('!1:1')) {
+        return Promise.resolve({ data: { values: [MULTI_HEADERS] } });
+      }
+      // Post-insert (EGP inserted at D): Rate shifts G→H, EUR(calc) D→E.
+      // Row 1 is a USD expense (amount in B), row 2 is RSD (amount in C).
+      return Promise.resolve({
+        data: {
+          values: [
+            ['2026-04-10', 20, '', '', '=INDIRECT("B"&ROW())*INDIRECT("G"&ROW())', 'A', 'a', 0.905],
+            [
+              '2026-04-10',
+              '',
+              500,
+              '',
+              '=INDIRECT("C"&ROW())*INDIRECT("G"&ROW())',
+              'B',
+              'b',
+              0.0086,
+            ],
+          ],
+        },
+      });
+    });
+
+    await appendExpenseRows(TEST_CONN, TEST_SPREADSHEET, [
+      {
+        date: '2026-04-11',
+        category: 'Food',
+        comment: '',
+        amounts: { EGP: 50 },
+        eurAmount: 0.95,
+        rate: 0.019,
+      },
+    ]);
+
+    const batchArgs = mockValuesBatchUpdate.mock.calls[0]?.[0] as BatchUpdateArgs;
+    // EUR(calc) moved to column E (post-insert), Rate to H.
+    const usdRow = batchArgs.requestBody.data.find((d) => d.range.endsWith('!E2'));
+    const rsdRow = batchArgs.requestBody.data.find((d) => d.range.endsWith('!E3'));
+    expect(usdRow?.values[0]?.[0]).toBe('=INDIRECT("B"&ROW())*INDIRECT("H"&ROW())');
+    expect(rsdRow?.values[0]?.[0]).toBe('=INDIRECT("C"&ROW())*INDIRECT("H"&ROW())');
+  });
+});
+
 // ── ensureSheetColumns ──────────────────────────────────────────────────────
 
 describe('ensureSheetColumns', () => {
@@ -1688,6 +1836,132 @@ describe('repairDateSerials', () => {
       data: { values: [[12345]] },
     });
     const count = await repairDateSerials(TEST_CONN, TEST_SPREADSHEET);
+    expect(count).toBe(0);
+    expect(mockValuesBatchUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ── repairEurFormulas ───────────────────────────────────────────────────────
+
+describe('repairEurFormulas — heals broken/stale EUR(calc) formulas', () => {
+  // Post-insert layout where a previously-correct INDIRECT formula now errors:
+  // Дата | USD | EGP | EUR (calc) | Категория | Комментарий | Rate
+  //  A=0   B=1   C=2   D=3          E=4         F=5           G=6
+  const HEADERS = [
+    'Дата',
+    'USD ($)',
+    'EGP (E£)',
+    'EUR (calc)',
+    'Категория',
+    'Комментарий',
+    'Rate (→EUR)',
+  ];
+
+  interface RepairBatchArgs {
+    requestBody: { data: { range: string; values: (string | number)[][] }[] };
+  }
+
+  // formulaRows: what FORMULA render returns; valueRows: what FORMATTED_VALUE
+  // render returns (computed value / error). Header read is FORMATTED_VALUE on
+  // range !1:1.
+  function wireRepair(formulaRows: unknown[][], valueRows: unknown[][]): void {
+    mockValuesGet.mockReset().mockImplementation((args: unknown) => {
+      const a = args as { range: string; valueRenderOption?: string };
+      if (a.range.includes('!1:1')) {
+        return Promise.resolve({ data: { values: [HEADERS] } });
+      }
+      if (a.valueRenderOption === 'FORMULA') {
+        return Promise.resolve({ data: { values: formulaRows } });
+      }
+      return Promise.resolve({ data: { values: valueRows } });
+    });
+  }
+
+  test('rebuilds a #VALUE!-producing INDIRECT formula to the correct current-layout columns', async () => {
+    // Stale formula: rate ref "F" is now the Комментарий text column → #VALUE!.
+    wireRepair(
+      [['2026-04-10', 20, '', '=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())', 'Travel', 'taxi', 0.905]],
+      [['2026-04-10', '20', '', '#VALUE!', 'Travel', 'taxi', '0.905']],
+    );
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
+    expect(count).toBe(1);
+    const args = mockValuesBatchUpdate.mock.calls[0]?.[0] as RepairBatchArgs;
+    const eurUpdate = args.requestBody.data.find((d) => d.range.endsWith('!D2'));
+    // Amount col B (USD) kept; rate ref repaired from F → G (the real Rate column).
+    expect(eurUpdate?.values[0]?.[0]).toBe('=INDIRECT("B"&ROW())*INDIRECT("G"&ROW())');
+  });
+
+  test('rebuilds a stale INDIRECT formula that silently computes a WRONG number (no #VALUE!)', async () => {
+    // After the shift, rate ref "F" lands on an empty Комментарий cell, so the
+    // formula computes 0 (a wrong number) instead of erroring — still stale.
+    wireRepair(
+      [['2026-04-10', 20, '', '=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())', 'Travel', '', 0.905]],
+      [['2026-04-10', '20', '', '0', 'Travel', '', '0.905']],
+    );
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
+    expect(count).toBe(1);
+    const args = mockValuesBatchUpdate.mock.calls[0]?.[0] as RepairBatchArgs;
+    const eurUpdate = args.requestBody.data.find((d) => d.range.endsWith('!D2'));
+    expect(eurUpdate?.values[0]?.[0]).toBe('=INDIRECT("B"&ROW())*INDIRECT("G"&ROW())');
+  });
+
+  test('leaves a correct formula (computes to a number) untouched', async () => {
+    wireRepair(
+      [['2026-04-10', 20, '', '=INDIRECT("B"&ROW())*INDIRECT("G"&ROW())', 'Travel', 'taxi', 0.905]],
+      [['2026-04-10', '20', '', '18.1', 'Travel', 'taxi', '0.905']],
+    );
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
+    expect(count).toBe(0);
+    expect(mockValuesBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('leaves an auto-adjusting relative-ref formula (computes to a number) untouched', async () => {
+    // Plain relative refs auto-adjust on a column shift, so a non-INDIRECT
+    // formula that computes a number must NOT be rewritten.
+    wireRepair(
+      [['2026-04-10', 20, '', '=B2*G2', 'Travel', 'taxi', 0.905]],
+      [['2026-04-10', '20', '', '18.1', 'Travel', 'taxi', '0.905']],
+    );
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
+    expect(count).toBe(0);
+    expect(mockValuesBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('converts a static EUR(calc) number into a formula and derives the missing rate', async () => {
+    // Legacy migration artifact: EUR(calc) is a static number, Rate is empty.
+    wireRepair(
+      [['2026-04-10', 20, '', 18.1, 'Travel', 'taxi', '']],
+      [['2026-04-10', '20', '', '18.1', 'Travel', 'taxi', '']],
+    );
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
+    expect(count).toBe(1);
+    const args = mockValuesBatchUpdate.mock.calls[0]?.[0] as RepairBatchArgs;
+    // Derived rate written to the Rate column (G), row 2: 18.1 / 20 = 0.905.
+    const rateUpdate = args.requestBody.data.find((d) => d.range.endsWith('!G2'));
+    expect(rateUpdate?.values[0]?.[0]).toBe(0.905);
+    // EUR(calc) becomes a formula referencing amount (B) × rate (G).
+    const eurUpdate = args.requestBody.data.find((d) => d.range.endsWith('!D2'));
+    expect(eurUpdate?.values[0]?.[0]).toBe('=INDIRECT("B"&ROW())*INDIRECT("G"&ROW())');
+  });
+
+  test('skips a broken formula whose rate cell is empty (cannot derive from an error)', async () => {
+    wireRepair(
+      [['2026-04-10', 20, '', '=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())', 'Travel', 'taxi', '']],
+      [['2026-04-10', '20', '', '#VALUE!', 'Travel', 'taxi', '']],
+    );
+
+    const count = await repairEurFormulas(TEST_CONN, TEST_SPREADSHEET);
+
     expect(count).toBe(0);
     expect(mockValuesBatchUpdate).not.toHaveBeenCalled();
   });

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -186,6 +186,50 @@ function colLetter(index: number): string {
 const RATE_COLUMN_HEADER = 'Rate (→EUR)';
 
 /**
+ * Build the self-positioning EUR(calc) formula: amount × rate.
+ *
+ * `INDIRECT("<col>"&ROW())` resolves the cell from the formula's OWN row, so
+ * the formula text is identical for every data row and needs no absolute row
+ * number — which lets `append()` bake it inline instead of a second write
+ * round-trip (see appendExpenseRowsImpl for the quota rationale). The flip side
+ * is that the column letters live inside a string Google can't see into, so a
+ * column insert/move does NOT auto-adjust them: any caller that shifts columns
+ * must recompute these formulas itself (see rewriteEurFormulasForLayout).
+ */
+function buildEurCalcFormula(amountColIdx: number, rateColIdx: number): string {
+  return `=INDIRECT("${colLetter(amountColIdx)}"&ROW())*INDIRECT("${colLetter(rateColIdx)}"&ROW())`;
+}
+
+/**
+ * Indices of non-EUR currency amount columns (e.g. "USD ($)") in header order.
+ * Excludes the computed "EUR (calc)" column, the Rate column, and the EUR
+ * currency column — EUR rows keep a static EUR(calc), never a formula.
+ */
+function nonEurCurrencyColumnIndices(headers: string[]): number[] {
+  const indices: number[] = [];
+  for (let i = 0; i < headers.length; i++) {
+    const match = headers[i]?.match(/^([A-Z]{3})\s*\(/);
+    if (match?.[1] && match[1] !== 'EUR') indices.push(i);
+  }
+  return indices;
+}
+
+/** A cell value Sheets treats as empty (no value / cleared). */
+function isEmptyCell(value: unknown): boolean {
+  return value === '' || value === undefined || value === null;
+}
+
+/**
+ * True when a cell's COMPUTED value is a Google Sheets formula error
+ * (#VALUE!, #REF!, #N/A, #NAME?, …). Read with a value render option, not
+ * FORMULA — under FORMULA render an erroring cell returns its formula text, not
+ * the error. Only meaningful for cells that actually hold a formula.
+ */
+function isFormulaError(computedValue: unknown): boolean {
+  return typeof computedValue === 'string' && computedValue.startsWith('#');
+}
+
+/**
  * Google Sheets API hard limits (write side — this bot's hot path).
  * Source: https://developers.google.com/workspace/sheets/api/limits
  *
@@ -406,9 +450,7 @@ async function appendExpenseRowsImpl(
 
     const needsFormula =
       expenseCurrency !== 'EUR' && !!data.rate && amountColIdx !== -1 && rateColIdx !== -1;
-    const eurFormula = needsFormula
-      ? `=INDIRECT("${colLetter(amountColIdx)}"&ROW())*INDIRECT("${colLetter(rateColIdx)}"&ROW())`
-      : null;
+    const eurFormula = needsFormula ? buildEurCalcFormula(amountColIdx, rateColIdx) : null;
 
     const row: (string | number)[] = [];
     for (let colIdx = 0; colIdx < headers.length; colIdx++) {
@@ -510,9 +552,7 @@ async function appendExpenseRowImpl(
 
   // Self-positioning EUR formula — see appendExpenseRowsImpl for rationale.
   // One append call, no second round-trip to attach the formula afterwards.
-  const eurFormula = needsFormula
-    ? `=INDIRECT("${colLetter(amountColIdx)}"&ROW())*INDIRECT("${colLetter(rateColIdx)}"&ROW())`
-    : null;
+  const eurFormula = needsFormula ? buildEurCalcFormula(amountColIdx, rateColIdx) : null;
 
   // Build row values based on header order
   const row: (string | number)[] = [];
@@ -642,10 +682,86 @@ async function insertCurrencyColumn(
 
   logger.info(`[SHEETS] Inserted currency column "${newHeader}" at index ${insertIdx}`);
 
-  // Return updated headers
+  // Compute the post-insert header layout.
   const updated = [...currentHeaders];
   updated.splice(insertIdx, 0, newHeader);
+
+  // Inserting before "EUR (calc)" shifts the Rate column (and everything right
+  // of the insert point) one position over. Existing rows' EUR(calc) formulas
+  // hard-code the OLD column letters inside INDIRECT() strings, which Google
+  // cannot auto-adjust — so the rate reference would now point at a text column
+  // and evaluate to #VALUE!. Recompute them for the new layout to keep
+  // historical EUR totals correct.
+  await rewriteEurFormulasForLayout(sheets, spreadsheetId, updated);
+
   return updated;
+}
+
+/**
+ * Recompute every data row's EUR(calc) formula against the given (current)
+ * header layout. Used after a column insert/move shifts the columns the
+ * formulas reference: the INDIRECT() column letters baked in at append time do
+ * not follow the shift, so the rate/amount references silently break (#VALUE!).
+ *
+ * Only rows whose EUR(calc) is already a formula are rewritten — EUR-native and
+ * empty rows hold static values that a column shift can't corrupt. Self-heals
+ * on every insert, preserving the single-write append optimisation.
+ */
+async function rewriteEurFormulasForLayout(
+  sheets: ReturnType<typeof google.sheets>,
+  spreadsheetId: string,
+  headers: string[],
+): Promise<void> {
+  const eurCalcIdx = headers.indexOf(SPREADSHEET_CONFIG.eurColumnHeader);
+  const rateColIdx = headers.indexOf(RATE_COLUMN_HEADER);
+  if (eurCalcIdx === -1 || rateColIdx === -1) return;
+
+  const amountColIndices = nonEurCurrencyColumnIndices(headers);
+  if (amountColIndices.length === 0) return;
+
+  const lastCol = colLetter(headers.length - 1);
+  const dataResponse = await withSheetsRetry(
+    () =>
+      sheets.spreadsheets.values.get({
+        spreadsheetId,
+        range: `${SPREADSHEET_CONFIG.sheetName}!A2:${lastCol}`,
+        valueRenderOption: 'FORMULA',
+      }),
+    'rewriteEurFormulasForLayout.read',
+  );
+  const rows = dataResponse.data.values ?? [];
+
+  const updates: { range: string; values: string[][] }[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i] as (string | number | null | undefined)[];
+    if (!row || row.length === 0) continue;
+
+    // Only formula cells carry a broken reference; static numbers are fine.
+    const eurVal = row[eurCalcIdx];
+    if (typeof eurVal !== 'string' || !eurVal.startsWith('=')) continue;
+
+    // The amount column is the non-EUR currency column holding a positive value.
+    const amountColIdx = amountColIndices.find((idx) => Number(row[idx]) > 0);
+    if (amountColIdx === undefined) continue;
+
+    updates.push({
+      range: `${SPREADSHEET_CONFIG.sheetName}!${colLetter(eurCalcIdx)}${i + 2}`, // +2: 1-based + header
+      values: [[buildEurCalcFormula(amountColIdx, rateColIdx)]],
+    });
+  }
+
+  if (updates.length === 0) return;
+
+  await withSheetsRetry(
+    () =>
+      sheets.spreadsheets.values.batchUpdate({
+        spreadsheetId,
+        requestBody: { valueInputOption: 'USER_ENTERED', data: updates },
+      }),
+    'rewriteEurFormulasForLayout.write',
+  );
+
+  logger.info(`[SHEETS] Rewrote ${updates.length} EUR(calc) formulas after column shift`);
 }
 
 /**
@@ -1259,10 +1375,81 @@ export async function repairDateSerials(conn: GoogleConn, spreadsheetId: string)
   return updates.length;
 }
 
+/** Column positions repairEurFormulas needs to plan a single row's repair. */
+interface EurRepairColumns {
+  eurColIdx: number;
+  rateColIdx: number;
+  amountColIndices: number[];
+}
+
+/** One planned repair: a rebuilt EUR(calc) formula, plus a derived rate when one was missing. */
+interface EurRowRepair {
+  rate?: number;
+  formula: string;
+}
+
 /**
- * Scan the Expenses tab for EUR (calc) cells that are static numbers (migration artifact)
- * and rewrite them as =AMOUNT*RATE formulas. Skips EUR-denominated rows and rows without a rate.
- * Returns the number of cells fixed.
+ * Decide what (if anything) to fix for one Expenses data row, given its FORMULA
+ * render and its computed (value) render:
+ *   - a stale self-positioning EUR(calc) formula whose baked-in INDIRECT letters
+ *     no longer match the live layout → rebuild; the rate was stored at append
+ *     time. A shift makes such a formula either ERROR (#VALUE!) or — when the
+ *     shifted letter lands on an empty/numeric cell — silently compute a WRONG
+ *     number, so a text comparison against the expected formula catches both;
+ *   - a static EUR(calc) number (migration artifact) → derive the rate if absent,
+ *     then attach a formula;
+ *   - a correct formula, an auto-adjusting relative-ref formula, or an empty cell
+ *     → leave untouched.
+ */
+function planEurRowRepair(
+  formulaRow: (string | number | null | undefined)[],
+  computedRow: (string | number | null | undefined)[],
+  cols: EurRepairColumns,
+): EurRowRepair | null {
+  const amountColIdx = cols.amountColIndices.find((idx) => Number(formulaRow[idx]) > 0);
+  if (amountColIdx === undefined) return null;
+
+  const formula = buildEurCalcFormula(amountColIdx, cols.rateColIdx);
+  const eurCell = formulaRow[cols.eurColIdx];
+  const hasFormula = typeof eurCell === 'string' && eurCell.startsWith('=');
+
+  if (hasFormula) {
+    // Already the correct formula for the live layout — nothing to do.
+    if (eurCell === formula) return null;
+    // Rebuild when the formula ERRORS, or when it is a self-positioning
+    // (INDIRECT) formula whose letters drifted from the layout — the latter can
+    // compute a wrong number without ever raising #VALUE!. Plain relative refs
+    // auto-adjust on a column shift, so a non-INDIRECT formula that computes a
+    // number is left alone.
+    const stale = isFormulaError(computedRow[cols.eurColIdx]) || eurCell.includes('INDIRECT');
+    if (!stale) return null;
+    // Without a rate we can't produce a correct value (the rebuilt formula would
+    // just multiply by an empty cell) → skip.
+    if (isEmptyCell(formulaRow[cols.rateColIdx])) return null;
+    return { formula };
+  }
+
+  // Static EUR(calc) number (migration artifact) — needs a formula.
+  if (isEmptyCell(eurCell)) return null;
+  if (!isEmptyCell(formulaRow[cols.rateColIdx])) return { formula };
+
+  // Rate missing: derive it from EUR / amount (preserves that day's rate).
+  const eurNum = Number(eurCell);
+  const amountNum = Number(formulaRow[amountColIdx]);
+  if (amountNum > 0 && eurNum > 0) {
+    return { rate: Math.round((eurNum / amountNum) * 1_000_000) / 1_000_000, formula };
+  }
+  return null; // Can't derive rate — skip
+}
+
+/**
+ * Scan the Expenses tab and repair broken EUR (calc) cells, rewriting each as a
+ * self-positioning amount × rate formula (see buildEurCalcFormula). Heals:
+ *   - static numbers left by a sheet migration;
+ *   - formulas that ERROR (#VALUE!/#REF!) because a column insert shifted the
+ *     columns their baked-in INDIRECT letters reference.
+ * Correct formulas and EUR-denominated rows are left untouched. Returns the
+ * number of EUR(calc) cells rewritten.
  */
 export async function repairEurFormulas(conn: GoogleConn, spreadsheetId: string): Promise<number> {
   const auth = authClient(conn);
@@ -1283,73 +1470,52 @@ export async function repairEurFormulas(conn: GoogleConn, spreadsheetId: string)
   const rateColIdx = headers.indexOf(RATE_COLUMN_HEADER);
   if (eurColIdx === -1 || rateColIdx === -1) return 0;
 
-  // Non-EUR currency columns
-  const currencyCols: { idx: number }[] = [];
-  for (let i = 0; i < headers.length; i++) {
-    const match = headers[i]?.match(/^([A-Z]{3})\s*\(/);
-    if (match?.[1] && match[1] !== 'EUR') {
-      currencyCols.push({ idx: i });
-    }
-  }
-  if (currencyCols.length === 0) return 0;
+  const amountColIndices = nonEurCurrencyColumnIndices(headers);
+  if (amountColIndices.length === 0) return 0;
 
   const lastCol = colLetter(headers.length - 1);
-  // FORMULA render option: formulas come back as "=C5*G5", static values as the number
-  const dataResponse = await withSheetsRetry(
-    () =>
-      sheets.spreadsheets.values.get({
-        spreadsheetId,
-        range: `${EXPENSES_TAB}!A2:${lastCol}`,
-        valueRenderOption: 'FORMULA',
-      }),
-    'repairEurFormulas.readData',
-  );
-  const rows = dataResponse.data.values ?? [];
+  // Read formulas AND computed values. Under FORMULA render a broken cell
+  // returns its (stale) formula text; under a value render it returns the
+  // #VALUE!/#REF! error — both are needed to tell a correct formula from a
+  // stale one without clobbering working formulas.
+  const [formulaResp, valueResp] = await Promise.all([
+    withSheetsRetry(
+      () =>
+        sheets.spreadsheets.values.get({
+          spreadsheetId,
+          range: `${EXPENSES_TAB}!A2:${lastCol}`,
+          valueRenderOption: 'FORMULA',
+        }),
+      'repairEurFormulas.readFormulas',
+    ),
+    withSheetsRetry(
+      () =>
+        sheets.spreadsheets.values.get({
+          spreadsheetId,
+          range: `${EXPENSES_TAB}!A2:${lastCol}`,
+          valueRenderOption: 'FORMATTED_VALUE',
+        }),
+      'repairEurFormulas.readValues',
+    ),
+  ]);
+  const formulaRows = formulaResp.data.values ?? [];
+  const valueRows = valueResp.data.values ?? [];
 
+  const cols: EurRepairColumns = { eurColIdx, rateColIdx, amountColIndices };
   const eurFormulaUpdates: { row: number; formula: string }[] = [];
   const rateUpdates: { row: number; rate: number }[] = [];
 
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i] as (string | number | null | undefined)[];
-    if (!row || row.length === 0) continue;
+  for (let i = 0; i < formulaRows.length; i++) {
+    const formulaRow = formulaRows[i] as (string | number | null | undefined)[];
+    if (!formulaRow || formulaRow.length === 0) continue;
+    const computedRow = (valueRows[i] ?? []) as (string | number | null | undefined)[];
 
-    const eurVal = row[eurColIdx];
-    // Already a formula — nothing to do
-    if (typeof eurVal === 'string' && eurVal.startsWith('=')) continue;
-    // Empty EUR cell — skip
-    if (eurVal === '' || eurVal === undefined || eurVal === null) continue;
-
-    // Find the non-EUR currency column with a positive amount
-    let amountColIdx = -1;
-    for (const { idx } of currencyCols) {
-      const val = row[idx];
-      if (val !== '' && val !== undefined && val !== null && Number(val) > 0) {
-        amountColIdx = idx;
-        break;
-      }
-    }
-    if (amountColIdx === -1) continue;
+    const plan = planEurRowRepair(formulaRow, computedRow, cols);
+    if (!plan) continue;
 
     const sheetRow = i + 2; // 1-based row + skip header
-
-    // If Rate is missing, derive it from EUR_value / amount (preserves the rate from that day)
-    const rateVal = row[rateColIdx];
-    const rateEmpty = rateVal === '' || rateVal === undefined || rateVal === null;
-    if (rateEmpty) {
-      const eurNum = Number(eurVal);
-      const amountNum = Number(row[amountColIdx]);
-      if (amountNum > 0 && eurNum > 0) {
-        const derivedRate = Math.round((eurNum / amountNum) * 1_000_000) / 1_000_000;
-        rateUpdates.push({ row: sheetRow, rate: derivedRate });
-      } else {
-        continue; // Can't derive rate — skip
-      }
-    }
-
-    eurFormulaUpdates.push({
-      row: sheetRow,
-      formula: `=${colLetter(amountColIdx)}${sheetRow}*${colLetter(rateColIdx)}${sheetRow}`,
-    });
+    if (plan.rate !== undefined) rateUpdates.push({ row: sheetRow, rate: plan.rate });
+    eurFormulaUpdates.push({ row: sheetRow, formula: plan.formula });
   }
 
   if (eurFormulaUpdates.length === 0 && rateUpdates.length === 0) return 0;
@@ -1366,19 +1532,17 @@ export async function repairEurFormulas(conn: GoogleConn, spreadsheetId: string)
     })),
   ];
 
-  if (batchData.length > 0) {
-    await withSheetsRetry(
-      () =>
-        sheets.spreadsheets.values.batchUpdate({
-          spreadsheetId,
-          requestBody: {
-            valueInputOption: 'USER_ENTERED',
-            data: batchData,
-          },
-        }),
-      'repairEurFormulas.write',
-    );
-  }
+  await withSheetsRetry(
+    () =>
+      sheets.spreadsheets.values.batchUpdate({
+        spreadsheetId,
+        requestBody: {
+          valueInputOption: 'USER_ENTERED',
+          data: batchData,
+        },
+      }),
+    'repairEurFormulas.write',
+  );
 
   logger.info(
     `[SHEETS] repairEurFormulas: ${eurFormulaUpdates.length} formulas, ${rateUpdates.length} rates derived`,

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -205,7 +205,7 @@ function buildEurCalcFormula(amountColIdx: number, rateColIdx: number): string {
  * Excludes the computed "EUR (calc)" column, the Rate column, and the EUR
  * currency column — EUR rows keep a static EUR(calc), never a formula.
  */
-function nonEurCurrencyColumnIndices(headers: string[]): number[] {
+export function nonEurCurrencyColumnIndices(headers: string[]): number[] {
   const indices: number[] = [];
   for (let i = 0; i < headers.length; i++) {
     const match = headers[i]?.match(/^([A-Z]{3})\s*\(/);
@@ -227,6 +227,47 @@ function isEmptyCell(value: unknown): boolean {
  */
 function isFormulaError(computedValue: unknown): boolean {
   return typeof computedValue === 'string' && computedValue.startsWith('#');
+}
+
+/**
+ * Max ValueRange entries per spreadsheets.values.batchUpdate request. A single
+ * unbounded batchUpdate on a multi-thousand-row sheet can exceed the API's
+ * request payload limit and fail the whole repair atomically; chunking keeps
+ * each request bounded and re-runnable (a failed chunk leaves earlier chunks
+ * written). Matches the 300-row chunk used by scripts/repair-all-sheets.ts.
+ */
+const SHEETS_VALUE_BATCH_CHUNK = 300;
+
+/** Split an array into fixed-size chunks (the final chunk may be smaller). */
+export function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Write value-range updates via spreadsheets.values.batchUpdate, split into
+ * bounded chunks so a large repair can't exceed the API payload limit. One
+ * shared path for every chunked value write (rewrite-on-insert + repair).
+ */
+async function writeValueUpdatesInChunks(
+  sheets: ReturnType<typeof google.sheets>,
+  spreadsheetId: string,
+  data: { range: string; values: (string | number)[][] }[],
+  retryLabel: string,
+): Promise<void> {
+  for (const chunk of chunkArray(data, SHEETS_VALUE_BATCH_CHUNK)) {
+    await withSheetsRetry(
+      () =>
+        sheets.spreadsheets.values.batchUpdate({
+          spreadsheetId,
+          requestBody: { valueInputOption: 'USER_ENTERED', data: chunk },
+        }),
+      retryLabel,
+    );
+  }
 }
 
 /**
@@ -752,12 +793,10 @@ async function rewriteEurFormulasForLayout(
 
   if (updates.length === 0) return;
 
-  await withSheetsRetry(
-    () =>
-      sheets.spreadsheets.values.batchUpdate({
-        spreadsheetId,
-        requestBody: { valueInputOption: 'USER_ENTERED', data: updates },
-      }),
+  await writeValueUpdatesInChunks(
+    sheets,
+    spreadsheetId,
+    updates,
     'rewriteEurFormulasForLayout.write',
   );
 
@@ -1532,17 +1571,7 @@ export async function repairEurFormulas(conn: GoogleConn, spreadsheetId: string)
     })),
   ];
 
-  await withSheetsRetry(
-    () =>
-      sheets.spreadsheets.values.batchUpdate({
-        spreadsheetId,
-        requestBody: {
-          valueInputOption: 'USER_ENTERED',
-          data: batchData,
-        },
-      }),
-    'repairEurFormulas.write',
-  );
+  await writeValueUpdatesInChunks(sheets, spreadsheetId, batchData, 'repairEurFormulas.write');
 
   logger.info(
     `[SHEETS] repairEurFormulas: ${eurFormulaUpdates.length} formulas, ${rateUpdates.length} rates derived`,


### PR DESCRIPTION
## Why
Adding a new currency (EGP) — now reachable via the new AI settings tool / changing default currency — inserts a column **before** EUR (calc) via `insertDimension`. The EUR (calc) formula uses hard-coded INDIRECT column letters (`=INDIRECT("B"&ROW())*INDIRECT("F"&ROW())`) that Google does NOT auto-shift, so the Rate reference moved `I→J` and the formula started multiplying by the Комментарий (text) column → `#VALUE!` on every pre-existing row (161 cells on the affected sheet). The existing repair path couldn't heal it: it **skipped cells that were already formulas**, and `scripts/repair-all-sheets.ts` couldn't even authenticate (read a non-existent `oauth_client_type` column → always fell back to legacy → 401 for current-client groups).

## What
- **Prevention:** `insertCurrencyColumn` now calls `rewriteEurFormulasForLayout` after inserting — rebuilds existing rows' EUR(calc) formulas against the post-insert layout, so a currency insert never leaves stale INDIRECT letters.
- **Heal:** `repairEurFormulas` no longer skips formula cells. It reads both the FORMULA and the computed value, and rebuilds EUR(calc) for rows whose cell errors (`#…`, locale-independent — catches `#VALUE!`/`#ЗНАЧ!`) or whose shifted INDIRECT silently computes a wrong number. Correct formulas and header/EUR-native/empty rows are left untouched.
- **Auth fix:** `scripts/repair-all-sheets.ts` reads `oauth_client` (the real column) and delegates Step 3 to the shared `repairEurFormulas` so the script can't drift from the bot.
- Single-source helpers `buildEurCalcFormula` / `nonEurCurrencyColumnIndices` reused across append / insert-rewrite / repair.

## Tests
New regression tests in `sheets.test.ts`: insert-rewrite (`F→G` after shift, static untouched, multi-currency per row) and repair-heal (rebuild #VALUE! INDIRECT, rebuild silent-wrong-number INDIRECT, leave correct/auto-adjusting formulas, static→formula with derived rate, skip when rate empty). Full suite: 153 files / 3610 tests / 0 fail. type-check + biome lint clean. codex review: no actionable issues.

## Note
Already-broken live sheets are healed by running the (now-fixed) repair on them after deploy.

Refs #112
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq7c53bgYsq6uZ9hmdhXu9
