### PR TITLE
chore(sheets): consolidate currency-column detector into one shared helper

### DIFF
--- a/scripts/repair-all-sheets.ts
+++ b/scripts/repair-all-sheets.ts
@@ -11,7 +11,7 @@
 
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../src/services/google/oauth';
-import { type GoogleConn, repairEurFormulas } from '../src/services/google/sheets';
+import { type GoogleConn, isCurrencyColumnHeader, repairEurFormulas } from '../src/services/google/sheets';
 import { Database } from 'bun:sqlite';
 
 const args = process.argv.slice(2);
@@ -131,10 +131,6 @@ function colLetter(index: number): string {
   return letter;
 }
 
-function isCurrencyHeader(h: string): boolean {
-  return /^[A-Z]{3}\s*\(/.test(h) && h !== 'EUR (calc)' && h !== 'Rate (→EUR)';
-}
-
 // ── Process each spreadsheet ──
 
 for (const { name, id: spreadsheetId } of toProcess) {
@@ -170,7 +166,7 @@ for (const { name, id: spreadsheetId } of toProcess) {
   // ── Step 1: Check and fix column order ──
 
   // Determine canonical order for this sheet's currencies
-  const currHeaders = headers.filter(isCurrencyHeader);
+  const currHeaders = headers.filter(isCurrencyColumnHeader);
   const canonicalHeaders = [...CANONICAL_PREFIX, ...currHeaders, ...CANONICAL_SUFFIX];
 
   // Check if current order matches canonical
@@ -276,7 +272,7 @@ for (const { name, id: spreadsheetId } of toProcess) {
   const currentHeaders = fmtRows[0] as string[];
   const currCols: { idx: number; code: string }[] = [];
   for (let i = 0; i < currentHeaders.length; i++) {
-    if (isCurrencyHeader(currentHeaders[i]!)) {
+    if (isCurrencyColumnHeader(currentHeaders[i]!)) {
       const m = currentHeaders[i]!.match(/^([A-Z]{3})/);
       if (m?.[1]) currCols.push({ idx: i, code: m[1] });
     }

--- a/src/services/google/sheets.test.ts
+++ b/src/services/google/sheets.test.ts
@@ -121,6 +121,7 @@ const {
   GOOGLE_SHEETS_LIMITS,
   getSpreadsheetUrl,
   googleConn,
+  isCurrencyColumnHeader,
   isRateLimitError,
   listMonthTabs,
   monthTabExists,
@@ -1906,15 +1907,46 @@ describe('chunkArray', () => {
   });
 });
 
+// ── isCurrencyColumnHeader ───────────────────────────────────────────────────
+
+describe('isCurrencyColumnHeader — shared currency-column detector (#112)', () => {
+  test('EUR (calc) is never treated as a currency column', () => {
+    // This is the single detector shared by sheets.ts and
+    // scripts/repair-all-sheets.ts. If EUR (calc) leaked through, the repair
+    // script's fillEurNativeRates would read the computed EUR(calc) value as an
+    // "EUR-native" amount and set Rate=1 on non-EUR rows — the exact corruption
+    // #113's review flagged as untested. The script is not importable
+    // (module-top DB/network), so asserting the exclusion on the shared code is
+    // what covers it.
+    expect(isCurrencyColumnHeader('EUR (calc)')).toBe(false);
+  });
+
+  test('excludes the Rate column and non-currency headers', () => {
+    expect(isCurrencyColumnHeader('Rate (→EUR)')).toBe(false);
+    expect(isCurrencyColumnHeader('Дата')).toBe(false);
+    expect(isCurrencyColumnHeader('Категория')).toBe(false);
+    expect(isCurrencyColumnHeader('Комментарий')).toBe(false);
+  });
+
+  test('includes currency amount columns, the EUR currency column included', () => {
+    expect(isCurrencyColumnHeader('USD ($)')).toBe(true);
+    expect(isCurrencyColumnHeader('RSD (дин.)')).toBe(true);
+    // The EUR *currency* column is a real amount column (distinct from EUR calc);
+    // the repair script needs it in currCols to match EUR expenses and fill
+    // EUR-native rates. nonEurCurrencyColumnIndices layers the EUR exclusion.
+    expect(isCurrencyColumnHeader('EUR (€)')).toBe(true);
+  });
+});
+
 // ── nonEurCurrencyColumnIndices ──────────────────────────────────────────────
 
 describe('nonEurCurrencyColumnIndices', () => {
   test('excludes EUR (calc), the Rate column, and the EUR currency column', () => {
     // The "EUR (calc)" computed column matches the bare ^[A-Z]{3}\s*\( shape, so
     // it MUST be excluded explicitly — otherwise a static EUR(calc) number would
-    // be mistaken for a currency amount and corrupt the repair/rewrite. This is
-    // the same exclusion the repair script's isCurrencyHeader relies on to avoid
-    // setting Rate=1 on a non-EUR row (#112 robustness review).
+    // be mistaken for a currency amount and corrupt the repair/rewrite. This
+    // builds on the shared isCurrencyColumnHeader the repair script also uses to
+    // avoid setting Rate=1 on a non-EUR row (#112 robustness review).
     const headers = [
       'Дата',
       'USD ($)',

--- a/src/services/google/sheets.ts
+++ b/src/services/google/sheets.ts
@@ -201,6 +201,25 @@ function buildEurCalcFormula(amountColIdx: number, rateColIdx: number): string {
 }
 
 /**
+ * True when a sheet header names a currency AMOUNT column: a 3-letter currency
+ * code followed by a parenthesised symbol, e.g. "USD ($)", "RSD (дин.)",
+ * "EUR (€)". Excludes the computed "EUR (calc)" column and the "Rate (→EUR)"
+ * column — both share the CODE-then-paren shape but hold a derived value, not a
+ * user-entered amount. The EUR *currency* column IS a currency column here;
+ * callers that must also skip EUR (formula repair, rate derivation) use
+ * nonEurCurrencyColumnIndices, which layers the EUR exclusion on top. This is
+ * the single detector shared with scripts/repair-all-sheets.ts (#112) so the
+ * script's untestable copy can't drift from the tested one.
+ */
+export function isCurrencyColumnHeader(header: string): boolean {
+  return (
+    /^[A-Z]{3}\s*\(/.test(header) &&
+    header !== SPREADSHEET_CONFIG.eurColumnHeader &&
+    header !== RATE_COLUMN_HEADER
+  );
+}
+
+/**
  * Indices of non-EUR currency amount columns (e.g. "USD ($)") in header order.
  * Excludes the computed "EUR (calc)" column, the Rate column, and the EUR
  * currency column — EUR rows keep a static EUR(calc), never a formula.
@@ -208,8 +227,10 @@ function buildEurCalcFormula(amountColIdx: number, rateColIdx: number): string {
 export function nonEurCurrencyColumnIndices(headers: string[]): number[] {
   const indices: number[] = [];
   for (let i = 0; i < headers.length; i++) {
-    const match = headers[i]?.match(/^([A-Z]{3})\s*\(/);
-    if (match?.[1] && match[1] !== 'EUR') indices.push(i);
+    const header = headers[i];
+    if (header && isCurrencyColumnHeader(header) && !header.startsWith('EUR')) {
+      indices.push(i);
+    }
   }
   return indices;
 }


### PR DESCRIPTION
## Why
Deferred follow-up on #112. Two parallel "which columns are currency columns" implementations existed — `isCurrencyHeader` in `scripts/repair-all-sheets.ts` and `nonEurCurrencyColumnIndices` in `src/services/google/sheets.ts`. The PR #113 review flagged that `fillEurNativeRates` (script) had no direct test because the two could drift.

## What
- New shared primitive `isCurrencyColumnHeader(header)` in `sheets.ts` — a `[A-Z]{3} (…)` header that isn't `EUR (calc)` or `Rate (→EUR)`.
- `nonEurCurrencyColumnIndices` now builds on it (adds the `!EUR` layer). Byte-for-byte identical behavior.
- `scripts/repair-all-sheets.ts` imports the shared helper; its local `isCurrencyHeader` deleted; both call sites use the shared code — so the script now runs the tested code.
- Preserved a real asymmetry (deliberately, not a behavior change): the script's currency-column set INCLUDES the EUR currency column (`fillEurNativeRates` needs it); `nonEurCurrencyColumnIndices` excludes it. EUR-exclusion is a layer on top of the shared primitive, not part of it.

## Tests
New `isCurrencyColumnHeader` describe (TDD red-first): `EUR (calc)`→false (the guarantee that a non-EUR row can't get Rate=1), Rate/Дата/Категория/Комментарий→false, USD/RSD/EUR currency headers→true. Full suite 3620/3620, type-check + biome lint clean, codex review: no blocking issues.

Refs #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq7c53bgYsq6uZ9hmdhXu9
