### PR TITLE
chore(knip): ignore submodule + remove orphaned dead code (#110)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "date-fns": "^4.1.0",
         "googleapis": "^166.0.0",
         "gramio": "^0.4.11",
-        "jsqr": "^1.4.0",
         "marked": "^17.0.5",
         "node-cron": "^4.2.1",
         "openai": "^6.34.0",
@@ -292,8 +291,6 @@
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.7", "", {}, "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw=="],
-
-    "jsqr": ["jsqr@1.4.0", "", {}, "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  // Entry points knip cannot infer on its own. index.ts is auto-detected from
+  // package.json "module".
+  //  - bank-sync.ts       second PM2 process (see ecosystem.config.cjs)
+  //  - ecosystem.config.cjs  PM2 process definitions (read by pm2, never imported)
+  //  - scripts/**         standalone tooling run via `bun scripts/<name>.ts`
+  //  - src/**/*.test.ts   test files (roots; make their imports count as usage)
+  //  - the two *module barrels* below are the intended public import surface for
+  //    their modules; consumers currently import the submodules directly, so the
+  //    barrels are never imported, but they are a deliberate API boundary, not
+  //    dead code — declaring them entries stops knip flagging the boundary.
+  "entry": [
+    "bank-sync.ts",
+    "ecosystem.config.cjs",
+    "scripts/**/*.ts",
+    "src/**/*.test.ts",
+    "src/services/dev-pipeline/index.ts",
+    "src/services/analytics/ta/index.ts"
+  ],
+  // ZenPlugins is a third-party git submodule — excluded here exactly like in
+  // biome.jsonc ("!src/services/bank/ZenPlugins"). Not checked out in CI, and
+  // the types the bot needs are mirrored locally in zenmoney-types.ts.
+  "project": [
+    "src/**/*.ts",
+    "!src/services/bank/ZenPlugins/**",
+    "libs/**/*.ts",
+    "*.ts"
+  ],
+  "ignore": [
+    // Deliberately-complete local mirror of ZenMoney submodule types (see the
+    // file header + CLAUDE.md "types maintained locally"). Some members are not
+    // consumed yet; kept for parity with the full ZenMoney data model.
+    "src/services/bank/zenmoney-types.ts",
+    // Shared test helpers (e.g. fetch mocking, mandated by the no-real-network
+    // test rule). Imported ad-hoc by tests, never by product code.
+    "src/test-utils/**"
+  ],
+  "ignoreDependencies": [
+    // Used at runtime as a pino transport target — a string reference in
+    // logger.ts ("target: 'pino-pretty'"), not a static import, so knip cannot
+    // see it. Removing it breaks pretty dev logs.
+    "pino-pretty"
+  ],
+  // An export used only inside its own file is a redundant `export` modifier or
+  // an intentional test seam / API surface — not dead code. Don't flag these;
+  // stripping the keyword would churn stable shared modules for no benefit.
+  "ignoreExportsUsedInFile": true,
+  // Bun.$ shell templates (`$`git rev-parse …``) in dev-pipeline/git-ops.ts and
+  // pipeline.ts make knip mistake git subcommands for standalone binaries.
+  "ignoreBinaries": [
+    "rev-parse",
+    "add",
+    "status",
+    "commit",
+    "push",
+    "remote",
+    "diff",
+    "ls-files",
+    "cat-file",
+    "checkout",
+    "log",
+    "main"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "date-fns": "^4.1.0",
     "googleapis": "^166.0.0",
     "gramio": "^0.4.11",
-    "jsqr": "^1.4.0",
     "marked": "^17.0.5",
     "node-cron": "^4.2.1",
     "openai": "^6.34.0",

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -275,7 +275,12 @@ export interface UpdateReceiptItemData {
 }
 
 /**
- * Per-year spreadsheet mapping for a group
+ * Per-year spreadsheet mapping for a group.
+ *
+ * @public Row-shape type for the group_spreadsheets table, kept for parity with
+ * the other table row types here. GroupSpreadsheetRepository currently reads
+ * narrower inline shapes, so this interface has no importer yet; the @public tag
+ * exempts it from the knip unused-exports gate. See ticket #110.
  */
 export interface GroupSpreadsheet {
   id: number;

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -12,13 +12,6 @@ export interface ToolResult {
   summary?: string;
 }
 
-export type AgentEvent =
-  | { type: 'text_delta'; text: string }
-  | { type: 'tool_start'; name: string; input: Record<string, unknown> }
-  | { type: 'tool_result'; name: string; result: ToolResult }
-  | { type: 'done' }
-  | { type: 'error'; error: string };
-
 export interface ToolCallResult {
   id: string;
   result: ToolResult;


### PR DESCRIPTION
## Why
Resolve knip ticket #110. knip was flagging ~35 real items drowned under 279 false-positive ZenPlugins-submodule "unused files" (no knip config existed). Every flag was investigated via `git log -S` + introducing-commit history before acting — per the repo's "never delete dead code without investigation" rule.

## What
- **`knip.jsonc`** added: excludes the `ZenPlugins/` submodule (mirrors biome), declares entry points (scripts/, libs/, barrels), `ignoreExportsUsedInFile`, and allowlists documented below.
- **Deleted (orphaned-by-migration, with evidence):**
  - `AgentEvent` type — its `agent.ts` consumer was removed in `5e57a49` when it moved to `AgentStreamWriter`.
  - `jsqr` dependency — replaced by `qr` in `25d16da`; zero source refs.
- **Kept + allowlisted with reason:** `GroupSpreadsheet` (@public row type), `zenmoney-types` mirror (deliberate local copy per CLAUDE.md), `pino-pretty` (runtime pino transport, invisible to static analysis), and exports used only within their own file (`createBot`, `CATEGORY_EMOJIS`, `aiDebugLogger`, etc.) via `ignoreExportsUsedInFile`.

## Results
knip exit 0 (clean), type-check + biome lint clean, full suite 3617/3617. No behavior change beyond the two orphaned removals (tests green confirm nothing referenced them).

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq7c53bgYsq6uZ9hmdhXu9
